### PR TITLE
ci: add tiered job dependencies to save CI minutes on early failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
   # Security Audit
   # ===========================================
   security:
+    needs: lint
     name: Security Audit
     runs-on: ubuntu-latest
     defaults:
@@ -69,6 +70,7 @@ jobs:
   # Tests - Cross Platform
   # ===========================================
   test:
+    needs: lint
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
@@ -117,6 +119,7 @@ jobs:
   # Property-Based Tests (extended)
   # ===========================================
   proptest:
+    needs: test
     name: Property Tests
     runs-on: ubuntu-latest
     defaults:
@@ -148,6 +151,7 @@ jobs:
   # Fuzzing (Linux only, nightly)
   # ===========================================
   fuzz:
+    needs: test
     name: Fuzz Tests
     runs-on: ubuntu-latest
     defaults:
@@ -190,6 +194,7 @@ jobs:
   # Build Release Binaries
   # ===========================================
   build-release:
+    needs: test
     name: Build Release (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     defaults:


### PR DESCRIPTION
## Summary

- Add `needs:` dependencies to CI workflow jobs so fast checks gate expensive ones
- **Tier 1 (gate):** `lint` runs first with no dependencies
- **Tier 2 (`needs: lint`):** `test` and `security` only run if linting passes
- **Tier 3 (`needs: test`):** `build-release`, `fuzz`, and `proptest` only run if tests pass

If linting fails, all downstream jobs are skipped immediately, saving CI minutes.

## Test plan

- [x] Verified only `needs:` lines were added — no job names or steps changed
- [x] All 508 unit tests pass (`cargo test --bin crosslink -- --skip proptest`)
- [x] YAML structure validated (proper indentation, valid syntax)
- [ ] CI runs on this PR will validate the workflow end-to-end

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)