### PR TITLE
Redesign milestones to per-file storage (fixes #16)

### DIFF
--- a/crosslink/src/commands/integrity_cmd.rs
+++ b/crosslink/src/commands/integrity_cmd.rs
@@ -4,7 +4,10 @@ use std::path::Path;
 use crate::db::{Database, SCHEMA_VERSION};
 use crate::hydration::hydrate_to_sqlite;
 use crate::identity::AgentConfig;
-use crate::issue_file::{read_all_issue_files, read_counters, write_counters, Counters};
+use crate::issue_file::{
+    read_all_issue_files, read_all_milestone_files, read_counters, read_milestones_file,
+    write_counters, Counters,
+};
 use crate::sync::SyncManager;
 use crate::IntegrityCommands;
 
@@ -150,6 +153,7 @@ fn check_counters(crosslink_dir: &Path, db: &Database, repair: bool) -> Result<C
     let repaired = Counters {
         next_display_id: expected_display.max(counters.next_display_id),
         next_comment_id: expected_comment.max(counters.next_comment_id),
+        next_milestone_id: counters.next_milestone_id,
     };
     write_counters(&counters_path, &repaired)?;
 
@@ -170,20 +174,48 @@ fn check_hydration(crosslink_dir: &Path, db: &Database, repair: bool) -> Result<
 
     let issues_dir = cache_dir.join("issues");
     let json_issues = read_all_issue_files(&issues_dir)?;
-    let json_count = json_issues
+    let json_issue_count = json_issues
         .iter()
         .filter(|i| i.display_id.is_some())
         .count() as i64;
-    let db_count = db.get_issue_count()?;
+    let db_issue_count = db.get_issue_count()?;
 
-    if json_count == db_count {
+    // Count milestones: per-file first, fall back to legacy single-file
+    let milestones_dir = cache_dir.join("meta").join("milestones");
+    let json_milestone_entries = read_all_milestone_files(&milestones_dir)?;
+    let json_milestone_count = if json_milestone_entries.is_empty() {
+        let legacy_path = cache_dir.join("meta").join("milestones.json");
+        let legacy = read_milestones_file(&legacy_path)?;
+        legacy.milestones.len() as i64
+    } else {
+        json_milestone_entries.len() as i64
+    };
+    let db_milestone_count = db.get_milestone_count()?;
+
+    let issues_ok = json_issue_count == db_issue_count;
+    let milestones_ok = json_milestone_count == db_milestone_count;
+
+    if issues_ok && milestones_ok {
         return Ok(CheckResult {
             name: "hydration".to_string(),
             status: CheckStatus::Pass,
         });
     }
 
-    let details = format!("{} issues in JSON, {} in SQLite", json_count, db_count);
+    let mut issues = Vec::new();
+    if !issues_ok {
+        issues.push(format!(
+            "{} issues in JSON, {} in SQLite",
+            json_issue_count, db_issue_count
+        ));
+    }
+    if !milestones_ok {
+        issues.push(format!(
+            "{} milestones in JSON, {} in SQLite",
+            json_milestone_count, db_milestone_count
+        ));
+    }
+    let details = issues.join("; ");
 
     if !repair {
         return Ok(CheckResult {
@@ -377,6 +409,7 @@ mod tests {
         let counters = Counters {
             next_display_id: 1,
             next_comment_id: 1,
+            next_milestone_id: 1,
         };
         write_counters(&meta_dir.join("counters.json"), &counters).unwrap();
 
@@ -398,6 +431,7 @@ mod tests {
         let counters = Counters {
             next_display_id: 1, // should be 2
             next_comment_id: 1,
+            next_milestone_id: 1,
         };
         write_counters(&meta_dir.join("counters.json"), &counters).unwrap();
 

--- a/crosslink/src/commands/migrate.rs
+++ b/crosslink/src/commands/migrate.rs
@@ -13,8 +13,8 @@ use crate::db::Database;
 use crate::hydration::hydrate_to_sqlite;
 use crate::identity::AgentConfig;
 use crate::issue_file::{
-    write_counters, write_issue_file, CommentEntry, Counters, IssueFile, MilestoneEntry,
-    MilestonesFile,
+    write_counters, write_issue_file, write_milestone_file, CommentEntry, Counters, IssueFile,
+    MilestoneEntry,
 };
 use crate::sync::SyncManager;
 
@@ -152,35 +152,31 @@ pub fn to_shared(crosslink_dir: &Path, db: &Database) -> Result<()> {
 
     // Write counters.json
     let max_display_id = issues.iter().map(|i| i.id).max().unwrap_or(0);
+    let max_milestone_id = milestones.iter().map(|m| m.id).max().unwrap_or(0);
     let counters = Counters {
         next_display_id: max_display_id + 1,
         next_comment_id: max_comment_id + 1,
+        next_milestone_id: max_milestone_id + 1,
     };
     write_counters(&meta_dir.join("counters.json"), &counters)?;
 
-    // Write milestones.json
+    // Write per-file milestones to meta/milestones/{uuid}.json
     if !milestones.is_empty() {
-        let mut milestone_map = HashMap::new();
+        let milestones_dir = meta_dir.join("milestones");
+        std::fs::create_dir_all(&milestones_dir)?;
         for ms in &milestones {
             let uuid = milestone_id_to_uuid[&ms.id];
-            milestone_map.insert(
+            let entry = MilestoneEntry {
                 uuid,
-                MilestoneEntry {
-                    uuid,
-                    display_id: ms.id,
-                    name: ms.name.clone(),
-                    description: ms.description.clone(),
-                    status: ms.status.clone(),
-                    created_at: ms.created_at,
-                    closed_at: ms.closed_at,
-                },
-            );
+                display_id: ms.id,
+                name: ms.name.clone(),
+                description: ms.description.clone(),
+                status: ms.status.clone(),
+                created_at: ms.created_at,
+                closed_at: ms.closed_at,
+            };
+            write_milestone_file(&milestones_dir.join(format!("{}.json", uuid)), &entry)?;
         }
-        let milestones_file = MilestonesFile {
-            milestones: milestone_map,
-        };
-        let mf_json = serde_json::to_string_pretty(&milestones_file)?;
-        std::fs::write(meta_dir.join("milestones.json"), mf_json)?;
     }
 
     // Commit and push
@@ -460,6 +456,7 @@ mod tests {
         let counters = Counters {
             next_display_id: max_display_id + 1,
             next_comment_id: max_comment_id + 1,
+            next_milestone_id: 1,
         };
         assert_eq!(counters.next_display_id, id3 + 1);
         assert_eq!(counters.next_comment_id, cid + 1);

--- a/crosslink/src/commands/milestone.rs
+++ b/crosslink/src/commands/milestone.rs
@@ -1,11 +1,22 @@
 use anyhow::{bail, Result};
 
 use crate::db::Database;
+use crate::shared_writer::SharedWriter;
 use crate::utils::format_issue_id;
 
-pub fn create(db: &Database, name: &str, description: Option<&str>) -> Result<()> {
-    let id = db.create_milestone(name, description)?;
-    println!("Created milestone #{}: {}", id, name);
+pub fn create(
+    db: &Database,
+    shared: Option<&SharedWriter>,
+    name: &str,
+    description: Option<&str>,
+) -> Result<()> {
+    if let Some(sw) = shared {
+        let id = sw.create_milestone(db, name, description)?;
+        println!("Created milestone #{}: {}", id, name);
+    } else {
+        let id = db.create_milestone(name, description)?;
+        println!("Created milestone #{}: {}", id, name);
+    }
     Ok(())
 }
 
@@ -130,8 +141,11 @@ pub fn remove(db: &Database, milestone_id: i64, issue_id: i64) -> Result<()> {
     Ok(())
 }
 
-pub fn close(db: &Database, id: i64) -> Result<()> {
-    if db.close_milestone(id)? {
+pub fn close(db: &Database, shared: Option<&SharedWriter>, id: i64) -> Result<()> {
+    if let Some(sw) = shared {
+        sw.close_milestone(db, id)?;
+        println!("Closed milestone #{}", id);
+    } else if db.close_milestone(id)? {
         println!("Closed milestone #{}", id);
     } else {
         println!("Milestone #{} not found", id);
@@ -140,8 +154,11 @@ pub fn close(db: &Database, id: i64) -> Result<()> {
     Ok(())
 }
 
-pub fn delete(db: &Database, id: i64) -> Result<()> {
-    if db.delete_milestone(id)? {
+pub fn delete(db: &Database, shared: Option<&SharedWriter>, id: i64) -> Result<()> {
+    if let Some(sw) = shared {
+        sw.delete_milestone(db, id)?;
+        println!("Deleted milestone #{}", id);
+    } else if db.delete_milestone(id)? {
         println!("Deleted milestone #{}", id);
     } else {
         println!("Milestone #{} not found", id);
@@ -166,7 +183,7 @@ mod tests {
     #[test]
     fn test_create_milestone() {
         let (db, _dir) = setup_test_db();
-        create(&db, "v1.0", None).unwrap();
+        create(&db, None, "v1.0", None).unwrap();
         let milestones = db.list_milestones(None).unwrap();
         assert_eq!(milestones.len(), 1);
         assert_eq!(milestones[0].name, "v1.0");
@@ -175,7 +192,7 @@ mod tests {
     #[test]
     fn test_create_milestone_with_description() {
         let (db, _dir) = setup_test_db();
-        create(&db, "v1.0", Some("First release")).unwrap();
+        create(&db, None, "v1.0", Some("First release")).unwrap();
         let milestones = db.list_milestones(None).unwrap();
         assert_eq!(milestones[0].description, Some("First release".to_string()));
     }
@@ -250,7 +267,7 @@ mod tests {
     fn test_close_milestone() {
         let (db, _dir) = setup_test_db();
         let id = db.create_milestone("v1.0", None).unwrap();
-        close(&db, id).unwrap();
+        close(&db, None, id).unwrap();
         let m = db.get_milestone(id).unwrap().unwrap();
         assert_eq!(m.status, "closed");
         assert!(m.closed_at.is_some());
@@ -260,7 +277,7 @@ mod tests {
     fn test_delete_milestone() {
         let (db, _dir) = setup_test_db();
         let id = db.create_milestone("v1.0", None).unwrap();
-        delete(&db, id).unwrap();
+        delete(&db, None, id).unwrap();
         let m = db.get_milestone(id).unwrap();
         assert!(m.is_none(), "Milestone should be deleted");
     }
@@ -285,7 +302,7 @@ mod tests {
         #[test]
         fn prop_create_milestone_persists(name in "[a-zA-Z0-9 ]{1,30}") {
             let (db, _dir) = setup_test_db();
-            create(&db, &name, None).unwrap();
+            create(&db, None, &name, None).unwrap();
             let milestones = db.list_milestones(None).unwrap();
             prop_assert_eq!(milestones.len(), 1);
             prop_assert_eq!(&milestones[0].name, &name);

--- a/crosslink/src/db.rs
+++ b/crosslink/src/db.rs
@@ -1122,6 +1122,13 @@ impl Database {
         Ok(count)
     }
 
+    pub fn get_milestone_count(&self) -> Result<i64> {
+        let count: i64 = self
+            .conn
+            .query_row("SELECT COUNT(*) FROM milestones", [], |row| row.get(0))?;
+        Ok(count)
+    }
+
     // === Hydration helpers (for shared issue coordination) ===
 
     /// Delete all shared data tables in preparation for re-hydration from JSON.

--- a/crosslink/src/hydration.rs
+++ b/crosslink/src/hydration.rs
@@ -11,7 +11,9 @@ use std::path::Path;
 use anyhow::Result;
 
 use crate::db::{Database, HydratedIssue, HydratedMilestone};
-use crate::issue_file::{read_all_issue_files, read_milestones_file, IssueFile};
+use crate::issue_file::{
+    read_all_issue_files, read_all_milestone_files, read_milestones_file, IssueFile,
+};
 
 /// Statistics returned after hydration.
 #[derive(Debug, Default)]
@@ -40,8 +42,14 @@ pub fn hydrate_to_sqlite(cache_dir: &Path, db: &Database) -> Result<HydrationSta
         return Ok(HydrationStats::default());
     }
 
-    let milestones_path = cache_dir.join("meta").join("milestones.json");
-    let milestones_file = read_milestones_file(&milestones_path)?;
+    // Try per-file milestones first (new format), fall back to legacy single-file
+    let milestones_dir = cache_dir.join("meta").join("milestones");
+    let mut milestone_entries = read_all_milestone_files(&milestones_dir)?;
+    if milestone_entries.is_empty() {
+        let legacy_path = cache_dir.join("meta").join("milestones.json");
+        let legacy = read_milestones_file(&legacy_path)?;
+        milestone_entries = legacy.milestones.into_values().collect();
+    }
 
     // Build uuid -> display_id lookup for resolving cross-references
     let mut uuid_to_id: HashMap<String, i64> = issue_files
@@ -50,9 +58,8 @@ pub fn hydrate_to_sqlite(cache_dir: &Path, db: &Database) -> Result<HydrationSta
         .collect();
 
     // Build milestone uuid -> display_id lookup
-    let milestone_uuid_to_id: HashMap<String, i64> = milestones_file
-        .milestones
-        .values()
+    let milestone_uuid_to_id: HashMap<String, i64> = milestone_entries
+        .iter()
         .map(|m| (m.uuid.to_string(), m.display_id))
         .collect();
 
@@ -62,7 +69,7 @@ pub fn hydrate_to_sqlite(cache_dir: &Path, db: &Database) -> Result<HydrationSta
         db.clear_shared_data()?;
 
         // Insert milestones first (issues may reference them)
-        for entry in milestones_file.milestones.values() {
+        for entry in &milestone_entries {
             let created_at = entry.created_at.to_rfc3339();
             let closed_at = entry.closed_at.map(|dt| dt.to_rfc3339());
             db.insert_hydrated_milestone(&HydratedMilestone {
@@ -491,5 +498,74 @@ mod tests {
 
         hydrate_to_sqlite(cache.path(), &db).unwrap();
         // If we got here without error, time entries were inserted successfully
+    }
+
+    #[test]
+    fn test_hydrate_milestones_per_file() {
+        let (db, _dir) = setup_test_db();
+        let cache = tempdir().unwrap();
+
+        let issue = make_issue(1, "Test");
+        write_issues_to_cache(cache.path(), &[issue]);
+
+        // Write per-file milestone
+        let ms_dir = cache.path().join("meta").join("milestones");
+        std::fs::create_dir_all(&ms_dir).unwrap();
+        let ms_uuid = Uuid::new_v4();
+        let entry = crate::issue_file::MilestoneEntry {
+            uuid: ms_uuid,
+            display_id: 1,
+            name: "v1.0".to_string(),
+            description: None,
+            status: "open".to_string(),
+            created_at: Utc::now(),
+            closed_at: None,
+        };
+        crate::issue_file::write_milestone_file(&ms_dir.join(format!("{}.json", ms_uuid)), &entry)
+            .unwrap();
+
+        let stats = hydrate_to_sqlite(cache.path(), &db).unwrap();
+        assert_eq!(stats.milestones, 1);
+
+        let ms = db.get_milestone(1).unwrap();
+        assert!(ms.is_some());
+        assert_eq!(ms.unwrap().name, "v1.0");
+    }
+
+    #[test]
+    fn test_hydrate_milestones_legacy_fallback() {
+        let (db, _dir) = setup_test_db();
+        let cache = tempdir().unwrap();
+
+        let issue = make_issue(1, "Test");
+        write_issues_to_cache(cache.path(), &[issue]);
+
+        // Write legacy single-file milestones.json (no per-file dir)
+        let meta_dir = cache.path().join("meta");
+        std::fs::create_dir_all(&meta_dir).unwrap();
+        let ms_uuid = Uuid::new_v4();
+        let mut milestones = std::collections::HashMap::new();
+        milestones.insert(
+            ms_uuid,
+            crate::issue_file::MilestoneEntry {
+                uuid: ms_uuid,
+                display_id: 1,
+                name: "legacy-ms".to_string(),
+                description: None,
+                status: "open".to_string(),
+                created_at: Utc::now(),
+                closed_at: None,
+            },
+        );
+        let mf = crate::issue_file::MilestonesFile { milestones };
+        let json = serde_json::to_string_pretty(&mf).unwrap();
+        std::fs::write(meta_dir.join("milestones.json"), json).unwrap();
+
+        let stats = hydrate_to_sqlite(cache.path(), &db).unwrap();
+        assert_eq!(stats.milestones, 1);
+
+        let ms = db.get_milestone(1).unwrap();
+        assert!(ms.is_some());
+        assert_eq!(ms.unwrap().name, "legacy-ms");
     }
 }

--- a/crosslink/src/issue_file.rs
+++ b/crosslink/src/issue_file.rs
@@ -69,6 +69,12 @@ pub struct TimeEntry {
 pub struct Counters {
     pub next_display_id: i64,
     pub next_comment_id: i64,
+    #[serde(default = "default_one")]
+    pub next_milestone_id: i64,
+}
+
+fn default_one() -> i64 {
+    1
 }
 
 impl Default for Counters {
@@ -76,6 +82,7 @@ impl Default for Counters {
         Counters {
             next_display_id: 1,
             next_comment_id: 1,
+            next_milestone_id: 1,
         }
     }
 }
@@ -165,6 +172,50 @@ pub fn read_milestones_file(path: &std::path::Path) -> anyhow::Result<Milestones
     }
     let content = std::fs::read_to_string(path)?;
     Ok(serde_json::from_str(&content)?)
+}
+
+/// Read a single milestone file from disk.
+pub fn read_milestone_file(path: &std::path::Path) -> anyhow::Result<MilestoneEntry> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read milestone file: {}", path.display()))?;
+    serde_json::from_str(&content)
+        .with_context(|| format!("Failed to parse milestone file: {}", path.display()))
+}
+
+/// Write a single milestone file to disk (pretty-printed JSON).
+pub fn write_milestone_file(path: &std::path::Path, entry: &MilestoneEntry) -> anyhow::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let content = serde_json::to_string_pretty(entry)?;
+    std::fs::write(path, content)
+        .with_context(|| format!("Failed to write milestone file: {}", path.display()))
+}
+
+/// Read all milestone files from a directory.
+pub fn read_all_milestone_files(
+    milestones_dir: &std::path::Path,
+) -> anyhow::Result<Vec<MilestoneEntry>> {
+    let mut entries = Vec::new();
+    if !milestones_dir.exists() {
+        return Ok(entries);
+    }
+    for entry in std::fs::read_dir(milestones_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) == Some("json") {
+            match read_milestone_file(&path) {
+                Ok(ms) => entries.push(ms),
+                Err(e) => {
+                    eprintln!(
+                        "Warning: skipping malformed milestone file {}: {e}",
+                        path.display()
+                    );
+                }
+            }
+        }
+    }
+    Ok(entries)
 }
 
 use anyhow::Context;
@@ -261,6 +312,7 @@ mod tests {
         let c = Counters {
             next_display_id: 42,
             next_comment_id: 157,
+            next_milestone_id: 3,
         };
         let json = serde_json::to_string(&c).unwrap();
         let parsed: Counters = serde_json::from_str(&json).unwrap();
@@ -404,9 +456,72 @@ mod tests {
         let c = Counters {
             next_display_id: 10,
             next_comment_id: 50,
+            next_milestone_id: 1,
         };
         write_counters(&path, &c).unwrap();
         let loaded = read_counters(&path).unwrap();
         assert_eq!(c, loaded);
+    }
+
+    #[test]
+    fn test_counters_backward_compat_missing_milestone_id() {
+        // Old counters.json without next_milestone_id should default to 1
+        let json = r#"{"next_display_id": 5, "next_comment_id": 3}"#;
+        let parsed: Counters = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.next_milestone_id, 1);
+    }
+
+    #[test]
+    fn test_milestone_file_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("milestone.json");
+
+        let entry = MilestoneEntry {
+            uuid: Uuid::new_v4(),
+            display_id: 1,
+            name: "v1.0".to_string(),
+            description: Some("First release".to_string()),
+            status: "open".to_string(),
+            created_at: Utc::now(),
+            closed_at: None,
+        };
+
+        write_milestone_file(&path, &entry).unwrap();
+        let loaded = read_milestone_file(&path).unwrap();
+        assert_eq!(entry.uuid, loaded.uuid);
+        assert_eq!(entry.name, loaded.name);
+        assert_eq!(entry.description, loaded.description);
+    }
+
+    #[test]
+    fn test_read_all_milestone_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let ms_dir = dir.path().join("milestones");
+        std::fs::create_dir_all(&ms_dir).unwrap();
+
+        for i in 0..3 {
+            let entry = MilestoneEntry {
+                uuid: Uuid::new_v4(),
+                display_id: i + 1,
+                name: format!("v{}.0", i + 1),
+                description: None,
+                status: "open".to_string(),
+                created_at: Utc::now(),
+                closed_at: None,
+            };
+            write_milestone_file(&ms_dir.join(format!("{}.json", entry.uuid)), &entry).unwrap();
+        }
+
+        let loaded = read_all_milestone_files(&ms_dir).unwrap();
+        assert_eq!(loaded.len(), 3);
+    }
+
+    #[test]
+    fn test_read_all_milestone_files_empty_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let ms_dir = dir.path().join("milestones");
+        // Dir doesn't exist
+        let loaded = read_all_milestone_files(&ms_dir).unwrap();
+        assert!(loaded.is_empty());
     }
 }

--- a/crosslink/src/main.rs
+++ b/crosslink/src/main.rs
@@ -969,9 +969,12 @@ fn main() -> Result<()> {
 
         Commands::Milestone { action } => {
             let db = get_db()?;
+            let crosslink_dir = find_crosslink_dir()?;
+            let shared = shared_writer::SharedWriter::new(&crosslink_dir)?;
+            let shared_ref = shared.as_ref();
             match action {
                 MilestoneCommands::Create { name, description } => {
-                    commands::milestone::create(&db, &name, description.as_deref())
+                    commands::milestone::create(&db, shared_ref, &name, description.as_deref())
                 }
                 MilestoneCommands::List { status } => commands::milestone::list(&db, Some(&status)),
                 MilestoneCommands::Show { id } => commands::milestone::show(&db, id),
@@ -979,8 +982,10 @@ fn main() -> Result<()> {
                 MilestoneCommands::Remove { id, issue } => {
                     commands::milestone::remove(&db, id, issue)
                 }
-                MilestoneCommands::Close { id } => commands::milestone::close(&db, id),
-                MilestoneCommands::Delete { id } => commands::milestone::delete(&db, id),
+                MilestoneCommands::Close { id } => commands::milestone::close(&db, shared_ref, id),
+                MilestoneCommands::Delete { id } => {
+                    commands::milestone::delete(&db, shared_ref, id)
+                }
             }
         }
 

--- a/crosslink/src/shared_writer.rs
+++ b/crosslink/src/shared_writer.rs
@@ -16,7 +16,8 @@ use crate::db::Database;
 use crate::hydration::hydrate_to_sqlite;
 use crate::identity::AgentConfig;
 use crate::issue_file::{
-    read_counters, read_issue_file, write_counters, CommentEntry, Counters, IssueFile,
+    read_counters, read_issue_file, read_milestone_file, write_counters, CommentEntry, Counters,
+    IssueFile, MilestoneEntry,
 };
 use crate::sync::SyncManager;
 
@@ -120,7 +121,7 @@ impl SharedWriter {
 
         // Ensure directory structure exists
         std::fs::create_dir_all(cache_dir.join("issues"))?;
-        std::fs::create_dir_all(cache_dir.join("meta"))?;
+        std::fs::create_dir_all(cache_dir.join("meta").join("milestones"))?;
 
         Ok(Some(SharedWriter {
             sync,
@@ -564,6 +565,99 @@ impl SharedWriter {
         Ok(())
     }
 
+    /// Create a milestone on the coordination branch.
+    ///
+    /// Returns the assigned milestone display ID.
+    pub fn create_milestone(
+        &self,
+        db: &Database,
+        name: &str,
+        description: Option<&str>,
+    ) -> Result<i64> {
+        let uuid = Uuid::new_v4();
+        let now = Utc::now();
+        let name_owned = name.to_string();
+        let desc_owned = description.map(|s| s.to_string());
+        let display_id = Cell::new(0i64);
+
+        let _ = self.write_commit_push(
+            |writer| {
+                let (id, counters) = writer.claim_milestone_id()?;
+                display_id.set(id);
+                let entry = MilestoneEntry {
+                    uuid,
+                    display_id: id,
+                    name: name_owned.clone(),
+                    description: desc_owned.clone(),
+                    status: "open".to_string(),
+                    created_at: now,
+                    closed_at: None,
+                };
+                let mut json = Vec::new();
+                serde_json::to_writer_pretty(&mut json, &entry)?;
+                Ok(WriteSet {
+                    files: vec![(format!("meta/milestones/{}.json", uuid), json)],
+                    counters: Some(counters),
+                    use_git_rm: false,
+                })
+            },
+            &format!("create milestone: {}", name),
+        )?;
+
+        hydrate_to_sqlite(&self.cache_dir, db)?;
+        Ok(display_id.get())
+    }
+
+    /// Close a milestone on the coordination branch.
+    pub fn close_milestone(&self, db: &Database, milestone_id: i64) -> Result<()> {
+        let _ = self.write_commit_push(
+            |writer| {
+                let mut entry = writer.load_milestone_by_id(milestone_id)?;
+                entry.status = "closed".to_string();
+                entry.closed_at = Some(Utc::now());
+                let mut json = Vec::new();
+                serde_json::to_writer_pretty(&mut json, &entry)?;
+                Ok(WriteSet {
+                    files: vec![(format!("meta/milestones/{}.json", entry.uuid), json)],
+                    counters: None,
+                    use_git_rm: false,
+                })
+            },
+            &format!("close milestone #{}", milestone_id),
+        )?;
+
+        hydrate_to_sqlite(&self.cache_dir, db)?;
+        Ok(())
+    }
+
+    /// Delete a milestone file from the coordination branch.
+    pub fn delete_milestone(&self, db: &Database, milestone_id: i64) -> Result<()> {
+        let entry = self.load_milestone_by_id(milestone_id)?;
+        let rel_path = format!("meta/milestones/{}.json", entry.uuid);
+
+        let _ = self.write_commit_push(
+            |writer| {
+                let path = writer
+                    .cache_dir
+                    .join("meta")
+                    .join("milestones")
+                    .join(format!("{}.json", entry.uuid));
+                if path.exists() {
+                    std::fs::remove_file(&path)?;
+                }
+                Ok(WriteSet {
+                    files: vec![(rel_path.clone(), vec![])],
+                    counters: None,
+                    use_git_rm: true,
+                })
+            },
+            &format!("delete milestone #{}", milestone_id),
+        )?;
+
+        hydrate_to_sqlite(&self.cache_dir, db)?;
+        Ok(())
+    }
+
     /// Promote offline issues (`display_id: null`) to real display IDs.
     ///
     /// Called during sync when connectivity is restored. Scans the cache for
@@ -805,6 +899,36 @@ impl SharedWriter {
         let first = counters.next_display_id;
         counters.next_display_id += count;
         Ok((first, counters))
+    }
+
+    /// Claim a milestone display ID from `meta/counters.json`.
+    ///
+    /// Returns `(claimed_id, updated_counters)`.
+    fn claim_milestone_id(&self) -> Result<(i64, Counters)> {
+        let mut counters = self.read_counters()?;
+        let id = counters.next_milestone_id;
+        counters.next_milestone_id += 1;
+        Ok((id, counters))
+    }
+
+    /// Load a milestone entry by display_id from per-file storage.
+    fn load_milestone_by_id(&self, display_id: i64) -> Result<MilestoneEntry> {
+        let milestones_dir = self.cache_dir.join("meta").join("milestones");
+        if milestones_dir.exists() {
+            for entry in std::fs::read_dir(&milestones_dir)? {
+                let entry = entry?;
+                let path = entry.path();
+                if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                    continue;
+                }
+                if let Ok(ms) = read_milestone_file(&path) {
+                    if ms.display_id == display_id {
+                        return Ok(ms);
+                    }
+                }
+            }
+        }
+        bail!("Milestone #{} not found in shared cache", display_id)
     }
 
     /// Rewrite a just-committed issue to set `display_id: null` and revert the

--- a/crosslink/src/sync.rs
+++ b/crosslink/src/sync.rs
@@ -112,7 +112,7 @@ impl SyncManager {
             std::fs::create_dir_all(self.cache_dir.join("heartbeats"))?;
             std::fs::create_dir_all(self.cache_dir.join("trust"))?;
             std::fs::create_dir_all(self.cache_dir.join("issues"))?;
-            std::fs::create_dir_all(self.cache_dir.join("meta"))?;
+            std::fs::create_dir_all(self.cache_dir.join("meta").join("milestones"))?;
 
             // Commit the initial state so the branch has at least one commit.
             // Without this, `git log` and other commands fail on the empty orphan.


### PR DESCRIPTION
## Summary

- Redesigns milestone storage from a single `meta/milestones.json` to per-file `meta/milestones/{uuid}.json`, matching the conflict-free pattern already used for issues
- Adds SharedWriter milestone methods (`create_milestone`, `close_milestone`, `delete_milestone`) so milestone operations go through the coordination branch when available
- Maintains backward compatibility: hydration reads per-file milestones first, falls back to legacy single-file format
- Adds `next_milestone_id` counter to `Counters` struct with `#[serde(default)]` for backward compat with existing `counters.json` files

## Changes

| File | Change |
|------|--------|
| `issue_file.rs` | `read_milestone_file`, `write_milestone_file`, `read_all_milestone_files` + `next_milestone_id` counter |
| `hydration.rs` | Per-file milestone read with legacy single-file fallback |
| `migrate.rs` | Writes per-file `meta/milestones/{uuid}.json` instead of single `milestones.json` |
| `shared_writer.rs` | `create_milestone`, `close_milestone`, `delete_milestone` + helpers |
| `sync.rs` | Creates `meta/milestones/` directory in `init_cache()` |
| `milestone.rs` | `create`, `close`, `delete` accept optional `SharedWriter` for dual-write |
| `main.rs` | Passes `SharedWriter` to milestone commands |
| `integrity_cmd.rs` | Compares milestone counts between JSON files and SQLite |
| `db.rs` | `get_milestone_count()` method |

## Test plan

- [x] All 867 tests pass (186 lib + 535 main + 146 integration)
- [x] `cargo clippy -- -D warnings` clean
- [x] Per-file milestone roundtrip test
- [x] Legacy single-file fallback hydration test
- [x] Backward compat: `Counters` without `next_milestone_id` deserializes correctly
- [x] Integrity check compares milestone counts

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)