### PR TITLE
feat: crosslink review diff + /review slash command

### DIFF
--- a/crosslink/build.rs
+++ b/crosslink/build.rs
@@ -11,6 +11,7 @@ fn main() {
     println!("cargo:rerun-if-changed=resources/claude/hooks/work-check.py");
     println!("cargo:rerun-if-changed=resources/claude/mcp/safe-fetch-server.py");
     println!("cargo:rerun-if-changed=resources/mcp.json");
+    println!("cargo:rerun-if-changed=resources/claude/commands/review.md");
 
     // Track crosslink config and rules files
     println!("cargo:rerun-if-changed=resources/crosslink/hook-config.json");

--- a/crosslink/resources/claude/commands/review.md
+++ b/crosslink/resources/claude/commands/review.md
@@ -1,0 +1,76 @@
+You are conducting a guided policy review of this project's crosslink configuration. Walk the user through each section, explain what's configured, and suggest improvements.
+
+## Step 1: Gather Current State
+
+First, run these commands to understand the current configuration:
+
+```bash
+crosslink review diff
+```
+
+Then read the key policy files:
+
+- `.crosslink/hook-config.json` — tracking mode and command restrictions
+- `.crosslink/rules/global.md` — core behavioral rules
+- `.crosslink/rules/project.md` — project-specific conventions
+
+## Step 2: Review Tracking Mode
+
+Read `.crosslink/hook-config.json` and the active tracking mode rule file (`.crosslink/rules/tracking-strict.md`, `tracking-normal.md`, or `tracking-relaxed.md`).
+
+Ask the user:
+- Is the current tracking mode (`strict`/`normal`/`relaxed`) appropriate for your workflow?
+- Are there git commands in `blocked_git_commands` that should be allowed, or allowed commands that should be blocked?
+- Are the `allowed_bash_prefixes` complete for your toolchain?
+
+## Step 3: Review Security Policies
+
+Read `.crosslink/rules/global.md` (the security section), `.crosslink/rules/web.md`, and `.crosslink/rules/sanitize-patterns.txt`.
+
+Ask the user:
+- Are the OWASP/injection prevention rules current for your stack?
+- Does `sanitize-patterns.txt` cover your application's sensitive patterns?
+- For web projects: are the RFIP (Remote File Inclusion Prevention) rules in `web.md` appropriate?
+
+## Step 4: Review Language Rules
+
+List all `.md` files in `.crosslink/rules/` and identify which languages are relevant to this project (check for source files in the repo).
+
+Ask the user:
+- Are rules deployed for all languages used in this project?
+- Are there language rules deployed that aren't relevant (unnecessary noise)?
+- Do any language-specific rules need updates for newer framework versions?
+
+## Step 5: Review Hook Implementations
+
+Read each hook file in `.claude/hooks/`:
+- `work-check.py` — enforces issue tracking before code changes
+- `session-start.py` — loads context on session start
+- `prompt-guard.py` — guards against prompt injection
+- `post-edit-check.py` — validates edits
+- `pre-web-check.py` — validates web requests
+
+For any files that `crosslink review diff` flagged as customized, highlight the differences and ask if they're still needed.
+
+## Step 6: Review Workflow Conventions
+
+Read `.crosslink/rules/global.md` (workflow sections) and `.crosslink/rules/project.md`.
+
+Ask the user:
+- Are the commit message conventions right?
+- Are the code review and testing expectations appropriate?
+- Should any workflow rules be added or relaxed?
+
+## Step 7: Summary and Recommendations
+
+Summarize findings:
+1. List any files that have drifted from defaults (from `crosslink review diff`)
+2. Recommend specific changes based on the discussion
+3. Offer to apply approved changes using `crosslink init --force` (resets to defaults) or targeted edits
+
+If the user wants to reset customized files to defaults:
+```bash
+crosslink init --force
+```
+
+If they want targeted edits, make the specific changes they approve.

--- a/crosslink/src/commands/init.rs
+++ b/crosslink/src/commands/init.rs
@@ -6,60 +6,71 @@ use crate::db::Database;
 
 // Embed hook files at compile time from resources/ (packaged with the crate)
 const SETTINGS_JSON: &str = include_str!("../../resources/claude/settings.json");
-const PROMPT_GUARD_PY: &str = include_str!("../../resources/claude/hooks/prompt-guard.py");
-const POST_EDIT_CHECK_PY: &str = include_str!("../../resources/claude/hooks/post-edit-check.py");
-const SESSION_START_PY: &str = include_str!("../../resources/claude/hooks/session-start.py");
-const PRE_WEB_CHECK_PY: &str = include_str!("../../resources/claude/hooks/pre-web-check.py");
-const WORK_CHECK_PY: &str = include_str!("../../resources/claude/hooks/work-check.py");
+pub(crate) const PROMPT_GUARD_PY: &str =
+    include_str!("../../resources/claude/hooks/prompt-guard.py");
+pub(crate) const POST_EDIT_CHECK_PY: &str =
+    include_str!("../../resources/claude/hooks/post-edit-check.py");
+pub(crate) const SESSION_START_PY: &str =
+    include_str!("../../resources/claude/hooks/session-start.py");
+pub(crate) const PRE_WEB_CHECK_PY: &str =
+    include_str!("../../resources/claude/hooks/pre-web-check.py");
+pub(crate) const WORK_CHECK_PY: &str = include_str!("../../resources/claude/hooks/work-check.py");
 
 // Embed MCP server for safe web fetching
 const SAFE_FETCH_SERVER_PY: &str = include_str!("../../resources/claude/mcp/safe-fetch-server.py");
 const MCP_JSON: &str = include_str!("../../resources/mcp.json");
+
+// Embed slash command for guided policy review
+const REVIEW_CMD_MD: &str = include_str!("../../resources/claude/commands/review.md");
 
 // Embed sanitization patterns
 const SANITIZE_PATTERNS: &str =
     include_str!("../../resources/crosslink/rules/sanitize-patterns.txt");
 
 // Embed hook configuration
-const HOOK_CONFIG_JSON: &str = include_str!("../../resources/crosslink/hook-config.json");
+pub(crate) const HOOK_CONFIG_JSON: &str =
+    include_str!("../../resources/crosslink/hook-config.json");
 
 // Embed tracking mode rule files
-const RULE_TRACKING_STRICT: &str =
+pub(crate) const RULE_TRACKING_STRICT: &str =
     include_str!("../../resources/crosslink/rules/tracking-strict.md");
-const RULE_TRACKING_NORMAL: &str =
+pub(crate) const RULE_TRACKING_NORMAL: &str =
     include_str!("../../resources/crosslink/rules/tracking-normal.md");
-const RULE_TRACKING_RELAXED: &str =
+pub(crate) const RULE_TRACKING_RELAXED: &str =
     include_str!("../../resources/crosslink/rules/tracking-relaxed.md");
 
 // Embed rule files at compile time from resources/crosslink/rules/
-const RULE_GLOBAL: &str = include_str!("../../resources/crosslink/rules/global.md");
-const RULE_PROJECT: &str = include_str!("../../resources/crosslink/rules/project.md");
-const RULE_RUST: &str = include_str!("../../resources/crosslink/rules/rust.md");
-const RULE_PYTHON: &str = include_str!("../../resources/crosslink/rules/python.md");
-const RULE_JAVASCRIPT: &str = include_str!("../../resources/crosslink/rules/javascript.md");
-const RULE_TYPESCRIPT: &str = include_str!("../../resources/crosslink/rules/typescript.md");
-const RULE_TYPESCRIPT_REACT: &str =
+pub(crate) const RULE_GLOBAL: &str = include_str!("../../resources/crosslink/rules/global.md");
+pub(crate) const RULE_PROJECT: &str = include_str!("../../resources/crosslink/rules/project.md");
+pub(crate) const RULE_RUST: &str = include_str!("../../resources/crosslink/rules/rust.md");
+pub(crate) const RULE_PYTHON: &str = include_str!("../../resources/crosslink/rules/python.md");
+pub(crate) const RULE_JAVASCRIPT: &str =
+    include_str!("../../resources/crosslink/rules/javascript.md");
+pub(crate) const RULE_TYPESCRIPT: &str =
+    include_str!("../../resources/crosslink/rules/typescript.md");
+pub(crate) const RULE_TYPESCRIPT_REACT: &str =
     include_str!("../../resources/crosslink/rules/typescript-react.md");
-const RULE_JAVASCRIPT_REACT: &str =
+pub(crate) const RULE_JAVASCRIPT_REACT: &str =
     include_str!("../../resources/crosslink/rules/javascript-react.md");
-const RULE_GO: &str = include_str!("../../resources/crosslink/rules/go.md");
-const RULE_JAVA: &str = include_str!("../../resources/crosslink/rules/java.md");
-const RULE_C: &str = include_str!("../../resources/crosslink/rules/c.md");
-const RULE_CPP: &str = include_str!("../../resources/crosslink/rules/cpp.md");
-const RULE_CSHARP: &str = include_str!("../../resources/crosslink/rules/csharp.md");
-const RULE_RUBY: &str = include_str!("../../resources/crosslink/rules/ruby.md");
-const RULE_PHP: &str = include_str!("../../resources/crosslink/rules/php.md");
-const RULE_SWIFT: &str = include_str!("../../resources/crosslink/rules/swift.md");
-const RULE_KOTLIN: &str = include_str!("../../resources/crosslink/rules/kotlin.md");
-const RULE_SCALA: &str = include_str!("../../resources/crosslink/rules/scala.md");
-const RULE_ZIG: &str = include_str!("../../resources/crosslink/rules/zig.md");
-const RULE_ODIN: &str = include_str!("../../resources/crosslink/rules/odin.md");
-const RULE_ELIXIR: &str = include_str!("../../resources/crosslink/rules/elixir.md");
-const RULE_ELIXIR_PHOENIX: &str = include_str!("../../resources/crosslink/rules/elixir-phoenix.md");
-const RULE_WEB: &str = include_str!("../../resources/crosslink/rules/web.md");
+pub(crate) const RULE_GO: &str = include_str!("../../resources/crosslink/rules/go.md");
+pub(crate) const RULE_JAVA: &str = include_str!("../../resources/crosslink/rules/java.md");
+pub(crate) const RULE_C: &str = include_str!("../../resources/crosslink/rules/c.md");
+pub(crate) const RULE_CPP: &str = include_str!("../../resources/crosslink/rules/cpp.md");
+pub(crate) const RULE_CSHARP: &str = include_str!("../../resources/crosslink/rules/csharp.md");
+pub(crate) const RULE_RUBY: &str = include_str!("../../resources/crosslink/rules/ruby.md");
+pub(crate) const RULE_PHP: &str = include_str!("../../resources/crosslink/rules/php.md");
+pub(crate) const RULE_SWIFT: &str = include_str!("../../resources/crosslink/rules/swift.md");
+pub(crate) const RULE_KOTLIN: &str = include_str!("../../resources/crosslink/rules/kotlin.md");
+pub(crate) const RULE_SCALA: &str = include_str!("../../resources/crosslink/rules/scala.md");
+pub(crate) const RULE_ZIG: &str = include_str!("../../resources/crosslink/rules/zig.md");
+pub(crate) const RULE_ODIN: &str = include_str!("../../resources/crosslink/rules/odin.md");
+pub(crate) const RULE_ELIXIR: &str = include_str!("../../resources/crosslink/rules/elixir.md");
+pub(crate) const RULE_ELIXIR_PHOENIX: &str =
+    include_str!("../../resources/crosslink/rules/elixir-phoenix.md");
+pub(crate) const RULE_WEB: &str = include_str!("../../resources/crosslink/rules/web.md");
 
 /// All rule files to deploy
-const RULE_FILES: &[(&str, &str)] = &[
+pub(crate) const RULE_FILES: &[(&str, &str)] = &[
     ("global.md", RULE_GLOBAL),
     ("project.md", RULE_PROJECT),
     ("rust.md", RULE_RUST),
@@ -238,6 +249,12 @@ pub fn run(path: &Path, force: bool) -> Result<()> {
         fs::create_dir_all(&mcp_dir).context("Failed to create .claude/mcp directory")?;
         fs::write(mcp_dir.join("safe-fetch-server.py"), SAFE_FETCH_SERVER_PY)
             .context("Failed to write safe-fetch-server.py")?;
+
+        // Write slash commands
+        let commands_dir = claude_dir.join("commands");
+        fs::create_dir_all(&commands_dir).context("Failed to create .claude/commands directory")?;
+        fs::write(commands_dir.join("review.md"), REVIEW_CMD_MD)
+            .context("Failed to write review.md")?;
 
         // Merge crosslink's MCP server entry into .mcp.json (preserving existing MCPs)
         let warnings =

--- a/crosslink/src/commands/mod.rs
+++ b/crosslink/src/commands/mod.rs
@@ -15,6 +15,7 @@ pub mod migrate;
 pub mod milestone;
 pub mod next;
 pub mod relate;
+pub mod review;
 pub mod search;
 pub mod session;
 pub mod show;

--- a/crosslink/src/commands/review.rs
+++ b/crosslink/src/commands/review.rs
@@ -1,0 +1,193 @@
+use anyhow::Result;
+use std::fs;
+use std::path::Path;
+
+use super::init;
+
+/// Hook files to compare: (deployed filename, embedded default)
+const HOOK_FILES: &[(&str, &str)] = &[
+    ("prompt-guard.py", init::PROMPT_GUARD_PY),
+    ("post-edit-check.py", init::POST_EDIT_CHECK_PY),
+    ("session-start.py", init::SESSION_START_PY),
+    ("pre-web-check.py", init::PRE_WEB_CHECK_PY),
+    ("work-check.py", init::WORK_CHECK_PY),
+];
+
+/// Compare a deployed file against its embedded default.
+/// Returns a description string.
+fn compare_file(deployed_path: &Path, default_content: &str) -> String {
+    match fs::read_to_string(deployed_path) {
+        Ok(content) => {
+            if content == default_content {
+                "matches default".to_string()
+            } else {
+                let diff_lines = content
+                    .lines()
+                    .zip(default_content.lines())
+                    .filter(|(a, b)| a != b)
+                    .count();
+                let len_diff = content
+                    .lines()
+                    .count()
+                    .abs_diff(default_content.lines().count());
+                let total_diff = diff_lines + len_diff;
+                format!("customized ({} lines differ)", total_diff)
+            }
+        }
+        Err(_) => "missing (not deployed)".to_string(),
+    }
+}
+
+/// `crosslink review diff` — compare deployed policy files against embedded defaults.
+pub fn diff(crosslink_dir: &Path, claude_dir: &Path, section: Option<&str>) -> Result<()> {
+    let show_all = section.is_none();
+
+    // --- Tracking Mode ---
+    if show_all || section == Some("tracking") {
+        println!("=== Tracking Mode ===");
+        let config_path = crosslink_dir.join("hook-config.json");
+        let status = compare_file(&config_path, init::HOOK_CONFIG_JSON);
+        // Also extract the current tracking mode if customized
+        if status.starts_with("customized") {
+            if let Ok(content) = fs::read_to_string(&config_path) {
+                if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&content) {
+                    let mode = parsed
+                        .get("tracking_mode")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("unknown");
+                    let default_mode: serde_json::Value =
+                        serde_json::from_str(init::HOOK_CONFIG_JSON).unwrap_or_default();
+                    let default = default_mode
+                        .get("tracking_mode")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("strict");
+                    println!(
+                        "  hook-config.json: {} (tracking_mode: \"{}\", default: \"{}\")",
+                        status, mode, default
+                    );
+                } else {
+                    println!("  hook-config.json: {}", status);
+                }
+            } else {
+                println!("  hook-config.json: {}", status);
+            }
+        } else {
+            println!("  hook-config.json: {}", status);
+        }
+        println!();
+    }
+
+    // --- Rules ---
+    if show_all || section == Some("rules") || section == Some("languages") {
+        println!("=== Rules ===");
+        let rules_dir = crosslink_dir.join("rules");
+        for (filename, default_content) in init::RULE_FILES {
+            let path = rules_dir.join(filename);
+            let status = compare_file(&path, default_content);
+            println!("  rules/{}: {}", filename, status);
+        }
+        println!();
+    }
+
+    // --- Hooks ---
+    if show_all || section == Some("hooks") {
+        println!("=== Hooks ===");
+        let hooks_dir = claude_dir.join("hooks");
+        for (filename, default_content) in HOOK_FILES {
+            let path = hooks_dir.join(filename);
+            let status = compare_file(&path, default_content);
+            println!("  .claude/hooks/{}: {}", filename, status);
+        }
+        println!();
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_compare_file_matches() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.txt");
+        fs::write(&path, "hello world").unwrap();
+        assert_eq!(compare_file(&path, "hello world"), "matches default");
+    }
+
+    #[test]
+    fn test_compare_file_customized() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.txt");
+        fs::write(&path, "hello modified\nextra line").unwrap();
+        let result = compare_file(&path, "hello world");
+        assert!(result.starts_with("customized"));
+        assert!(result.contains("lines differ"));
+    }
+
+    #[test]
+    fn test_compare_file_missing() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("nonexistent.txt");
+        assert_eq!(compare_file(&path, "content"), "missing (not deployed)");
+    }
+
+    #[test]
+    fn test_diff_defaults_match() {
+        // Init a fresh crosslink dir, then diff — everything should match
+        let dir = tempdir().unwrap();
+        crate::commands::init::run(dir.path(), false).unwrap();
+
+        let crosslink_dir = dir.path().join(".crosslink");
+        let claude_dir = dir.path().join(".claude");
+
+        // Should not error
+        diff(&crosslink_dir, &claude_dir, None).unwrap();
+    }
+
+    #[test]
+    fn test_diff_customized_file() {
+        let dir = tempdir().unwrap();
+        crate::commands::init::run(dir.path(), false).unwrap();
+
+        // Modify a rule file
+        let rule_path = dir.path().join(".crosslink/rules/global.md");
+        fs::write(
+            &rule_path,
+            "# My custom global rules\nDifferent content here.",
+        )
+        .unwrap();
+
+        let crosslink_dir = dir.path().join(".crosslink");
+        let claude_dir = dir.path().join(".claude");
+
+        // Should not error — just prints customized status
+        diff(&crosslink_dir, &claude_dir, Some("rules")).unwrap();
+    }
+
+    #[test]
+    fn test_diff_section_filter() {
+        let dir = tempdir().unwrap();
+        crate::commands::init::run(dir.path(), false).unwrap();
+
+        let crosslink_dir = dir.path().join(".crosslink");
+        let claude_dir = dir.path().join(".claude");
+
+        // Each section should work independently
+        diff(&crosslink_dir, &claude_dir, Some("tracking")).unwrap();
+        diff(&crosslink_dir, &claude_dir, Some("hooks")).unwrap();
+        diff(&crosslink_dir, &claude_dir, Some("languages")).unwrap();
+    }
+
+    #[test]
+    fn test_init_creates_commands_dir() {
+        let dir = tempdir().unwrap();
+        crate::commands::init::run(dir.path(), false).unwrap();
+
+        assert!(dir.path().join(".claude/commands/review.md").exists());
+        let content = fs::read_to_string(dir.path().join(".claude/commands/review.md")).unwrap();
+        assert!(content.contains("policy review"));
+    }
+}

--- a/crosslink/src/main.rs
+++ b/crosslink/src/main.rs
@@ -339,6 +339,12 @@ enum Commands {
 
     /// Import shared issues from coordination branch into local SQLite
     MigrateFromShared,
+
+    /// Review crosslink policy configuration
+    Review {
+        #[command(subcommand)]
+        command: ReviewCommands,
+    },
 }
 
 #[derive(Subcommand)]
@@ -513,6 +519,16 @@ enum LocksCommands {
     Steal {
         /// Issue ID
         id: i64,
+    },
+}
+
+#[derive(Subcommand)]
+enum ReviewCommands {
+    /// Compare deployed policy files against embedded defaults
+    Diff {
+        /// Filter by section: tracking, rules, languages, hooks
+        #[arg(short, long)]
+        section: Option<String>,
     },
 }
 
@@ -987,6 +1003,18 @@ fn main() -> Result<()> {
             let crosslink_dir = find_crosslink_dir()?;
             let db = get_db()?;
             commands::migrate::from_shared(&crosslink_dir, &db)
+        }
+        Commands::Review { command } => {
+            let crosslink_dir = find_crosslink_dir()?;
+            let claude_dir = crosslink_dir
+                .parent()
+                .ok_or_else(|| anyhow::anyhow!("Cannot determine project root"))?
+                .join(".claude");
+            match command {
+                ReviewCommands::Diff { section } => {
+                    commands::review::diff(&crosslink_dir, &claude_dir, section.as_deref())
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds `crosslink review diff` CLI command comparing deployed policy files against embedded defaults
- Bundles `/review` slash command via `crosslink init` for guided policy audits
- Exposes init.rs constants as `pub(crate)` for review module reuse

## Test plan
- [x] `cargo test` — 817 tests pass (7 new)
- [x] `crosslink init --force` creates `.claude/commands/review.md`
- [x] `crosslink review diff` shows correct comparison output
- [ ] `/review` in Claude Code triggers guided review flow

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)