### PR TITLE
Epic #54: Driver intervention tracking

### DIFF
--- a/crosslink/resources/claude/commands/kickoff.md
+++ b/crosslink/resources/claude/commands/kickoff.md
@@ -66,6 +66,7 @@ Build a detailed prompt for the child agent. The prompt must be self-contained â
   4. Implement the feature fully (no stubs or placeholders)
   5. **Document decisions as you go**: When choosing between approaches, run `crosslink comment <issue-id> "Decision: <chose X over Y because Z>" --kind decision`
   6. **Document discoveries**: When finding something unexpected, run `crosslink comment <issue-id> "Found: <observation>" --kind observation`
+  6b. **Log interventions**: If a hook blocks you, a human rejects a tool use, or you receive a redirect, log it immediately: `crosslink intervene <issue-id> "Description" --trigger <type> --context "what you were attempting"`
   7. **Run the project's test suite** to verify changes don't break anything (use the detected test command)
   8. **Document results**: `crosslink comment <issue-id> "Result: <test summary, what was delivered>" --kind result`
   9. Use `/commit` to commit the work when implementation is complete
@@ -127,6 +128,7 @@ Add the self-review checklist as the final step before writing DONE (even for `-
 - No debug/temporary code left behind
 - Commit messages are clean and descriptive
 - Changes match the original feature description from `KICKOFF.md`
+- All driver interventions have been logged via `crosslink intervene`
 
 Then:
 - When completely finished, write the word `DONE` to a file called `.kickoff-status` in the worktree root

--- a/crosslink/resources/claude/hooks/work-check.py
+++ b/crosslink/resources/claude/hooks/work-check.py
@@ -153,7 +153,11 @@ def main():
             "You MUST instead:\n"
             "  - Inform the user that this is a manual step for them\n"
             "  - Continue with your other work\n\n"
-            "Read-only git commands (status, diff, log, show, branch) are allowed."
+            "Read-only git commands (status, diff, log, show, branch) are allowed.\n\n"
+            "--- INTERVENTION LOGGING ---\n"
+            "Log this blocked action for the audit trail:\n"
+            "  crosslink intervene <issue-id> \"Attempted: <command>\" "
+            "--trigger tool_blocked --context \"<what you were trying to accomplish>\""
         )
         sys.exit(2)
 
@@ -171,7 +175,11 @@ def main():
             "  crosslink quick \"<describe the work>\" -p <priority> -l <label>\n\n"
             "Or pick an existing issue:\n"
             "  crosslink list -s open\n"
-            "  crosslink session work <id>"
+            "  crosslink session work <id>\n\n"
+            "--- INTERVENTION LOGGING ---\n"
+            "If a human redirected you here, log the intervention:\n"
+            "  crosslink intervene <issue-id> \"Redirected to create issue before commit\" "
+            "--trigger redirect --context \"Attempted git commit without active issue\""
         )
         sys.exit(2)
 
@@ -213,7 +221,11 @@ def main():
         "If an issue already exists for this work, use:\n"
         "  crosslink list -s open\n"
         "  crosslink session work <id>\n\n"
-        "This is how the project tracks work. Comply, then continue."
+        "This is how the project tracks work. Comply, then continue.\n\n"
+        "--- INTERVENTION LOGGING ---\n"
+        "After creating the issue, log this intervention:\n"
+        "  crosslink intervene <issue-id> \"Blocked: no active issue\" "
+        "--trigger tool_blocked --context \"<what you were about to do>\""
     )
 
     normal_msg = (

--- a/crosslink/resources/crosslink/hook-config.json
+++ b/crosslink/resources/crosslink/hook-config.json
@@ -1,5 +1,6 @@
 {
   "tracking_mode": "strict",
+  "intervention_tracking": true,
   "blocked_git_commands": [
     "git push", "git merge", "git rebase", "git cherry-pick",
     "git reset", "git checkout .", "git restore .", "git clean",

--- a/crosslink/resources/crosslink/rules/global.md
+++ b/crosslink/resources/crosslink/rules/global.md
@@ -126,6 +126,28 @@ crosslink comment <id> "Delivered: JWT auth with refresh tokens, all 47 tests pa
 
 **If you close an issue that has zero typed comments, you have violated this rule.**
 
+### Intervention Logging (MANDATORY — AUDIT REQUIREMENT)
+
+When a driver (human operator) intervenes in your work, you MUST log it immediately using `crosslink intervene`. Driver interventions are the highest-signal data for improving agent autonomy.
+
+**You MUST log an intervention when any of these occur:**
+- A tool call you proposed is rejected by the driver → `--trigger tool_rejected`
+- A hook or policy blocks your tool call → `--trigger tool_blocked`
+- The driver redirects your approach ("actually do X instead") → `--trigger redirect`
+- The driver provides context you didn't have (requirements, constraints, domain knowledge) → `--trigger context_provided`
+- The driver performs an action themselves (git push, deployment, etc.) → `--trigger manual_action`
+- The driver answers a question that changes your approach → `--trigger question_answered`
+
+```bash
+crosslink intervene <issue-id> "Description of what happened" --trigger <type> --context "What you were attempting"
+```
+
+**Rules:**
+- Log IMMEDIATELY after the intervention occurs, before continuing work.
+- Do not skip logging because the intervention seems "small" or "obvious."
+- Do not batch multiple interventions into a single log entry.
+- If a hook blocks you and provides intervention logging instructions, follow them.
+
 ### Pre-Coding Grounding
 Before using unfamiliar libraries/APIs:
 1. **Verify it exists**: WebSearch to confirm the API

--- a/crosslink/src/commands/export.rs
+++ b/crosslink/src/commands/export.rs
@@ -86,13 +86,19 @@ fn build_issue_file(
     let comments_raw = db.get_comments_with_author(issue.id)?;
     let comments: Vec<CommentEntry> = comments_raw
         .into_iter()
-        .map(|(id, author, content, created_at, kind)| CommentEntry {
-            id,
-            author: author.unwrap_or_else(|| "unknown".to_string()),
-            content,
-            created_at,
-            kind,
-        })
+        .map(
+            |(id, author, content, created_at, kind, trigger_type, intervention_context)| {
+                CommentEntry {
+                    id,
+                    author: author.unwrap_or_else(|| "unknown".to_string()),
+                    content,
+                    created_at,
+                    kind,
+                    trigger_type,
+                    intervention_context,
+                }
+            },
+        )
         .collect();
 
     let blocker_ids = db.get_blockers(issue.id)?;

--- a/crosslink/src/commands/intervene.rs
+++ b/crosslink/src/commands/intervene.rs
@@ -1,0 +1,190 @@
+use anyhow::{bail, Result};
+use std::path::Path;
+
+use crate::db::Database;
+use crate::issue_file::validate_trigger_type;
+use crate::shared_writer::SharedWriter;
+use crate::utils::format_issue_id;
+
+/// Check if intervention tracking is enabled in hook-config.json.
+fn is_intervention_tracking_enabled(crosslink_dir: &Path) -> bool {
+    let config_path = crosslink_dir.join("hook-config.json");
+    let content = match std::fs::read_to_string(&config_path) {
+        Ok(c) => c,
+        Err(_) => return true, // default: enabled
+    };
+    let parsed: serde_json::Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(_) => return true,
+    };
+    parsed
+        .get("intervention_tracking")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true)
+}
+
+pub fn run(
+    db: &Database,
+    writer: Option<&SharedWriter>,
+    issue_id: i64,
+    description: &str,
+    trigger_type: &str,
+    context: Option<&str>,
+    crosslink_dir: &Path,
+) -> Result<()> {
+    if !is_intervention_tracking_enabled(crosslink_dir) {
+        println!("Intervention tracking is disabled in hook-config.json. Skipping.");
+        return Ok(());
+    }
+
+    if !validate_trigger_type(trigger_type) {
+        bail!(
+            "Unknown trigger type '{}'. Valid types: tool_rejected, tool_blocked, redirect, context_provided, manual_action, question_answered",
+            trigger_type
+        );
+    }
+
+    db.require_issue(issue_id)?;
+
+    if let Some(w) = writer {
+        w.add_intervention_comment(db, issue_id, description, trigger_type, context)?;
+    } else {
+        db.add_intervention_comment(issue_id, description, trigger_type, context)?;
+    }
+
+    println!(
+        "Logged intervention on issue {} [{}]",
+        format_issue_id(issue_id),
+        trigger_type
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn setup_db() -> (Database, tempfile::TempDir) {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let db = Database::open(&db_path).unwrap();
+        (db, dir)
+    }
+
+    #[test]
+    fn test_intervene_creates_intervention_comment() {
+        let (db, dir) = setup_db();
+        let id = db.create_issue("Test", None, "medium").unwrap();
+
+        let crosslink_dir = dir.path();
+        run(
+            &db,
+            None,
+            id,
+            "Blocked: git push",
+            "tool_blocked",
+            Some("pushing feature branch"),
+            crosslink_dir,
+        )
+        .unwrap();
+
+        let comments = db.get_comments(id).unwrap();
+        assert_eq!(comments.len(), 1);
+        assert_eq!(comments[0].kind, "intervention");
+        assert_eq!(comments[0].trigger_type.as_deref(), Some("tool_blocked"));
+        assert_eq!(
+            comments[0].intervention_context.as_deref(),
+            Some("pushing feature branch")
+        );
+        assert_eq!(comments[0].content, "Blocked: git push");
+    }
+
+    #[test]
+    fn test_intervene_without_context() {
+        let (db, dir) = setup_db();
+        let id = db.create_issue("Test", None, "medium").unwrap();
+
+        run(
+            &db,
+            None,
+            id,
+            "Driver redirected approach",
+            "redirect",
+            None,
+            dir.path(),
+        )
+        .unwrap();
+
+        let comments = db.get_comments(id).unwrap();
+        assert_eq!(comments.len(), 1);
+        assert_eq!(comments[0].trigger_type.as_deref(), Some("redirect"));
+        assert!(comments[0].intervention_context.is_none());
+    }
+
+    #[test]
+    fn test_intervene_invalid_trigger_type() {
+        let (db, dir) = setup_db();
+        let id = db.create_issue("Test", None, "medium").unwrap();
+
+        let result = run(&db, None, id, "test", "invalid_type", None, dir.path());
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Unknown trigger type"));
+    }
+
+    #[test]
+    fn test_intervene_nonexistent_issue() {
+        let (db, dir) = setup_db();
+
+        let result = run(&db, None, 99999, "test", "tool_blocked", None, dir.path());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_intervene_disabled_by_config() {
+        let (db, dir) = setup_db();
+        let id = db.create_issue("Test", None, "medium").unwrap();
+
+        // Write config that disables intervention tracking
+        let config = r#"{"tracking_mode":"strict","intervention_tracking":false}"#;
+        std::fs::write(dir.path().join("hook-config.json"), config).unwrap();
+
+        run(&db, None, id, "test", "tool_blocked", None, dir.path()).unwrap();
+
+        // No comment should be created
+        let comments = db.get_comments(id).unwrap();
+        assert!(comments.is_empty());
+    }
+
+    #[test]
+    fn test_all_trigger_types_accepted() {
+        let (db, dir) = setup_db();
+        let id = db.create_issue("Test", None, "medium").unwrap();
+
+        for trigger in &[
+            "tool_rejected",
+            "tool_blocked",
+            "redirect",
+            "context_provided",
+            "manual_action",
+            "question_answered",
+        ] {
+            run(
+                &db,
+                None,
+                id,
+                &format!("Test {}", trigger),
+                trigger,
+                None,
+                dir.path(),
+            )
+            .unwrap();
+        }
+
+        let comments = db.get_comments(id).unwrap();
+        assert_eq!(comments.len(), 6);
+    }
+}

--- a/crosslink/src/commands/migrate.rs
+++ b/crosslink/src/commands/migrate.rs
@@ -103,6 +103,8 @@ pub fn to_shared(crosslink_dir: &Path, db: &Database) -> Result<()> {
                     content: c.content.clone(),
                     created_at: c.created_at,
                     kind: "note".to_string(),
+                    trigger_type: None,
+                    intervention_context: None,
                 }
             })
             .collect();
@@ -396,6 +398,8 @@ mod tests {
                     content: c.content.clone(),
                     created_at: c.created_at,
                     kind: "note".to_string(),
+                    trigger_type: None,
+                    intervention_context: None,
                 })
                 .collect(),
             blockers: blocker_uuids,

--- a/crosslink/src/commands/mod.rs
+++ b/crosslink/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod export;
 pub mod import;
 pub mod init;
 pub mod integrity_cmd;
+pub mod intervene;
 pub mod label;
 pub mod list;
 pub mod locks_cmd;

--- a/crosslink/src/commands/review.rs
+++ b/crosslink/src/commands/review.rs
@@ -221,10 +221,16 @@ pub fn trail(db: &Database, id: i64, kind_filter: Option<&str>, json: bool) -> R
         println!("Comment trail for issue {}:", format_issue_id(id));
         println!();
         for comment in &filtered {
+            let intervention_info = match (&comment.trigger_type, &comment.intervention_context) {
+                (Some(trigger), Some(ctx)) => format!(" trigger={} ctx=\"{}\"", trigger, ctx),
+                (Some(trigger), None) => format!(" trigger={}", trigger),
+                _ => String::new(),
+            };
             println!(
-                "  [{}] [{}] {}",
+                "  [{}] [{}{}] {}",
                 comment.created_at.format("%Y-%m-%d %H:%M"),
                 comment.kind,
+                intervention_info,
                 comment.content
             );
         }

--- a/crosslink/src/commands/show.rs
+++ b/crosslink/src/commands/show.rs
@@ -89,11 +89,17 @@ pub fn run(db: &Database, id: i64) -> Result<()> {
             } else {
                 String::new()
             };
+            let intervention_suffix = match (&comment.trigger_type, &comment.intervention_context) {
+                (Some(trigger), Some(ctx)) => format!(" (trigger: {}, context: {})", trigger, ctx),
+                (Some(trigger), None) => format!(" (trigger: {})", trigger),
+                _ => String::new(),
+            };
             println!(
-                "  [{}] {}{}",
+                "  [{}] {}{}{}",
                 comment.created_at.format("%Y-%m-%d %H:%M"),
                 kind_prefix,
-                comment.content
+                comment.content,
+                intervention_suffix
             );
         }
     }

--- a/crosslink/src/db.rs
+++ b/crosslink/src/db.rs
@@ -5,10 +5,18 @@ use std::path::Path;
 
 use crate::models::{Comment, Issue, Session};
 
-pub const SCHEMA_VERSION: i32 = 11;
+pub const SCHEMA_VERSION: i32 = 12;
 
-/// Row from `get_comments_with_author`: (id, author, content, created_at, kind).
-pub type CommentAuthorRow = (i64, Option<String>, String, DateTime<Utc>, String);
+/// Row from `get_comments_with_author`: (id, author, content, created_at, kind, trigger_type, intervention_context).
+pub type CommentAuthorRow = (
+    i64,
+    Option<String>,
+    String,
+    DateTime<Utc>,
+    String,
+    Option<String>,
+    Option<String>,
+);
 
 /// Row from `get_time_entries_for_issue`: (id, started_at, ended_at, duration_seconds).
 pub type TimeEntryRow = (i64, DateTime<Utc>, Option<DateTime<Utc>>, Option<i64>);
@@ -265,6 +273,17 @@ impl Database {
                 );
             }
 
+            // Migration v12: Add trigger_type and intervention_context for driver intervention tracking
+            if version < 12 {
+                let _ = self
+                    .conn
+                    .execute("ALTER TABLE comments ADD COLUMN trigger_type TEXT", []);
+                let _ = self.conn.execute(
+                    "ALTER TABLE comments ADD COLUMN intervention_context TEXT",
+                    [],
+                );
+            }
+
             self.conn
                 .execute(&format!("PRAGMA user_version = {}", SCHEMA_VERSION), [])?;
         }
@@ -513,9 +532,25 @@ impl Database {
         Ok(self.conn.last_insert_rowid())
     }
 
+    pub fn add_intervention_comment(
+        &self,
+        issue_id: i64,
+        content: &str,
+        trigger_type: &str,
+        intervention_context: Option<&str>,
+    ) -> Result<i64> {
+        let now = Utc::now().to_rfc3339();
+        self.conn.execute(
+            "INSERT INTO comments (issue_id, content, created_at, kind, trigger_type, intervention_context)
+             VALUES (?1, ?2, ?3, 'intervention', ?4, ?5)",
+            params![issue_id, content, now, trigger_type, intervention_context],
+        )?;
+        Ok(self.conn.last_insert_rowid())
+    }
+
     pub fn get_comments(&self, issue_id: i64) -> Result<Vec<Comment>> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, issue_id, content, created_at, COALESCE(kind, 'note') FROM comments WHERE issue_id = ?1 ORDER BY created_at",
+            "SELECT id, issue_id, content, created_at, COALESCE(kind, 'note'), trigger_type, intervention_context FROM comments WHERE issue_id = ?1 ORDER BY created_at",
         )?;
         let comments = stmt
             .query_map([issue_id], |row| {
@@ -525,6 +560,8 @@ impl Database {
                     content: row.get(2)?,
                     created_at: parse_datetime(row.get::<_, String>(3)?),
                     kind: row.get(4)?,
+                    trigger_type: row.get(5)?,
+                    intervention_context: row.get(6)?,
                 })
             })?
             .collect::<std::result::Result<Vec<_>, _>>()?;
@@ -634,7 +671,7 @@ impl Database {
     /// Get comments with author field for an issue (author added in migration v10).
     pub fn get_comments_with_author(&self, issue_id: i64) -> Result<Vec<CommentAuthorRow>> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, author, content, created_at, COALESCE(kind, 'note') FROM comments WHERE issue_id = ?1 ORDER BY created_at",
+            "SELECT id, author, content, created_at, COALESCE(kind, 'note'), trigger_type, intervention_context FROM comments WHERE issue_id = ?1 ORDER BY created_at",
         )?;
         let comments = stmt
             .query_map([issue_id], |row| {
@@ -644,6 +681,8 @@ impl Database {
                     row.get::<_, String>(2)?,
                     parse_datetime(row.get::<_, String>(3)?),
                     row.get::<_, String>(4)?,
+                    row.get::<_, Option<String>>(5)?,
+                    row.get::<_, Option<String>>(6)?,
                 ))
             })?
             .collect::<std::result::Result<Vec<_>, _>>()?;
@@ -1275,11 +1314,13 @@ impl Database {
         content: &str,
         created_at: &str,
         kind: &str,
+        trigger_type: Option<&str>,
+        intervention_context: Option<&str>,
     ) -> Result<()> {
         self.conn.execute(
-            "INSERT INTO comments (id, issue_id, uuid, author, content, created_at, kind)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-            params![id, issue_id, uuid, author, content, created_at, kind],
+            "INSERT INTO comments (id, issue_id, uuid, author, content, created_at, kind, trigger_type, intervention_context)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            params![id, issue_id, uuid, author, content, created_at, kind, trigger_type, intervention_context],
         )?;
         Ok(())
     }

--- a/crosslink/src/hydration.rs
+++ b/crosslink/src/hydration.rs
@@ -140,6 +140,8 @@ pub fn hydrate_to_sqlite(cache_dir: &Path, db: &Database) -> Result<HydrationSta
                     &comment.content,
                     &comment_created,
                     &comment.kind,
+                    comment.trigger_type.as_deref(),
+                    comment.intervention_context.as_deref(),
                 )?;
                 stats.comments += 1;
             }
@@ -354,6 +356,8 @@ mod tests {
             content: "First comment".to_string(),
             created_at: Utc::now(),
             kind: "note".to_string(),
+            trigger_type: None,
+            intervention_context: None,
         }];
         write_issues_to_cache(cache.path(), &[issue]);
 

--- a/crosslink/src/issue_file.rs
+++ b/crosslink/src/issue_file.rs
@@ -53,6 +53,10 @@ pub struct CommentEntry {
     pub created_at: DateTime<Utc>,
     #[serde(default = "default_comment_kind")]
     pub kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trigger_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub intervention_context: Option<String>,
 }
 
 fn default_comment_kind() -> String {
@@ -69,10 +73,24 @@ const KNOWN_COMMENT_KINDS: &[&str] = &[
     "result",
     "handoff",
     "human",
+    "intervention",
 ];
 
 pub fn validate_comment_kind(kind: &str) -> bool {
     KNOWN_COMMENT_KINDS.contains(&kind)
+}
+
+pub const KNOWN_TRIGGER_TYPES: &[&str] = &[
+    "tool_rejected",
+    "tool_blocked",
+    "redirect",
+    "context_provided",
+    "manual_action",
+    "question_answered",
+];
+
+pub fn validate_trigger_type(trigger: &str) -> bool {
+    KNOWN_TRIGGER_TYPES.contains(&trigger)
 }
 
 /// An inline time-tracking entry within an issue file.
@@ -267,6 +285,8 @@ mod tests {
                 content: "Reproduced on staging".to_string(),
                 created_at: Utc::now(),
                 kind: "note".to_string(),
+                trigger_type: None,
+                intervention_context: None,
             }],
             blockers: vec![Uuid::new_v4()],
             related: vec![],

--- a/crosslink/src/main.rs
+++ b/crosslink/src/main.rs
@@ -201,6 +201,21 @@ enum Commands {
         kind: String,
     },
 
+    /// Log a driver intervention on an issue
+    Intervene {
+        /// Issue ID
+        #[arg(value_parser = parse_issue_id_clap)]
+        id: i64,
+        /// Description of the intervention
+        description: String,
+        /// Trigger type (tool_rejected, tool_blocked, redirect, context_provided, manual_action, question_answered)
+        #[arg(long)]
+        trigger: String,
+        /// Context: what the agent was attempting when intervention occurred
+        #[arg(long)]
+        context: Option<String>,
+    },
+
     /// Add a label to an issue
     Label {
         /// Issue ID
@@ -874,6 +889,26 @@ fn main() -> Result<()> {
             let crosslink_dir = find_crosslink_dir()?;
             let writer = get_writer(&crosslink_dir);
             commands::comment::run(&db, writer.as_ref(), id, &text, &kind)
+        }
+
+        Commands::Intervene {
+            id,
+            description,
+            trigger,
+            context,
+        } => {
+            let db = get_db()?;
+            let crosslink_dir = find_crosslink_dir()?;
+            let writer = get_writer(&crosslink_dir);
+            commands::intervene::run(
+                &db,
+                writer.as_ref(),
+                id,
+                &description,
+                &trigger,
+                context.as_deref(),
+                &crosslink_dir,
+            )
         }
 
         Commands::Label { id, label } => {

--- a/crosslink/src/models.rs
+++ b/crosslink/src/models.rs
@@ -22,6 +22,10 @@ pub struct Comment {
     pub created_at: DateTime<Utc>,
     #[serde(default = "default_comment_kind")]
     pub kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trigger_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub intervention_context: Option<String>,
 }
 
 fn default_comment_kind() -> String {
@@ -156,6 +160,8 @@ mod tests {
             content: "A comment".to_string(),
             created_at: Utc::now(),
             kind: "note".to_string(),
+            trigger_type: None,
+            intervention_context: None,
         };
 
         let json = serde_json::to_string(&comment).unwrap();
@@ -174,6 +180,8 @@ mod tests {
             content: "".to_string(),
             created_at: Utc::now(),
             kind: "note".to_string(),
+            trigger_type: None,
+            intervention_context: None,
         };
 
         let json = serde_json::to_string(&comment).unwrap();
@@ -308,6 +316,8 @@ mod tests {
                 content: content.clone(),
                 created_at: Utc::now(),
                 kind: "note".to_string(),
+                trigger_type: None,
+                intervention_context: None,
             };
 
             let json = serde_json::to_string(&comment).unwrap();

--- a/crosslink/src/shared_writer.rs
+++ b/crosslink/src/shared_writer.rs
@@ -404,6 +404,8 @@ impl SharedWriter {
                     content: content_owned.clone(),
                     created_at: Utc::now(),
                     kind: kind_owned.clone(),
+                    trigger_type: None,
+                    intervention_context: None,
                 });
                 issue.updated_at = Utc::now();
 
@@ -415,6 +417,54 @@ impl SharedWriter {
                 })
             },
             &format!("comment on issue #{}", display_id),
+        )?;
+
+        hydrate_to_sqlite(&self.cache_dir, db)?;
+        Ok(comment_id.get())
+    }
+
+    /// Add a driver intervention comment to an issue (kind = "intervention").
+    pub fn add_intervention_comment(
+        &self,
+        db: &Database,
+        display_id: i64,
+        content: &str,
+        trigger_type: &str,
+        intervention_context: Option<&str>,
+    ) -> Result<i64> {
+        let content_owned = content.to_string();
+        let trigger_owned = trigger_type.to_string();
+        let context_owned = intervention_context.map(|s| s.to_string());
+        let agent_id = self.agent.agent_id.clone();
+        let comment_id = Cell::new(0i64);
+
+        let _ = self.write_commit_push(
+            |writer| {
+                let mut issue = writer.load_issue_by_id(display_id, db)?;
+                let mut counters = writer.read_counters()?;
+                let id = counters.next_comment_id;
+                counters.next_comment_id += 1;
+                comment_id.set(id);
+
+                issue.comments.push(CommentEntry {
+                    id,
+                    author: agent_id.clone(),
+                    content: content_owned.clone(),
+                    created_at: Utc::now(),
+                    kind: "intervention".to_string(),
+                    trigger_type: Some(trigger_owned.clone()),
+                    intervention_context: context_owned.clone(),
+                });
+                issue.updated_at = Utc::now();
+
+                let json = serde_json::to_vec_pretty(&issue)?;
+                Ok(WriteSet {
+                    files: vec![(format!("issues/{}.json", issue.uuid), json)],
+                    counters: Some(counters),
+                    use_git_rm: false,
+                })
+            },
+            &format!("intervention on issue #{}", display_id),
         )?;
 
         hydrate_to_sqlite(&self.cache_dir, db)?;


### PR DESCRIPTION
## Summary

Implements Epic #54 — Driver intervention tracking. Captures moments where a human operator ("driver") intervenes during an agent's work, creating structured audit trail entries.

- **#55 — `crosslink intervene` command**: New CLI command for logging driver interventions with trigger categorization (`tool_rejected`, `tool_blocked`, `redirect`, `context_provided`, `manual_action`, `question_answered`). Adds `trigger_type` and `intervention_context` optional fields to `CommentEntry`/`Comment` models with DB migration v12. Respects `intervention_tracking` config flag in `hook-config.json`.
- **#58 — Hook-to-agent intervention flow**: Updated `work-check.py` hook messages to guide agents toward self-reporting via `crosslink intervene` after being blocked. Hooks do NOT auto-log — they guide the agent.
- **#59 — Agent self-reporting norms**: Added mandatory intervention logging section to `global.md` rules and intervention instructions to `kickoff.md` agent prompt template.

**16 files changed, 432 insertions(+), 22 deletions(-)**

## Test plan

- [x] `cargo test` — 336 tests pass (146 integration + 190 lib)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `crosslink intervene <id> "desc" --trigger tool_blocked --context "..."` creates intervention comment
- [x] `crosslink show <id>` displays `[intervention]` with trigger/context
- [x] `crosslink review trail <id> --kind intervention` filters correctly
- [x] `crosslink review trail <id> --json` includes trigger_type/intervention_context
- [x] Old DB without new columns migrates cleanly
- [x] Old hub JSON without trigger fields deserializes (defaults to None)
- [x] Invalid trigger type returns error with valid types listed
- [x] `intervention_tracking: false` in config skips logging

Closes #54, closes #55, closes #58, closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)