### PR TITLE
Track driver signing key in interventions and trust approvals

### DIFF
--- a/crosslink/src/commands/export.rs
+++ b/crosslink/src/commands/export.rs
@@ -87,7 +87,16 @@ fn build_issue_file(
     let comments: Vec<CommentEntry> = comments_raw
         .into_iter()
         .map(
-            |(id, author, content, created_at, kind, trigger_type, intervention_context)| {
+            |(
+                id,
+                author,
+                content,
+                created_at,
+                kind,
+                trigger_type,
+                intervention_context,
+                driver_key_fingerprint,
+            )| {
                 CommentEntry {
                     id,
                     author: author.unwrap_or_else(|| "unknown".to_string()),
@@ -96,6 +105,7 @@ fn build_issue_file(
                     kind,
                     trigger_type,
                     intervention_context,
+                    driver_key_fingerprint,
                     signed_by: None,
                     signature: None,
                 }

--- a/crosslink/src/commands/intervene.rs
+++ b/crosslink/src/commands/intervene.rs
@@ -2,6 +2,7 @@ use anyhow::{bail, Result};
 use std::path::Path;
 
 use crate::db::Database;
+use crate::identity::resolve_driver_fingerprint;
 use crate::issue_file::validate_trigger_type;
 use crate::shared_writer::SharedWriter;
 use crate::utils::format_issue_id;
@@ -46,17 +47,36 @@ pub fn run(
 
     db.require_issue(issue_id)?;
 
+    let driver_fp = resolve_driver_fingerprint(crosslink_dir);
+    let driver_fp_ref = driver_fp.as_deref();
+
     if let Some(w) = writer {
-        w.add_intervention_comment(db, issue_id, description, trigger_type, context)?;
+        w.add_intervention_comment(
+            db,
+            issue_id,
+            description,
+            trigger_type,
+            context,
+            driver_fp_ref,
+        )?;
     } else {
-        db.add_intervention_comment(issue_id, description, trigger_type, context)?;
+        db.add_intervention_comment(issue_id, description, trigger_type, context, driver_fp_ref)?;
     }
 
-    println!(
-        "Logged intervention on issue {} [{}]",
-        format_issue_id(issue_id),
-        trigger_type
-    );
+    if let Some(ref fp) = driver_fp {
+        println!(
+            "Logged intervention on issue {} [{}] (driver: {})",
+            format_issue_id(issue_id),
+            trigger_type,
+            fp
+        );
+    } else {
+        println!(
+            "Logged intervention on issue {} [{}]",
+            format_issue_id(issue_id),
+            trigger_type
+        );
+    }
     Ok(())
 }
 

--- a/crosslink/src/commands/migrate.rs
+++ b/crosslink/src/commands/migrate.rs
@@ -105,6 +105,7 @@ pub fn to_shared(crosslink_dir: &Path, db: &Database) -> Result<()> {
                     kind: "note".to_string(),
                     trigger_type: None,
                     intervention_context: None,
+                    driver_key_fingerprint: None,
                     signed_by: None,
                     signature: None,
                 }
@@ -402,6 +403,7 @@ mod tests {
                     kind: "note".to_string(),
                     trigger_type: None,
                     intervention_context: None,
+                    driver_key_fingerprint: None,
                     signed_by: None,
                     signature: None,
                 })

--- a/crosslink/src/commands/trust.rs
+++ b/crosslink/src/commands/trust.rs
@@ -1,7 +1,28 @@
 use anyhow::{bail, Result};
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
 use std::path::Path;
 
+use crate::identity::resolve_driver_fingerprint;
 use crate::signing::{AllowedSignerEntry, AllowedSigners};
+
+/// Metadata for a trust approval decision, stored in `trust/approvals/<agent-id>.json`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TrustApproval {
+    pub agent_id: String,
+    pub principal: String,
+    pub approved_by: Option<String>,
+    pub approved_at: String,
+}
+
+/// Metadata for a trust revocation, stored in `trust/approvals/<agent-id>.json`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TrustRevocation {
+    pub agent_id: String,
+    pub principal: String,
+    pub revoked_by: Option<String>,
+    pub revoked_at: String,
+}
 
 /// `crosslink trust approve <agent-id>`
 ///
@@ -43,10 +64,30 @@ pub fn approve(crosslink_dir: &Path, agent_id: &str) -> Result<()> {
     });
     signers.save(&signers_path)?;
 
+    // Record approval metadata with driver identity
+    let driver_fp = resolve_driver_fingerprint(crosslink_dir);
+    let approval = TrustApproval {
+        agent_id: agent_id.to_string(),
+        principal: principal.clone(),
+        approved_by: driver_fp.clone(),
+        approved_at: Utc::now().to_rfc3339(),
+    };
+    let approvals_dir = cache.join("trust").join("approvals");
+    std::fs::create_dir_all(&approvals_dir)?;
+    let approval_path = approvals_dir.join(format!("{}.json", agent_id));
+    std::fs::write(&approval_path, serde_json::to_string_pretty(&approval)?)?;
+
     // Commit and push
     commit_trust_change(cache, &format!("trust: approve agent '{}'", agent_id))?;
 
-    println!("Approved agent '{}' (principal: {})", agent_id, principal);
+    if let Some(fp) = driver_fp {
+        println!(
+            "Approved agent '{}' (principal: {}, approved by: {})",
+            agent_id, principal, fp
+        );
+    } else {
+        println!("Approved agent '{}' (principal: {})", agent_id, principal);
+    }
     Ok(())
 }
 
@@ -68,6 +109,19 @@ pub fn revoke(crosslink_dir: &Path, agent_id: &str) -> Result<()> {
     }
 
     signers.save(&signers_path)?;
+
+    // Record revocation metadata with driver identity
+    let driver_fp = resolve_driver_fingerprint(crosslink_dir);
+    let revocation = TrustRevocation {
+        agent_id: agent_id.to_string(),
+        principal: principal.clone(),
+        revoked_by: driver_fp,
+        revoked_at: Utc::now().to_rfc3339(),
+    };
+    let approvals_dir = cache.join("trust").join("approvals");
+    std::fs::create_dir_all(&approvals_dir)?;
+    let approval_path = approvals_dir.join(format!("{}.json", agent_id));
+    std::fs::write(&approval_path, serde_json::to_string_pretty(&revocation)?)?;
 
     commit_trust_change(cache, &format!("trust: revoke agent '{}'", agent_id))?;
 

--- a/crosslink/src/db.rs
+++ b/crosslink/src/db.rs
@@ -5,15 +5,16 @@ use std::path::Path;
 
 use crate::models::{Comment, Issue, Session};
 
-pub const SCHEMA_VERSION: i32 = 12;
+pub const SCHEMA_VERSION: i32 = 13;
 
-/// Row from `get_comments_with_author`: (id, author, content, created_at, kind, trigger_type, intervention_context).
+/// Row from `get_comments_with_author`: (id, author, content, created_at, kind, trigger_type, intervention_context, driver_key_fingerprint).
 pub type CommentAuthorRow = (
     i64,
     Option<String>,
     String,
     DateTime<Utc>,
     String,
+    Option<String>,
     Option<String>,
     Option<String>,
 );
@@ -284,6 +285,14 @@ impl Database {
                 );
             }
 
+            // Migration v13: Add driver_key_fingerprint to comments for audit trail
+            if version < 13 {
+                let _ = self.conn.execute(
+                    "ALTER TABLE comments ADD COLUMN driver_key_fingerprint TEXT",
+                    [],
+                );
+            }
+
             self.conn
                 .execute(&format!("PRAGMA user_version = {}", SCHEMA_VERSION), [])?;
         }
@@ -538,19 +547,20 @@ impl Database {
         content: &str,
         trigger_type: &str,
         intervention_context: Option<&str>,
+        driver_key_fingerprint: Option<&str>,
     ) -> Result<i64> {
         let now = Utc::now().to_rfc3339();
         self.conn.execute(
-            "INSERT INTO comments (issue_id, content, created_at, kind, trigger_type, intervention_context)
-             VALUES (?1, ?2, ?3, 'intervention', ?4, ?5)",
-            params![issue_id, content, now, trigger_type, intervention_context],
+            "INSERT INTO comments (issue_id, content, created_at, kind, trigger_type, intervention_context, driver_key_fingerprint)
+             VALUES (?1, ?2, ?3, 'intervention', ?4, ?5, ?6)",
+            params![issue_id, content, now, trigger_type, intervention_context, driver_key_fingerprint],
         )?;
         Ok(self.conn.last_insert_rowid())
     }
 
     pub fn get_comments(&self, issue_id: i64) -> Result<Vec<Comment>> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, issue_id, content, created_at, COALESCE(kind, 'note'), trigger_type, intervention_context FROM comments WHERE issue_id = ?1 ORDER BY created_at",
+            "SELECT id, issue_id, content, created_at, COALESCE(kind, 'note'), trigger_type, intervention_context, driver_key_fingerprint FROM comments WHERE issue_id = ?1 ORDER BY created_at",
         )?;
         let comments = stmt
             .query_map([issue_id], |row| {
@@ -562,6 +572,7 @@ impl Database {
                     kind: row.get(4)?,
                     trigger_type: row.get(5)?,
                     intervention_context: row.get(6)?,
+                    driver_key_fingerprint: row.get(7)?,
                 })
             })?
             .collect::<std::result::Result<Vec<_>, _>>()?;
@@ -671,7 +682,7 @@ impl Database {
     /// Get comments with author field for an issue (author added in migration v10).
     pub fn get_comments_with_author(&self, issue_id: i64) -> Result<Vec<CommentAuthorRow>> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, author, content, created_at, COALESCE(kind, 'note'), trigger_type, intervention_context FROM comments WHERE issue_id = ?1 ORDER BY created_at",
+            "SELECT id, author, content, created_at, COALESCE(kind, 'note'), trigger_type, intervention_context, driver_key_fingerprint FROM comments WHERE issue_id = ?1 ORDER BY created_at",
         )?;
         let comments = stmt
             .query_map([issue_id], |row| {
@@ -683,6 +694,7 @@ impl Database {
                     row.get::<_, String>(4)?,
                     row.get::<_, Option<String>>(5)?,
                     row.get::<_, Option<String>>(6)?,
+                    row.get::<_, Option<String>>(7)?,
                 ))
             })?
             .collect::<std::result::Result<Vec<_>, _>>()?;
@@ -1311,11 +1323,12 @@ impl Database {
         kind: &str,
         trigger_type: Option<&str>,
         intervention_context: Option<&str>,
+        driver_key_fingerprint: Option<&str>,
     ) -> Result<()> {
         self.conn.execute(
-            "INSERT INTO comments (id, issue_id, uuid, author, content, created_at, kind, trigger_type, intervention_context)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
-            params![id, issue_id, uuid, author, content, created_at, kind, trigger_type, intervention_context],
+            "INSERT INTO comments (id, issue_id, uuid, author, content, created_at, kind, trigger_type, intervention_context, driver_key_fingerprint)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+            params![id, issue_id, uuid, author, content, created_at, kind, trigger_type, intervention_context, driver_key_fingerprint],
         )?;
         Ok(())
     }

--- a/crosslink/src/hydration.rs
+++ b/crosslink/src/hydration.rs
@@ -142,6 +142,7 @@ pub fn hydrate_to_sqlite(cache_dir: &Path, db: &Database) -> Result<HydrationSta
                     &comment.kind,
                     comment.trigger_type.as_deref(),
                     comment.intervention_context.as_deref(),
+                    comment.driver_key_fingerprint.as_deref(),
                 )?;
                 stats.comments += 1;
             }
@@ -358,6 +359,7 @@ mod tests {
             kind: "note".to_string(),
             trigger_type: None,
             intervention_context: None,
+            driver_key_fingerprint: None,
             signed_by: None,
             signature: None,
         }];

--- a/crosslink/src/identity.rs
+++ b/crosslink/src/identity.rs
@@ -2,6 +2,8 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
+use crate::signing;
+
 /// Machine-local agent identity. Lives at `.crosslink/agent.json`.
 /// This file is gitignored — each machine has its own.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -91,6 +93,17 @@ fn detect_hostname() -> String {
         }
     }
     "unknown".to_string()
+}
+
+/// Resolve the current driver's SSH key fingerprint from `.crosslink/driver-key.pub`.
+///
+/// Returns `None` if the driver key file doesn't exist or the fingerprint can't be computed.
+pub fn resolve_driver_fingerprint(crosslink_dir: &Path) -> Option<String> {
+    let driver_pub = crosslink_dir.join("driver-key.pub");
+    if !driver_pub.exists() {
+        return None;
+    }
+    signing::get_key_fingerprint(&driver_pub).ok()
 }
 
 #[cfg(test)]
@@ -217,6 +230,20 @@ mod tests {
     fn test_detect_hostname_returns_something() {
         let hostname = detect_hostname();
         assert!(!hostname.is_empty());
+    }
+
+    #[test]
+    fn test_resolve_driver_fingerprint_missing_file() {
+        let dir = tempdir().unwrap();
+        assert!(resolve_driver_fingerprint(dir.path()).is_none());
+    }
+
+    #[test]
+    fn test_resolve_driver_fingerprint_invalid_content() {
+        let dir = tempdir().unwrap();
+        std::fs::write(dir.path().join("driver-key.pub"), "not a key").unwrap();
+        // ssh-keygen will fail on invalid content
+        assert!(resolve_driver_fingerprint(dir.path()).is_none());
     }
 
     proptest! {

--- a/crosslink/src/issue_file.rs
+++ b/crosslink/src/issue_file.rs
@@ -57,6 +57,8 @@ pub struct CommentEntry {
     pub trigger_type: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub intervention_context: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub driver_key_fingerprint: Option<String>,
     /// SSH fingerprint of the signer (e.g. "SHA256:..."), if signed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub signed_by: Option<String>,
@@ -293,6 +295,7 @@ mod tests {
                 kind: "note".to_string(),
                 trigger_type: None,
                 intervention_context: None,
+                driver_key_fingerprint: None,
                 signed_by: None,
                 signature: None,
             }],

--- a/crosslink/src/models.rs
+++ b/crosslink/src/models.rs
@@ -26,6 +26,8 @@ pub struct Comment {
     pub trigger_type: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub intervention_context: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub driver_key_fingerprint: Option<String>,
 }
 
 fn default_comment_kind() -> String {
@@ -162,6 +164,7 @@ mod tests {
             kind: "note".to_string(),
             trigger_type: None,
             intervention_context: None,
+            driver_key_fingerprint: None,
         };
 
         let json = serde_json::to_string(&comment).unwrap();
@@ -182,6 +185,7 @@ mod tests {
             kind: "note".to_string(),
             trigger_type: None,
             intervention_context: None,
+            driver_key_fingerprint: None,
         };
 
         let json = serde_json::to_string(&comment).unwrap();
@@ -318,6 +322,7 @@ mod tests {
                 kind: "note".to_string(),
                 trigger_type: None,
                 intervention_context: None,
+                driver_key_fingerprint: None,
             };
 
             let json = serde_json::to_string(&comment).unwrap();

--- a/crosslink/src/shared_writer.rs
+++ b/crosslink/src/shared_writer.rs
@@ -406,6 +406,7 @@ impl SharedWriter {
                     kind: kind_owned.clone(),
                     trigger_type: None,
                     intervention_context: None,
+                    driver_key_fingerprint: None,
                     signed_by,
                     signature,
                 });
@@ -433,10 +434,12 @@ impl SharedWriter {
         content: &str,
         trigger_type: &str,
         intervention_context: Option<&str>,
+        driver_key_fingerprint: Option<&str>,
     ) -> Result<i64> {
         let content_owned = content.to_string();
         let trigger_owned = trigger_type.to_string();
         let context_owned = intervention_context.map(|s| s.to_string());
+        let driver_fp_owned = driver_key_fingerprint.map(|s| s.to_string());
         let agent_id = self.agent.agent_id.clone();
         let comment_id = Cell::new(0i64);
 
@@ -457,6 +460,7 @@ impl SharedWriter {
                     kind: "intervention".to_string(),
                     trigger_type: Some(trigger_owned.clone()),
                     intervention_context: context_owned.clone(),
+                    driver_key_fingerprint: driver_fp_owned.clone(),
                     signed_by,
                     signature,
                 });


### PR DESCRIPTION
## Summary
- Add driver SSH key fingerprint tracking to intervention logs and trust approval/revocation records
- Resolve driver identity from `.crosslink/driver-key.pub` via new `resolve_driver_fingerprint()` helper in `identity.rs`
- Add `driver_key_fingerprint` column to comments table (schema migration v12→v13)
- Write JSON approval/revocation metadata to `trust/approvals/<agent-id>.json`

Closes #88

## Test plan
- [x] All 146 existing tests pass
- [x] New tests for missing/invalid driver key files
- [x] Manual: run `crosslink intervene` with a driver key present, verify fingerprint appears in output
- [x] Manual: run `crosslink trust approve` and verify JSON metadata includes `approved_by`

🤖 Generated with [Claude Code](https://claude.com/claude-code)