### PR TITLE
Deduplicate config-loading logic across hook Python scripts

### DIFF
--- a/crosslink/resources/claude/hooks/crosslink_config.py
+++ b/crosslink/resources/claude/hooks/crosslink_config.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""
+Shared configuration and utility functions for crosslink Claude Code hooks.
+
+This module is deployed to .claude/hooks/crosslink_config.py by `crosslink init`
+and imported by the other hook scripts (work-check.py, prompt-guard.py, etc.).
+"""
+
+import json
+import os
+import subprocess
+
+
+def project_root_from_script():
+    """Derive project root from this module's location (.claude/hooks/ -> project root)."""
+    try:
+        return os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    except (NameError, OSError):
+        return None
+
+
+def get_project_root():
+    """Get the project root directory.
+
+    Prefers deriving from the hook script's own path (works even when cwd is a
+    subdirectory), falling back to cwd.
+    """
+    root = project_root_from_script()
+    if root and os.path.isdir(root):
+        return root
+    return os.getcwd()
+
+
+def find_crosslink_dir():
+    """Find the .crosslink directory.
+
+    Prefers the project root derived from the hook script's own path
+    (reliable even when cwd is a subdirectory), falling back to walking
+    up from cwd for standalone/test usage.
+    """
+    # Primary: resolve from script location
+    root = project_root_from_script()
+    if root:
+        candidate = os.path.join(root, '.crosslink')
+        if os.path.isdir(candidate):
+            return candidate
+
+    # Fallback: walk up from cwd
+    current = os.getcwd()
+    for _ in range(10):
+        candidate = os.path.join(current, '.crosslink')
+        if os.path.isdir(candidate):
+            return candidate
+        parent = os.path.dirname(current)
+        if parent == current:
+            break
+        current = parent
+    return None
+
+
+def _merge_with_extend(base, override):
+    """Merge *override* into *base* with array-extend support.
+
+    Keys in *override* that start with ``+`` are treated as array-extend
+    directives: their values are appended to the corresponding base array
+    (with the ``+`` stripped from the key name).  For example::
+
+        base:     {"allowed_bash_prefixes": ["ls", "pwd"]}
+        override: {"+allowed_bash_prefixes": ["my-tool"]}
+        result:   {"allowed_bash_prefixes": ["ls", "pwd", "my-tool"]}
+
+    If the base has no matching key, the override value is used as-is.
+    If the ``+``-prefixed value is not a list, it replaces like a normal key.
+    Keys without a ``+`` prefix replace the base value (backward compatible).
+    """
+    for key, value in override.items():
+        if key.startswith("+"):
+            real_key = key[1:]
+            if isinstance(value, list) and isinstance(base.get(real_key), list):
+                base[real_key] = base[real_key] + value
+            else:
+                base[real_key] = value
+        else:
+            base[key] = value
+    return base
+
+
+def load_config_merged(crosslink_dir):
+    """Load hook-config.json, then merge hook-config.local.json on top.
+
+    Supports the ``+key`` convention for extending arrays rather than
+    replacing them.  See ``_merge_with_extend`` for details.
+
+    Returns the merged dict, or {} if neither file exists.
+    """
+    if not crosslink_dir:
+        return {}
+
+    config = {}
+    config_path = os.path.join(crosslink_dir, "hook-config.json")
+    if os.path.isfile(config_path):
+        try:
+            with open(config_path, "r", encoding="utf-8") as f:
+                config = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    local_path = os.path.join(crosslink_dir, "hook-config.local.json")
+    if os.path.isfile(local_path):
+        try:
+            with open(local_path, "r", encoding="utf-8") as f:
+                local = json.load(f)
+            _merge_with_extend(config, local)
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    return config
+
+
+def load_tracking_mode(crosslink_dir):
+    """Read tracking_mode from merged config. Defaults to 'strict'."""
+    config = load_config_merged(crosslink_dir)
+    mode = config.get("tracking_mode", "strict")
+    if mode in ("strict", "normal", "relaxed"):
+        return mode
+    return "strict"
+
+
+def find_crosslink_binary(crosslink_dir):
+    """Find the crosslink binary, checking config, PATH, and common locations."""
+    import shutil
+
+    # 1. Check hook-config.json (+ local override) for explicit path
+    config = load_config_merged(crosslink_dir)
+    bin_path = config.get("crosslink_binary")
+    if bin_path and os.path.isfile(bin_path) and os.access(bin_path, os.X_OK):
+        return bin_path
+
+    # 2. Check PATH
+    found = shutil.which("crosslink")
+    if found:
+        return found
+
+    # 3. Check common cargo install location
+    home = os.path.expanduser("~")
+    candidate = os.path.join(home, ".cargo", "bin", "crosslink")
+    if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+        return candidate
+
+    # 4. Check relative to project root (dev builds)
+    root = project_root_from_script()
+    if root:
+        for profile in ("release", "debug"):
+            candidate = os.path.join(root, "crosslink", "target", profile, "crosslink")
+            if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+                return candidate
+
+    return "crosslink"  # fallback to PATH lookup
+
+
+_crosslink_bin = None
+
+
+def run_crosslink(args, crosslink_dir=None):
+    """Run a crosslink command and return output."""
+    global _crosslink_bin
+    if _crosslink_bin is None:
+        _crosslink_bin = find_crosslink_binary(crosslink_dir)
+    try:
+        result = subprocess.run(
+            [_crosslink_bin] + args,
+            capture_output=True,
+            text=True,
+            timeout=3
+        )
+        return result.stdout.strip() if result.returncode == 0 else None
+    except (subprocess.TimeoutExpired, FileNotFoundError, Exception):
+        return None

--- a/crosslink/resources/claude/hooks/prompt-guard.py
+++ b/crosslink/resources/claude/hooks/prompt-guard.py
@@ -16,49 +16,13 @@ from datetime import datetime
 # Fix Windows encoding issues with Unicode characters
 sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
 
-
-def _project_root_from_script():
-    """Derive project root from this script's location (.claude/hooks/<script>.py -> project root)."""
-    try:
-        return os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-    except (NameError, OSError):
-        return None
-
-
-def _get_project_root():
-    """Get the project root directory.
-
-    Prefers deriving from the hook script's own path (works even when cwd is a
-    subdirectory), falling back to cwd.
-    """
-    root = _project_root_from_script()
-    if root and os.path.isdir(root):
-        return root
-    return os.getcwd()
-
-
-def find_crosslink_dir():
-    """Find the .crosslink directory.
-
-    Prefers the project root derived from the hook script's own path,
-    falling back to walking up from cwd.
-    """
-    root = _project_root_from_script()
-    if root:
-        candidate = os.path.join(root, '.crosslink')
-        if os.path.isdir(candidate):
-            return candidate
-
-    current = os.getcwd()
-    for _ in range(10):
-        candidate = os.path.join(current, '.crosslink')
-        if os.path.isdir(candidate):
-            return candidate
-        parent = os.path.dirname(current)
-        if parent == current:
-            break
-        current = parent
-    return None
+# Add hooks directory to path for shared module import
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from crosslink_config import (
+    find_crosslink_dir,
+    get_project_root,
+    load_tracking_mode,
+)
 
 
 def load_rule_file(rules_dir, filename):
@@ -144,7 +108,7 @@ def detect_languages():
     }
 
     found = set()
-    cwd = _get_project_root()
+    cwd = get_project_root()
 
     # Check for project config files first (more reliable than scanning)
     config_indicators = {
@@ -228,7 +192,7 @@ SKIP_DIRS = {
 
 def get_project_tree(max_depth=3, max_entries=50):
     """Generate a compact project tree to prevent path hallucinations."""
-    cwd = _get_project_root()
+    cwd = get_project_root()
     entries = []
 
     def should_skip(name):
@@ -305,7 +269,7 @@ def run_command(cmd, timeout=5):
 
 def get_dependencies(max_deps=30):
     """Get installed dependencies with versions. Uses caching based on lock file mtime."""
-    cwd = _get_project_root()
+    cwd = get_project_root()
     deps = []
 
     # Check for Rust (Cargo.toml)
@@ -550,66 +514,6 @@ def mark_full_guard_sent(crosslink_dir):
             f.write(str(datetime.now().timestamp()))
     except OSError:
         pass
-
-
-def _merge_with_extend(base, override):
-    """Merge *override* into *base* with array-extend support.
-
-    Keys in *override* that start with ``+`` are treated as array-extend
-    directives: their values are appended to the corresponding base array
-    (with the ``+`` stripped from the key name).  For example::
-
-        base:     {"allowed_bash_prefixes": ["ls", "pwd"]}
-        override: {"+allowed_bash_prefixes": ["my-tool"]}
-        result:   {"allowed_bash_prefixes": ["ls", "pwd", "my-tool"]}
-
-    If the base has no matching key, the override value is used as-is.
-    If the ``+``-prefixed value is not a list, it replaces like a normal key.
-    Keys without a ``+`` prefix replace the base value (backward compatible).
-    """
-    for key, value in override.items():
-        if key.startswith("+"):
-            real_key = key[1:]
-            if isinstance(value, list) and isinstance(base.get(real_key), list):
-                base[real_key] = base[real_key] + value
-            else:
-                base[real_key] = value
-        else:
-            base[key] = value
-    return base
-
-
-def load_tracking_mode(crosslink_dir):
-    """Read tracking_mode from .crosslink/hook-config.json, with .local override. Defaults to 'strict'.
-
-    Supports the ``+key`` convention for extending arrays.  See
-    ``_merge_with_extend`` for details.
-    """
-    if not crosslink_dir:
-        return "strict"
-
-    config = {}
-    config_path = os.path.join(crosslink_dir, "hook-config.json")
-    if os.path.isfile(config_path):
-        try:
-            with open(config_path, "r", encoding="utf-8") as f:
-                config = json.load(f)
-        except (json.JSONDecodeError, OSError):
-            pass
-
-    local_path = os.path.join(crosslink_dir, "hook-config.local.json")
-    if os.path.isfile(local_path):
-        try:
-            with open(local_path, "r", encoding="utf-8") as f:
-                local = json.load(f)
-            _merge_with_extend(config, local)
-        except (json.JSONDecodeError, OSError):
-            pass
-
-    mode = config.get("tracking_mode", "strict")
-    if mode in ("strict", "normal", "relaxed"):
-        return mode
-    return "strict"
 
 
 def load_tracking_rules(crosslink_dir, tracking_mode):

--- a/crosslink/resources/claude/hooks/work-check.py
+++ b/crosslink/resources/claude/hooks/work-check.py
@@ -5,13 +5,20 @@ is being actively worked on. Forces issue creation before code changes.
 """
 
 import json
-import subprocess
 import sys
 import os
 import io
 
 # Fix Windows encoding issues
 sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
+
+# Add hooks directory to path for shared module import
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from crosslink_config import (
+    find_crosslink_dir,
+    load_config_merged,
+    run_crosslink,
+)
 
 # Defaults — overridden by .crosslink/hook-config.json if present
 DEFAULT_BLOCKED_GIT = [
@@ -37,65 +44,6 @@ DEFAULT_ALLOWED_BASH = [
 ]
 
 
-def _merge_with_extend(base, override):
-    """Merge *override* into *base* with array-extend support.
-
-    Keys in *override* that start with ``+`` are treated as array-extend
-    directives: their values are appended to the corresponding base array
-    (with the ``+`` stripped from the key name).  For example::
-
-        base:     {"allowed_bash_prefixes": ["ls", "pwd"]}
-        override: {"+allowed_bash_prefixes": ["my-tool"]}
-        result:   {"allowed_bash_prefixes": ["ls", "pwd", "my-tool"]}
-
-    If the base has no matching key, the override value is used as-is.
-    If the ``+``-prefixed value is not a list, it replaces like a normal key.
-    Keys without a ``+`` prefix replace the base value (backward compatible).
-    """
-    for key, value in override.items():
-        if key.startswith("+"):
-            real_key = key[1:]
-            if isinstance(value, list) and isinstance(base.get(real_key), list):
-                base[real_key] = base[real_key] + value
-            else:
-                base[real_key] = value
-        else:
-            base[key] = value
-    return base
-
-
-def _load_config_merged(crosslink_dir):
-    """Load hook-config.json, then merge hook-config.local.json on top.
-
-    Supports the ``+key`` convention for extending arrays rather than
-    replacing them.  See ``_merge_with_extend`` for details.
-
-    Returns the merged dict, or {} if neither file exists.
-    """
-    if not crosslink_dir:
-        return {}
-
-    config = {}
-    config_path = os.path.join(crosslink_dir, "hook-config.json")
-    if os.path.isfile(config_path):
-        try:
-            with open(config_path, "r", encoding="utf-8") as f:
-                config = json.load(f)
-        except (json.JSONDecodeError, OSError):
-            pass
-
-    local_path = os.path.join(crosslink_dir, "hook-config.local.json")
-    if os.path.isfile(local_path):
-        try:
-            with open(local_path, "r", encoding="utf-8") as f:
-                local = json.load(f)
-            _merge_with_extend(config, local)
-        except (json.JSONDecodeError, OSError):
-            pass
-
-    return config
-
-
 def load_config(crosslink_dir):
     """Load hook config from .crosslink/hook-config.json (with .local override), falling back to defaults.
 
@@ -110,7 +58,7 @@ def load_config(crosslink_dir):
     allowed = list(DEFAULT_ALLOWED_BASH)
     mode = "strict"
 
-    config = _load_config_merged(crosslink_dir)
+    config = load_config_merged(crosslink_dir)
     if not config:
         return mode, blocked, gated, allowed
 
@@ -124,93 +72,6 @@ def load_config(crosslink_dir):
         allowed = config["allowed_bash_prefixes"]
 
     return mode, blocked, gated, allowed
-
-
-def _project_root_from_script():
-    """Derive project root from this script's location (.claude/hooks/<script>.py -> project root)."""
-    try:
-        return os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-    except (NameError, OSError):
-        return None
-
-
-def find_crosslink_dir():
-    """Find the .crosslink directory.
-
-    Prefers the project root derived from the hook script's own path
-    (reliable even when cwd is a subdirectory), falling back to walking
-    up from cwd for standalone/test usage.
-    """
-    # Primary: resolve from script location
-    root = _project_root_from_script()
-    if root:
-        candidate = os.path.join(root, '.crosslink')
-        if os.path.isdir(candidate):
-            return candidate
-
-    # Fallback: walk up from cwd
-    current = os.getcwd()
-    for _ in range(10):
-        candidate = os.path.join(current, '.crosslink')
-        if os.path.isdir(candidate):
-            return candidate
-        parent = os.path.dirname(current)
-        if parent == current:
-            break
-        current = parent
-    return None
-
-
-def _find_crosslink(crosslink_dir):
-    """Find the crosslink binary, checking config, PATH, and common locations."""
-    import shutil
-
-    # 1. Check hook-config.json (+ local override) for explicit path
-    config = _load_config_merged(crosslink_dir)
-    bin_path = config.get("crosslink_binary")
-    if bin_path and os.path.isfile(bin_path) and os.access(bin_path, os.X_OK):
-        return bin_path
-
-    # 2. Check PATH
-    found = shutil.which("crosslink")
-    if found:
-        return found
-
-    # 3. Check common cargo install location
-    home = os.path.expanduser("~")
-    candidate = os.path.join(home, ".cargo", "bin", "crosslink")
-    if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
-        return candidate
-
-    # 4. Check relative to project root (dev builds)
-    root = _project_root_from_script()
-    if root:
-        for profile in ("release", "debug"):
-            candidate = os.path.join(root, "crosslink", "target", profile, "crosslink")
-            if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
-                return candidate
-
-    return "crosslink"  # fallback to PATH lookup
-
-
-_crosslink_bin = None
-
-
-def run_crosslink(args, crosslink_dir=None):
-    """Run a crosslink command and return output."""
-    global _crosslink_bin
-    if _crosslink_bin is None:
-        _crosslink_bin = _find_crosslink(crosslink_dir)
-    try:
-        result = subprocess.run(
-            [_crosslink_bin] + args,
-            capture_output=True,
-            text=True,
-            timeout=3
-        )
-        return result.stdout.strip() if result.returncode == 0 else None
-    except (subprocess.TimeoutExpired, FileNotFoundError, Exception):
-        return None
 
 
 def _matches_command_list(command, cmd_list):

--- a/crosslink/src/commands/init.rs
+++ b/crosslink/src/commands/init.rs
@@ -15,6 +15,8 @@ pub(crate) const SESSION_START_PY: &str =
 pub(crate) const PRE_WEB_CHECK_PY: &str =
     include_str!("../../resources/claude/hooks/pre-web-check.py");
 pub(crate) const WORK_CHECK_PY: &str = include_str!("../../resources/claude/hooks/work-check.py");
+pub(crate) const CROSSLINK_CONFIG_PY: &str =
+    include_str!("../../resources/claude/hooks/crosslink_config.py");
 
 // Embed MCP server for safe web fetching
 const SAFE_FETCH_SERVER_PY: &str = include_str!("../../resources/claude/mcp/safe-fetch-server.py");
@@ -248,6 +250,9 @@ pub fn run(path: &Path, force: bool) -> Result<()> {
         fs::write(hooks_dir.join("work-check.py"), WORK_CHECK_PY)
             .context("Failed to write work-check.py")?;
 
+        fs::write(hooks_dir.join("crosslink_config.py"), CROSSLINK_CONFIG_PY)
+            .context("Failed to write crosslink_config.py")?;
+
         // Create MCP server directory and write safe-fetch server
         let mcp_dir = claude_dir.join("mcp");
         fs::create_dir_all(&mcp_dir).context("Failed to create .claude/mcp directory")?;
@@ -323,6 +328,10 @@ mod tests {
         assert!(dir.path().join(".claude/hooks/session-start.py").exists());
         assert!(dir.path().join(".claude/hooks/pre-web-check.py").exists());
         assert!(dir.path().join(".claude/hooks/work-check.py").exists());
+        assert!(dir
+            .path()
+            .join(".claude/hooks/crosslink_config.py")
+            .exists());
         assert!(dir.path().join(".claude/mcp/safe-fetch-server.py").exists());
         assert!(dir.path().join(".mcp.json").exists());
     }
@@ -690,6 +699,7 @@ mod tests {
         assert!(!SESSION_START_PY.is_empty());
         assert!(!PRE_WEB_CHECK_PY.is_empty());
         assert!(!WORK_CHECK_PY.is_empty());
+        assert!(!CROSSLINK_CONFIG_PY.is_empty());
         assert!(!SAFE_FETCH_SERVER_PY.is_empty());
         assert!(!MCP_JSON.is_empty());
         assert!(!REVIEW_CMD_MD.is_empty());


### PR DESCRIPTION
## Summary

- Extract shared config-loading, binary-finding, and project-root logic from `work-check.py` and `prompt-guard.py` into a new `crosslink_config.py` shared module
- Both hooks now import from the shared module, eliminating ~190 lines of duplicated code
- The new module is embedded at compile time and deployed by `crosslink init` alongside the other hook scripts

## Details

Closes #20

**New file:** `crosslink/resources/claude/hooks/crosslink_config.py` with 7 shared functions:
- `project_root_from_script()` — derive project root from hook location
- `get_project_root()` — project root with cwd fallback
- `find_crosslink_dir()` — locate `.crosslink/` directory
- `load_config_merged()` — load + shallow-merge `hook-config.json` and `hook-config.local.json`
- `load_tracking_mode()` — read tracking mode from merged config
- `find_crosslink_binary()` — locate crosslink binary (config, PATH, cargo, dev builds)
- `run_crosslink()` — execute crosslink commands with cached binary path

**Updated files:**
- `work-check.py` — removed 6 duplicated functions, imports from shared module
- `prompt-guard.py` — removed 4 duplicated functions, imports from shared module
- `init.rs` — embeds and deploys `crosslink_config.py` via `include_str!`

## Test plan

- [x] `cargo test` — all 817 tests pass (171 lib + 505 bin + 141 integration)
- [x] `cargo build` — compiles successfully
- [ ] `crosslink init --force` on a test project deploys `crosslink_config.py` to `.claude/hooks/`
- [ ] Hooks function correctly after deployment (work-check blocks without issue, prompt-guard injects rules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)