### PR TITLE
fix: add workflow_call trigger to ci.yml and dry-run publish on release PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_call:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,14 @@ on:
   push:
     tags:
       - 'v*'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'crosslink/Cargo.toml'
+      - 'crosslink/Cargo.lock'
+      - 'crosslink/src/**'
+      - 'crosslink/build.rs'
+      - 'crosslink/resources/**'
 
 env:
   CARGO_TERM_COLOR: always
@@ -13,9 +21,27 @@ jobs:
     name: CI
     uses: ./.github/workflows/ci.yml
 
+  dry-run:
+    name: Publish Dry Run
+    needs: ci
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: crosslink
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Package dry run
+        run: cargo publish --dry-run
+
   publish:
     name: Publish
     needs: ci
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment: cargo
     defaults:


### PR DESCRIPTION
## Summary

- **ci.yml**: Add `workflow_call:` trigger so it can be used as a reusable workflow by `publish.yml`
- **publish.yml**: Add `dry-run` job that runs `cargo publish --dry-run` on PRs touching crate source files, and gate the real publish with an explicit `if` condition

Fixes the publish workflow failure on v0.1.3-beta.1 release.

## Test plan
- [x] CI will validate the workflow YAML on this PR
- [x] After merge, re-tag v0.1.3-beta.1 or push a new tag to verify publish workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)