### PR TITLE
fix: stop crosslink init from overriding project signing key

### DIFF
--- a/crosslink/src/commands/init.rs
+++ b/crosslink/src/commands/init.rs
@@ -234,21 +234,11 @@ fn setup_driver_signing(project_root: &Path, signing_key: Option<&str>) -> Resul
                 Err(_) => println!("Driver signing key: {}", pubkey_path.display()),
             }
 
-            // Configure git to use SSH signing in this repo
-            let private_key_path = if pubkey_path.to_string_lossy().ends_with(".pub") {
-                let s = pubkey_path.to_string_lossy();
-                std::path::PathBuf::from(&s[..s.len() - 4])
-            } else {
-                pubkey_path.clone()
-            };
-
-            if private_key_path.exists() {
-                if let Err(e) =
-                    signing::configure_git_ssh_signing(project_root, &private_key_path, None)
-                {
-                    println!("Warning: Could not configure git signing: {}", e);
-                }
-            }
+            // NOTE: We intentionally do NOT call configure_git_ssh_signing()
+            // on the project worktree here. Crosslink should not override the
+            // user's git signing configuration. The hub cache worktree (used for
+            // lock claims, issue entries, etc.) has its own signing config set
+            // up separately in sync.rs.
         }
         Err(_) => {
             println!(


### PR DESCRIPTION
## Summary
- Removes the `configure_git_ssh_signing()` call from `setup_driver_signing()` in `init.rs`
- `crosslink init` no longer overrides `user.signingkey` in the project worktree's local git config
- Hub cache signing (used for lock claims, issue entries) is unchanged in `sync.rs`

Closes #105

## Test plan
- [x] All 146 cargo tests pass
- [x] Run `crosslink init` and verify `git config user.signingkey` is unchanged
- [x] Verify hub branch operations still sign correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)