### PR TITLE
feat: add managed .gitignore section to crosslink init

### DIFF
--- a/crosslink/src/commands/init.rs
+++ b/crosslink/src/commands/init.rs
@@ -429,7 +429,11 @@ fn write_root_gitignore(project_root: &Path) -> Result<()> {
         if existing.is_empty() {
             managed_block
         } else {
-            let separator = if existing.ends_with('\n') { "\n" } else { "\n\n" };
+            let separator = if existing.ends_with('\n') {
+                "\n"
+            } else {
+                "\n\n"
+            };
             format!("{}{}{}", existing, separator, managed_block)
         }
     };
@@ -1562,7 +1566,10 @@ mod tests {
         run(dir.path(), &test_opts(true)).unwrap();
         let second = fs::read_to_string(dir.path().join(".gitignore")).unwrap();
 
-        assert_eq!(first, second, "Re-init should not duplicate gitignore entries");
+        assert_eq!(
+            first, second,
+            "Re-init should not duplicate gitignore entries"
+        );
     }
 
     #[test]
@@ -1596,16 +1603,28 @@ mod tests {
 
         // Add user content before and after the managed section
         let content = fs::read_to_string(dir.path().join(".gitignore")).unwrap();
-        let new_content = format!("# My custom rules\n/build/\n\n{}\n# Trailing rules\n*.tmp\n", content);
+        let new_content = format!(
+            "# My custom rules\n/build/\n\n{}\n# Trailing rules\n*.tmp\n",
+            content
+        );
         fs::write(dir.path().join(".gitignore"), new_content).unwrap();
 
         // Force re-init
         run(dir.path(), &test_opts(true)).unwrap();
 
         let result = fs::read_to_string(dir.path().join(".gitignore")).unwrap();
-        assert!(result.contains("/build/"), "Pre-section user entries preserved");
-        assert!(result.contains("*.tmp"), "Post-section user entries preserved");
-        assert!(result.contains(".crosslink/issues.db"), "Managed entries present");
+        assert!(
+            result.contains("/build/"),
+            "Pre-section user entries preserved"
+        );
+        assert!(
+            result.contains("*.tmp"),
+            "Post-section user entries preserved"
+        );
+        assert!(
+            result.contains(".crosslink/issues.db"),
+            "Managed entries present"
+        );
 
         // Should have exactly one managed section
         assert_eq!(


### PR DESCRIPTION
## Summary
- `crosslink init` now generates a marked section in the project root `.gitignore` covering machine-local `.crosslink/` state (issues.db, agent.json, session.json, keys, caches) and auto-generated `.claude/` directories (hooks/, commands/, mcp/)
- Uses start/end markers (`# === Crosslink managed ===`) for idempotent updates — re-running init replaces the section in-place without duplicating entries or disturbing user content
- Includes DO-track comments documenting which files ARE meant to be committed (hook-config.json, rules/, settings.json)
- Updates `.crosslink/.gitignore` to also ignore `integrations/`

## Test plan
- [x] 8 new unit tests covering fresh creation, idempotent re-init, user entry preservation, section replacement, DO-track comments, inner gitignore
- [x] All 47 init unit tests pass
- [x] All 146 integration tests pass
- [x] `cargo clippy -- -D warnings` clean

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)