### PR TITLE
chore: add .DS_Store to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+**/.DS_Store
+
 /target/
 /crosslink/target/
 /crosslink-simple/target/


### PR DESCRIPTION
## Summary

Adds `**/.DS_Store` to the root `.gitignore` to prevent macOS Finder metadata files from being committed.

## Test plan

- [x] No functional changes — gitignore only