### PR TITLE
feat: support +key array-extend semantics in hook-config.local.json

### DIFF
--- a/crosslink/resources/claude/hooks/prompt-guard.py
+++ b/crosslink/resources/claude/hooks/prompt-guard.py
@@ -552,8 +552,39 @@ def mark_full_guard_sent(crosslink_dir):
         pass
 
 
+def _merge_with_extend(base, override):
+    """Merge *override* into *base* with array-extend support.
+
+    Keys in *override* that start with ``+`` are treated as array-extend
+    directives: their values are appended to the corresponding base array
+    (with the ``+`` stripped from the key name).  For example::
+
+        base:     {"allowed_bash_prefixes": ["ls", "pwd"]}
+        override: {"+allowed_bash_prefixes": ["my-tool"]}
+        result:   {"allowed_bash_prefixes": ["ls", "pwd", "my-tool"]}
+
+    If the base has no matching key, the override value is used as-is.
+    If the ``+``-prefixed value is not a list, it replaces like a normal key.
+    Keys without a ``+`` prefix replace the base value (backward compatible).
+    """
+    for key, value in override.items():
+        if key.startswith("+"):
+            real_key = key[1:]
+            if isinstance(value, list) and isinstance(base.get(real_key), list):
+                base[real_key] = base[real_key] + value
+            else:
+                base[real_key] = value
+        else:
+            base[key] = value
+    return base
+
+
 def load_tracking_mode(crosslink_dir):
-    """Read tracking_mode from .crosslink/hook-config.json, with .local override. Defaults to 'strict'."""
+    """Read tracking_mode from .crosslink/hook-config.json, with .local override. Defaults to 'strict'.
+
+    Supports the ``+key`` convention for extending arrays.  See
+    ``_merge_with_extend`` for details.
+    """
     if not crosslink_dir:
         return "strict"
 
@@ -571,7 +602,7 @@ def load_tracking_mode(crosslink_dir):
         try:
             with open(local_path, "r", encoding="utf-8") as f:
                 local = json.load(f)
-            config.update(local)  # shallow merge: local keys win
+            _merge_with_extend(config, local)
         except (json.JSONDecodeError, OSError):
             pass
 

--- a/crosslink/resources/claude/hooks/work-check.py
+++ b/crosslink/resources/claude/hooks/work-check.py
@@ -37,8 +37,38 @@ DEFAULT_ALLOWED_BASH = [
 ]
 
 
+def _merge_with_extend(base, override):
+    """Merge *override* into *base* with array-extend support.
+
+    Keys in *override* that start with ``+`` are treated as array-extend
+    directives: their values are appended to the corresponding base array
+    (with the ``+`` stripped from the key name).  For example::
+
+        base:     {"allowed_bash_prefixes": ["ls", "pwd"]}
+        override: {"+allowed_bash_prefixes": ["my-tool"]}
+        result:   {"allowed_bash_prefixes": ["ls", "pwd", "my-tool"]}
+
+    If the base has no matching key, the override value is used as-is.
+    If the ``+``-prefixed value is not a list, it replaces like a normal key.
+    Keys without a ``+`` prefix replace the base value (backward compatible).
+    """
+    for key, value in override.items():
+        if key.startswith("+"):
+            real_key = key[1:]
+            if isinstance(value, list) and isinstance(base.get(real_key), list):
+                base[real_key] = base[real_key] + value
+            else:
+                base[real_key] = value
+        else:
+            base[key] = value
+    return base
+
+
 def _load_config_merged(crosslink_dir):
-    """Load hook-config.json, then shallow-merge hook-config.local.json on top.
+    """Load hook-config.json, then merge hook-config.local.json on top.
+
+    Supports the ``+key`` convention for extending arrays rather than
+    replacing them.  See ``_merge_with_extend`` for details.
 
     Returns the merged dict, or {} if neither file exists.
     """
@@ -59,7 +89,7 @@ def _load_config_merged(crosslink_dir):
         try:
             with open(local_path, "r", encoding="utf-8") as f:
                 local = json.load(f)
-            config.update(local)  # shallow merge: local keys win
+            _merge_with_extend(config, local)
         except (json.JSONDecodeError, OSError):
             pass
 


### PR DESCRIPTION
## Summary
- Add `_merge_with_extend()` to `work-check.py` and `prompt-guard.py` so that keys prefixed with `+` in `hook-config.local.json` append to the base array instead of replacing it
- Keys without the `+` prefix continue to replace as before (fully backward compatible)
- Handles edge cases: no matching base key (use value as-is), non-array `+` value (treat as replace)

Closes #12

## Example

```json
// hook-config.local.json
{ "+allowed_bash_prefixes": ["my-extra-tool"] }
```

This appends `"my-extra-tool"` to the default `allowed_bash_prefixes` array rather than replacing it.

## Test plan
- [x] Unit tested: basic replace, array extend, missing base key, non-list values, mixed keys
- [x] Integration tested through `_load_config_merged()` and `load_tracking_mode()`
- [x] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)