### PR TITLE
Add kickoff workflow skills to crosslink init

### DIFF
--- a/crosslink/resources/claude/commands/check.md
+++ b/crosslink/resources/claude/commands/check.md
@@ -1,0 +1,84 @@
+---
+allowed-tools: Bash(tmux *), Bash(cat *), Bash(test *), Bash(ls *), Bash(git *), Bash(tail *)
+description: Check on a background feature agent running in a tmux session
+---
+
+## Context
+
+- Active tmux sessions: !`tmux list-sessions 2>/dev/null || echo "no tmux server running"`
+- Current worktrees: !`git worktree list`
+
+## Your task
+
+The user optionally provides a tmux session name (e.g. `feat-add-batch-retry`). If no session name is given, check **all** active `feat-*` tmux sessions and report a summary for each.
+
+### 1. Identify sessions to check
+
+- If the user provided a session name, use that single session.
+- If no session name was provided, find `feat-*` tmux sessions that belong to **this repo only**:
+  1. Get the list of worktree paths for this repo: `git worktree list --porcelain | grep '^worktree ' | sed 's/^worktree //'`
+  2. Get all `feat-*` tmux sessions with their working directories: `tmux list-sessions -F '#{session_name} #{session_path}' 2>/dev/null | grep '^feat-'`
+  3. Only include sessions whose `session_path` matches one of this repo's worktree paths
+- If no matching sessions exist, report "No active feature agent sessions for this repo."
+
+### 2. For each session, perform these checks:
+
+#### a. Check the sentinel file
+
+Get the worktree path for this session from tmux: `tmux display-message -t <session-name> -p '#{session_path}'`. Alternatively, match the session name to a feature branch in `git worktree list`.
+
+- Check if `.kickoff-status` exists in the worktree: `cat <worktree-path>/.kickoff-status 2>/dev/null`
+- If it contains `DONE`, mark this session as finished.
+
+#### b. Capture the terminal state
+
+```bash
+tmux capture-pane -t <session-name> -p -S -80
+```
+
+This captures the last ~80 lines of visible output.
+
+#### c. Analyze state
+
+Read the captured output and determine the agent's current state:
+
+- **Working**: Tool calls in progress, code being written/read
+- **Waiting for input**: A question or prompt is displayed (look for `?`, option lists, or input prompts)
+- **Error/stuck**: Error messages, repeated failures, or no recent activity
+- **Completed**: The sentinel file says DONE, or the claude process has exited
+
+### 3. Report
+
+When checking **multiple sessions**, use a compact table format:
+
+```
+Feature Agents:
+
+  feat-add-retry       Working    Implementing retry logic in _sources.py
+  feat-fix-lens-bug    Done       All changes committed and reviewed
+  feat-new-cli-cmd     Waiting    Asking about CLI argument format
+```
+
+When checking a **single session**, use the detailed format:
+
+```
+Session: <name>
+Status:  <Working | Waiting | Done | Error>
+
+<2-3 sentence summary of what the agent is currently doing or has accomplished>
+```
+
+### 4. Offer actions
+
+Based on the status of each session, suggest relevant next steps:
+
+- **If working**: "Check back later, or attach directly: `tmux attach -t <name>`"
+- **If waiting for input**: Read the question, and ask the user what to answer. If the user provides an answer, send it: `tmux send-keys -t <session-name> "<response>" Enter`
+- **If done**: "Agent finished. Review the changes: `cd <worktree-path> && git log --oneline <base-branch>..HEAD`"
+- **If error**: Show the relevant error output and suggest the user attach to debug: `tmux attach -t <name>`
+
+## Constraints
+
+- Do not modify any files in the worktree — this is a read-only check.
+- Do not kill the tmux session unless the user explicitly asks.
+- When relaying a user's answer to a waiting prompt, send exactly what the user provides — do not embellish or modify.

--- a/crosslink/resources/claude/commands/featree.md
+++ b/crosslink/resources/claude/commands/featree.md
@@ -1,0 +1,63 @@
+---
+allowed-tools: Bash(git *), Bash(uuidgen), Bash(ls *), Bash(ln *), Bash(rm *), Bash(test *), Bash(mkdir *), Bash(grep *), Skill
+description: Create a feature branch and move it to a new git worktree
+---
+
+## Context
+
+- Current repo root: !`git rev-parse --show-toplevel`
+- Current branch: !`git branch --show-current`
+- Existing worktrees: !`git worktree list`
+- Working tree status: !`git status --short`
+
+## Your task
+
+The user provides a human-readable feature description (e.g. "add batch retry logic"). You will first create a feature branch using the `/feature` skill, then move it into a new git worktree.
+
+### 1. Create the feature branch
+
+- Invoke the `/feature` skill with the user's description as the argument.
+- This creates the `feature/<slug>` branch.
+- Note the branch name that was created.
+
+### 2. Generate worktree path
+
+- The worktree directory is `<repo-root>/.worktrees/<slug>` (inside the repo, gitignored).
+- Extract the slug from the branch name by stripping the `feature/` prefix.
+- Create the `.worktrees` directory if it doesn't exist: `mkdir -p <repo-root>/.worktrees`
+- Ensure `.worktrees/` is gitignored: check if it's already in `.gitignore`, and if not, append it.
+
+### 3. Create the worktree
+
+- Switch back to the previous branch (the one we were on before `/feature` created the new branch): `git checkout -`
+- Create the worktree pointing at the feature branch: `git worktree add <worktree-path> feature/<slug>`
+
+### 4. Symlink shared databases (if applicable)
+
+Check if the project uses any local databases or state files that should be shared across worktrees (e.g. `.crosslink/issues.db`). For each one found in the base repo:
+
+```bash
+# Only if the file exists in the base repo
+ln -s <repo-root>/<db-file> <worktree-path>/<db-file>
+```
+
+Known database files to check: `.crosslink/issues.db`
+
+If none of these files exist in the base repo, skip this step.
+
+### 5. Report to user
+
+Print a summary:
+```
+Worktree: <path>
+Branch:   feature/<slug>
+
+To start working:
+  cd <worktree-path>
+```
+
+## Constraints
+
+- Never force-push or delete branches.
+- Do not push the branch to a remote — the user will do that when ready.
+- Worktrees MUST be placed inside `<repo-root>/.worktrees/` to inherit the project's Claude Code trust scope and settings hierarchy.

--- a/crosslink/resources/claude/commands/feature.md
+++ b/crosslink/resources/claude/commands/feature.md
@@ -1,0 +1,44 @@
+---
+allowed-tools: Bash(git *), Bash(crosslink *)
+description: Create a feature branch from a human-readable description
+---
+
+## Context
+
+- Current branch: !`git branch --show-current`
+- Recent release branches: !`git branch --list 'release/*' | tail -5`
+- Existing feature branches: !`git branch --list 'feature/*' | tail -10`
+- Working tree status: !`git status --short`
+- Remotes: !`git remote -v`
+
+## Your task
+
+The user will provide a human-readable description of the feature (e.g. "add batch retry logic"). Create a feature branch following the project's naming convention.
+
+### 1. Derive the branch name
+
+- Slugify the description: lowercase, strip non-alphanumeric characters (except hyphens), replace spaces with hyphens, collapse consecutive hyphens.
+- The branch name is `feature/<slug>` (e.g. `feature/add-batch-retry-logic`).
+- If the slug is empty or the branch already exists, ask the user for a different name.
+
+### 2. Validate preconditions
+
+- Confirm there are no uncommitted changes (other than `.crosslink/issues.db`). If there are, warn the user and ask whether to stash or abort.
+- Identify the base branch. Default to the current branch. If the user provides a `--from <ref>` argument, use that instead.
+
+### 3. Create the branch
+
+- `git checkout -b feature/<slug>` (from the resolved base)
+- Print the created branch name so the user can confirm.
+
+### 4. Track in crosslink
+
+- Create a crosslink issue for the feature work with the user's original description as the title.
+- Set priority to `medium` (unless the user specifies otherwise).
+- Use: `crosslink create "<description>" -p medium --label feature`
+
+## Constraints
+
+- Never force-push or delete branches.
+- Do not push the branch to a remote — the user will do that when ready.
+- Keep the slug concise. If the description is very long, truncate to the first 6-8 meaningful words.

--- a/crosslink/resources/claude/commands/kickoff.md
+++ b/crosslink/resources/claude/commands/kickoff.md
@@ -1,0 +1,114 @@
+---
+allowed-tools: Bash(git *), Bash(uuidgen), Bash(ls *), Bash(ln *), Bash(rm *), Bash(tmux *), Bash(claude *), Bash(cat *), Bash(mkdir *), Bash(which *), Bash(test *), Bash(head *), Bash(grep *), Skill
+description: Create a worktree and launch a background claude agent in tmux to implement a feature
+---
+
+## Context
+
+- Current repo root: !`git rev-parse --show-toplevel`
+- Current branch: !`git branch --show-current`
+- Existing worktrees: !`git worktree list`
+- Working tree status: !`git status --short`
+- tmux available: !`which tmux`
+- CLAUDE.md head: !`head -3 CLAUDE.md`
+- Project root files: !`ls -1`
+
+## Your task
+
+The user provides a feature description (e.g. "add batch retry logic") and optionally additional context, file references, or constraints. You will create an isolated worktree, then launch a background `claude` process in a tmux session to implement the feature autonomously.
+
+### 1. Validate prerequisites
+
+- Confirm `tmux` is installed (`which tmux`). If not, abort with a message telling the user to install it.
+- Confirm `claude` CLI is installed (`which claude`). If not, abort.
+
+### 2. Create the worktree via /featree
+
+- Invoke the `/featree` skill with the user's feature description.
+- Capture the worktree path and branch name from the output.
+- The worktree will be at `<repo-root>/.worktrees/<slug>` (inside the repo, inheriting trust scope).
+
+### 3. Detect project conventions
+
+Before writing the prompt, detect what tools the project uses so the child agent gets appropriate instructions:
+
+- **Test runner**: Check for `justfile` (`just test`), `Makefile`, `package.json` (`npm test`), `pyproject.toml` (`uv run pytest` or `pytest`), `Cargo.toml` (`cargo test`), etc.
+- **Linter**: Check for `ruff.toml`, `.eslintrc`, `clippy`, etc.
+- **Task runner**: `just`, `make`, `npm run`, `cargo`, etc.
+- **CLAUDE.md**: If present, the child agent will read it for full project conventions.
+
+### 4. Prepare the agent prompt
+
+Build a detailed prompt for the child agent. The prompt must be self-contained — the child has no access to this conversation's context. Include:
+
+- The feature description from the user
+- Any specific files, modules, or code areas the user mentioned
+- Any constraints or requirements the user specified
+- Instructions to:
+  1. **Read the project's CLAUDE.md** (if it exists) for conventions before starting
+  2. Explore relevant code before making changes
+  3. Implement the feature fully (no stubs or placeholders)
+  4. **Run the project's test suite** to verify changes don't break anything (use the detected test command)
+  5. Use `/commit` to commit the work when implementation is complete
+  6. Review the diff of all changes and fix any issues found
+  7. Use `/commit` again after any fixes
+  8. When completely finished, write the word `DONE` to a file called `.kickoff-status` in the worktree root
+
+Write the prompt to `KICKOFF.md` in the worktree root. Ensure it's excluded from git by adding to the main repo's `.git/info/exclude`:
+
+```bash
+common_dir=$(git -C <worktree-path> rev-parse --git-common-dir)
+grep -qxF 'KICKOFF.md' "$common_dir/info/exclude" || echo "KICKOFF.md" >> "$common_dir/info/exclude"
+grep -qxF '.kickoff-status' "$common_dir/info/exclude" || echo ".kickoff-status" >> "$common_dir/info/exclude"
+```
+
+### 5. Derive the tmux session name
+
+- Use the feature branch slug as the tmux session name (e.g. `feat-add-batch-retry-logic`).
+- Prefix with `feat-` and truncate to 50 characters if needed.
+- Replace any characters invalid for tmux session names (periods, colons) with hyphens.
+
+### 6. Launch the tmux session
+
+```bash
+tmux new-session -d -s <session-name> -c <worktree-path>
+```
+
+Then send the claude command into the session:
+- Prefix with `env -u CLAUDECODE` to clear nested-session detection.
+- Do NOT use `--dangerously-skip-permissions`. Use `--allowedTools` for auto-approval after user grants trust.
+- Use `--` before the positional prompt argument to terminate option parsing.
+
+```bash
+tmux send-keys -t <session-name> "env -u CLAUDECODE claude --model opus --allowedTools 'Read,Write,Edit,Glob,Grep,Skill,Task,WebSearch,WebFetch,Bash(git *),Bash(ls *),Bash(mkdir *),Bash(test *),Bash(which *),Bash(touch *),Bash(cat *),Bash(head *),Bash(tail *),Bash(wc *),Bash(diff *),Bash(echo *),Bash(crosslink *),<project-specific-tools>' -- \"\$(cat KICKOFF.md)\"" Enter
+```
+
+**Project-specific tool additions** based on detected conventions:
+- Python/uv: `Bash(uv *)`
+- Node: `Bash(npm *),Bash(npx *)`
+- Rust: `Bash(cargo *)`
+- Just: `Bash(just *)`
+- Make: `Bash(make *)`
+
+### 7. Report to user
+
+```
+Feature agent launched.
+
+  Worktree: <path>
+  Branch:   feature/<slug>
+  Session:  <tmux-session-name>
+
+  Approve trust:   tmux attach -t <tmux-session-name>
+  Check status:    /check <tmux-session-name>
+
+  The agent is waiting for trust approval. Attach to the session and approve the prompt to begin.
+```
+
+## Constraints
+
+- Never force-push or delete branches.
+- Do not push the branch to a remote.
+- The child agent prompt must be fully self-contained.
+- Leave `KICKOFF.md` in the worktree for reference (git-excluded).
+- If a tmux session with the same name already exists, append a short random suffix.

--- a/crosslink/src/commands/init.rs
+++ b/crosslink/src/commands/init.rs
@@ -20,8 +20,12 @@ pub(crate) const WORK_CHECK_PY: &str = include_str!("../../resources/claude/hook
 const SAFE_FETCH_SERVER_PY: &str = include_str!("../../resources/claude/mcp/safe-fetch-server.py");
 const MCP_JSON: &str = include_str!("../../resources/mcp.json");
 
-// Embed slash command for guided policy review
+// Embed slash commands
 const REVIEW_CMD_MD: &str = include_str!("../../resources/claude/commands/review.md");
+const FEATURE_CMD_MD: &str = include_str!("../../resources/claude/commands/feature.md");
+const FEATREE_CMD_MD: &str = include_str!("../../resources/claude/commands/featree.md");
+const KICKOFF_CMD_MD: &str = include_str!("../../resources/claude/commands/kickoff.md");
+const CHECK_CMD_MD: &str = include_str!("../../resources/claude/commands/check.md");
 
 // Embed sanitization patterns
 const SANITIZE_PATTERNS: &str =
@@ -255,6 +259,14 @@ pub fn run(path: &Path, force: bool) -> Result<()> {
         fs::create_dir_all(&commands_dir).context("Failed to create .claude/commands directory")?;
         fs::write(commands_dir.join("review.md"), REVIEW_CMD_MD)
             .context("Failed to write review.md")?;
+        fs::write(commands_dir.join("feature.md"), FEATURE_CMD_MD)
+            .context("Failed to write feature.md")?;
+        fs::write(commands_dir.join("featree.md"), FEATREE_CMD_MD)
+            .context("Failed to write featree.md")?;
+        fs::write(commands_dir.join("kickoff.md"), KICKOFF_CMD_MD)
+            .context("Failed to write kickoff.md")?;
+        fs::write(commands_dir.join("check.md"), CHECK_CMD_MD)
+            .context("Failed to write check.md")?;
 
         // Merge crosslink's MCP server entry into .mcp.json (preserving existing MCPs)
         let warnings =
@@ -680,6 +692,11 @@ mod tests {
         assert!(!WORK_CHECK_PY.is_empty());
         assert!(!SAFE_FETCH_SERVER_PY.is_empty());
         assert!(!MCP_JSON.is_empty());
+        assert!(!REVIEW_CMD_MD.is_empty());
+        assert!(!FEATURE_CMD_MD.is_empty());
+        assert!(!FEATREE_CMD_MD.is_empty());
+        assert!(!KICKOFF_CMD_MD.is_empty());
+        assert!(!CHECK_CMD_MD.is_empty());
         assert!(!SANITIZE_PATTERNS.is_empty());
         assert!(!HOOK_CONFIG_JSON.is_empty());
         assert!(!RULE_TRACKING_STRICT.is_empty());


### PR DESCRIPTION
## Summary

Closes #22

- Add four slash command skills (`/feature`, `/featree`, `/kickoff`, `/check`) to `crosslink init` deployment
- Skills enable a worktree-based background agent workflow: create feature branches, isolate in worktrees, launch autonomous claude agents in tmux, and monitor their progress
- Follows the existing `/review` command pattern: embedded at compile time via `include_str!()`, deployed to `.claude/commands/` on init

## Test plan

- [x] `cargo test` — all 646 tests pass (505 unit + 141 integration)
- [x] `cargo build` compiles with new embedded resources
- [x] Existing init tests continue to pass (idempotent, force-update, etc.)
- [ ] Manual: run `crosslink init --force` in a project and verify all four `.claude/commands/*.md` files are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)