### PR TITLE
release: v0.1.2-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.1.2-alpha.1] - 2026-02-27
+
+### Fixed
+- SyncManager now detects when running inside a git worktree and reuses the main repo's hub cache instead of trying to create a duplicate `crosslink/hub` worktree (#41)
+- Set git user config in test helper for CI compatibility
+
+### Changed
+- Kickoff skill (`/kickoff`) now supports `--verify` flag with three levels: `local` (default), `ci`, and `thorough` for post-implementation verification (#39)
+- Updated `/kickoff` and `/featree` skill permissions to cover all tools used during execution (added `Write`, `Read`, `Bash(echo *)`, `Bash(crosslink *)`) (#42)
+- Featree skill now uses `crosslink init --force` and `crosslink sync` instead of manual database symlinking for worktree initialization (#42)
+
+### Removed
+- Stale `.chainlink/` directory (legacy issue tracker artifacts)
+- Tracked `crosslink/.crosslink/issues.db` (should be local-only)
+
 ## [0.1.1-alpha.1] - 2026-02-26
 
 ### Multi-Agent Collaboration

--- a/crosslink/Cargo.lock
+++ b/crosslink/Cargo.lock
@@ -190,7 +190,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crosslink"
-version = "0.1.1-alpha.1"
+version = "0.1.2-alpha.1"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/crosslink/Cargo.toml
+++ b/crosslink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosslink"
-version = "0.1.1-alpha.1"
+version = "0.1.2-alpha.1"
 edition = "2021"
 description = "A lean issue tracker CLI for AI-assisted development sessions"
 license = "MIT"


### PR DESCRIPTION
## Summary

- **Fix**: SyncManager now detects git worktree context and reuses the main repo's hub cache instead of creating duplicates (#41)
- **Feat**: Kickoff skill supports `--verify` flag (`local`/`ci`/`thorough`) for post-implementation CI and self-review (#39)
- **Fix**: Updated `/kickoff` and `/featree` skill permissions to cover all tools used during execution (#42)
- **Chore**: Removed stale `.chainlink/` artifacts and tracked `issues.db` from repo

## Test plan
- [x] All 146 tests pass (unit + integration)
- [x] `cargo check` clean after version bump

## Changelog
See [CHANGELOG.md](CHANGELOG.md) for full details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)