### PR TITLE
Fix YAML parse error in _brand.yml font families

### DIFF
--- a/docs_src/_brand.yml
+++ b/docs_src/_brand.yml
@@ -19,11 +19,11 @@ color:
 
 typography:
   base:
-    family: Helvetica, Arial, sans-serif
+    family: 'Helvetica, Arial, sans-serif'
   headings:
-    family: Helvetica, Arial, sans-serif
+    family: 'Helvetica, Arial, sans-serif'
     weight: 700
   monospace:
-    family: "IBM Plex Mono", "Fira Code", monospace
+    family: '"IBM Plex Mono", "Fira Code", monospace'
   monospace-inline:
-    family: "IBM Plex Mono", "Fira Code", monospace
+    family: '"IBM Plex Mono", "Fira Code", monospace'


### PR DESCRIPTION
## Summary
- Quote all comma-separated font family values in `docs_src/_brand.yml` with single quotes so YAML doesn't misinterpret commas as flow sequence delimiters
- Fixes the `YAMLException: bad indentation of a mapping entry` error that breaks the Quarto render step in the Deploy Documentation workflow

## Test plan
- [ ] Verify the Deploy Documentation workflow passes on this branch
- [ ] Confirm the docs site renders with correct fonts

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)