### PR TITLE
feat: add knowledge management prompting norms for agents

### DIFF
--- a/crosslink/build.rs
+++ b/crosslink/build.rs
@@ -39,6 +39,7 @@ fn main() {
     println!("cargo:rerun-if-changed=resources/crosslink/rules/elixir-phoenix.md");
     println!("cargo:rerun-if-changed=resources/crosslink/rules/web.md");
     println!("cargo:rerun-if-changed=resources/crosslink/rules/sanitize-patterns.txt");
+    println!("cargo:rerun-if-changed=resources/crosslink/rules/knowledge.md");
     println!("cargo:rerun-if-changed=resources/crosslink/rules/tracking-strict.md");
     println!("cargo:rerun-if-changed=resources/crosslink/rules/tracking-normal.md");
     println!("cargo:rerun-if-changed=resources/crosslink/rules/tracking-relaxed.md");

--- a/crosslink/resources/claude/commands/kickoff.md
+++ b/crosslink/resources/claude/commands/kickoff.md
@@ -76,6 +76,8 @@ Build a detailed prompt for the child agent. The prompt must be self-contained â
   1. **Start your crosslink session**: Run `crosslink session start` then `crosslink session work <issue-id>` to register yourself and mark your focus
   2. **Read the project's CLAUDE.md** (if it exists) for conventions before starting
   3. Explore relevant code before making changes
+  3b. **Check the knowledge repo** for relevant research before starting implementation: `crosslink knowledge search '<relevant terms>'`. Existing knowledge pages may save you from redundant research.
+  3c. **Save research to the knowledge repo**: If you perform web research during implementation, save the results for future agents: `crosslink knowledge add <slug> --title '<topic>' --tag <category> --source '<url>' --content '<summary>'`. If you discover important codebase patterns or architecture details, document them as knowledge pages with `--tag codebase`.
   4. **Document your plan**: `crosslink comment <issue-id> "Plan: <your approach, key files, chosen strategy>" --kind plan`
   5. Implement the feature fully (no stubs or placeholders). Before each major step, run `crosslink session action "Starting <description>..."` to leave breadcrumbs for context compression recovery
   6. **Document decisions as you go**: When choosing between approaches, run `crosslink comment <issue-id> "Decision: <chose X over Y because Z>" --kind decision`

--- a/crosslink/resources/claude/hooks/session-start.py
+++ b/crosslink/resources/claude/hooks/session-start.py
@@ -196,6 +196,17 @@ def main():
     if locks_result and "No locks" not in locks_result:
         context_parts.append(f"## Active Locks\n{locks_result}")
 
+    # Show knowledge repo summary
+    knowledge_list = run_crosslink(["knowledge", "list", "--quiet"])
+    if knowledge_list is not None:
+        # --quiet outputs one slug per line; count non-empty lines
+        page_count = len([line for line in knowledge_list.splitlines() if line.strip()])
+        if page_count > 0:
+            context_parts.append(
+                f"## Knowledge Repo\n{page_count} page(s) available. "
+                "Search with `crosslink knowledge search '<query>'` before researching a topic."
+            )
+
     # Get ready issues (unblocked work)
     ready_issues = run_crosslink(["ready"])
     if ready_issues:

--- a/crosslink/resources/crosslink/rules/knowledge.md
+++ b/crosslink/resources/crosslink/rules/knowledge.md
@@ -1,0 +1,53 @@
+## Knowledge Management
+
+The project has a shared knowledge repository for saving and retrieving research, codebase patterns, and reference material across agent sessions.
+
+### Before Researching
+
+Before performing web research or deep codebase exploration on a topic, check if knowledge already exists:
+
+```bash
+crosslink knowledge search '<query>'
+```
+
+If relevant pages exist, read them first to avoid duplicating work.
+
+### After Performing Web Research
+
+When you use WebSearch, WebFetch, or similar tools to research a topic, save a summary to the knowledge repo:
+
+```bash
+crosslink knowledge add <slug> --title '<descriptive title>' --tag <category> --source '<url>' --content '<summary of findings>'
+```
+
+- Use a short, descriptive slug (e.g., `rust-async-patterns`, `jwt-refresh-tokens`)
+- Include the source URL so future agents can verify or update the information
+- Write the content as a concise, actionable summary — not a raw dump
+
+### Updating Existing Knowledge
+
+If a knowledge page already exists on a topic, update it rather than creating a duplicate:
+
+```bash
+crosslink knowledge edit <slug> --append '<new information>'
+```
+
+Add new sources when updating:
+
+```bash
+crosslink knowledge edit <slug> --append '<new findings>' --source '<new-url>'
+```
+
+### Documenting Codebase Knowledge
+
+When you discover important facts about the project's own codebase, architecture, or tooling, save them as knowledge pages for future agents:
+
+- Build and test processes
+- Architecture patterns and conventions
+- External API integration details and gotchas
+- Deployment and infrastructure notes
+- Common debugging techniques for the project
+
+```bash
+crosslink knowledge add <slug> --title '<topic>' --tag codebase --content '<what you learned>'
+```

--- a/crosslink/src/commands/init.rs
+++ b/crosslink/src/commands/init.rs
@@ -330,6 +330,8 @@ pub(crate) const RULE_ELIXIR: &str = include_str!("../../resources/crosslink/rul
 pub(crate) const RULE_ELIXIR_PHOENIX: &str =
     include_str!("../../resources/crosslink/rules/elixir-phoenix.md");
 pub(crate) const RULE_WEB: &str = include_str!("../../resources/crosslink/rules/web.md");
+pub(crate) const RULE_KNOWLEDGE: &str =
+    include_str!("../../resources/crosslink/rules/knowledge.md");
 
 /// All rule files to deploy
 pub(crate) const RULE_FILES: &[(&str, &str)] = &[
@@ -356,6 +358,7 @@ pub(crate) const RULE_FILES: &[(&str, &str)] = &[
     ("elixir.md", RULE_ELIXIR),
     ("elixir-phoenix.md", RULE_ELIXIR_PHOENIX),
     ("web.md", RULE_WEB),
+    ("knowledge.md", RULE_KNOWLEDGE),
     ("sanitize-patterns.txt", SANITIZE_PATTERNS),
     ("tracking-strict.md", RULE_TRACKING_STRICT),
     ("tracking-normal.md", RULE_TRACKING_NORMAL),


### PR DESCRIPTION
## Summary

- Add `knowledge.md` rule file instructing agents to search the knowledge repo before researching, save web research results, update existing pages, and document codebase patterns
- Update `kickoff.md` template with knowledge search/save steps (3b, 3c) for child agents
- Update `session-start.py` hook to display knowledge page count on session start, reminding agents the repo exists
- Register new rule file in `build.rs` and `init.rs` so `crosslink init` propagates it to projects

Closes #66

## Test plan

- [x] All 917 tests pass (`cargo test` — 771 unit + 146 integration)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Verify `crosslink init --force` deploys `knowledge.md` to `.crosslink/rules/`
- [ ] Verify session-start hook shows knowledge page count when pages exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)