### PR TITLE
feat: harden CI/CD and expand fuzz testing coverage (T1-T5)

### DIFF
--- a/.github/workflows/ci-feature.yml
+++ b/.github/workflows/ci-feature.yml
@@ -8,6 +8,9 @@ on:
   push:
     branches: ['feature/**']
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -41,7 +44,7 @@ jobs:
           key: ${{ runner.os }}-cargo-feature-${{ hashFiles('crosslink/Cargo.lock') }}
 
       - name: Build
-        run: cargo build --verbose
+        run: cargo build --locked --verbose
 
       - name: Run unit tests
         run: cargo test --bin crosslink --verbose -- --skip proptest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
   pull_request:
     branches: [develop]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -110,7 +113,7 @@ jobs:
           key: ${{ runner.os }}-cargo-test-${{ hashFiles('crosslink/Cargo.lock') }}
 
       - name: Build
-        run: cargo build --verbose
+        run: cargo build --locked --verbose
 
       - name: Run unit tests (with proptests, Ubuntu only)
         if: matrix.os == 'ubuntu-latest'
@@ -156,7 +159,7 @@ jobs:
           PROPTEST_CASES: 1000
 
   # ===========================================
-  # Fuzzing (Linux only, nightly)
+  # Fuzzing - smoke test (Linux only, nightly Rust)
   # ===========================================
   fuzz:
     needs: test
@@ -186,14 +189,38 @@ jobs:
             crosslink/fuzz/target/
           key: ${{ runner.os }}-cargo-fuzz-${{ hashFiles('crosslink/Cargo.lock') }}
 
-      - name: Fuzz create_issue (30 seconds)
-        run: cargo +nightly fuzz run fuzz_create_issue -- -max_total_time=30
-        continue-on-error: true
+      - name: Fuzz create_issue (60s)
+        run: cargo +nightly fuzz run fuzz_create_issue -- -max_total_time=60
 
-      - name: Fuzz search (30 seconds)
-        run: cargo +nightly fuzz run fuzz_search -- -max_total_time=30
-        continue-on-error: true
+      - name: Fuzz search (60s)
+        run: cargo +nightly fuzz run fuzz_search -- -max_total_time=60
 
-      - name: Fuzz import (30 seconds)
-        run: cargo +nightly fuzz run fuzz_import -- -max_total_time=30
-        continue-on-error: true
+      - name: Fuzz import (60s)
+        run: cargo +nightly fuzz run fuzz_import -- -max_total_time=60
+
+      - name: Fuzz dependency_graph (60s)
+        run: cargo +nightly fuzz run fuzz_dependency_graph -- -max_total_time=60
+
+      - name: Fuzz state_machine (60s)
+        run: cargo +nightly fuzz run fuzz_state_machine -- -max_total_time=60
+
+      - name: Fuzz cli_output (60s)
+        run: cargo +nightly fuzz run fuzz_cli_output -- -max_total_time=60
+
+      - name: Fuzz comments (60s)
+        run: cargo +nightly fuzz run fuzz_comments -- -max_total_time=60
+
+      - name: Fuzz labels (60s)
+        run: cargo +nightly fuzz run fuzz_labels -- -max_total_time=60
+
+      - name: Fuzz update_operations (60s)
+        run: cargo +nightly fuzz run fuzz_update_operations -- -max_total_time=60
+
+      - name: Fuzz milestones (60s)
+        run: cargo +nightly fuzz run fuzz_milestones -- -max_total_time=60
+
+      - name: Fuzz subissues (60s)
+        run: cargo +nightly fuzz run fuzz_subissues -- -max_total_time=60
+
+      - name: Fuzz relations (60s)
+        run: cargo +nightly fuzz run fuzz_relations -- -max_total_time=60

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -1,0 +1,63 @@
+name: Fuzz (Nightly)
+
+# Extended fuzzing runs on a nightly schedule.
+# Runs all fuzz targets for 300 seconds each to discover edge cases
+# that the 60-second CI smoke tests miss.
+on:
+  schedule:
+    - cron: '0 3 * * *' # 3 AM UTC daily
+  workflow_dispatch: # Allow manual triggering
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fuzz-extended:
+    name: Fuzz Extended (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    defaults:
+      run:
+        working-directory: crosslink
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - fuzz_create_issue
+          - fuzz_search
+          - fuzz_import
+          - fuzz_dependency_graph
+          - fuzz_state_machine
+          - fuzz_cli_output
+          - fuzz_comments
+          - fuzz_labels
+          - fuzz_update_operations
+          - fuzz_milestones
+          - fuzz_subissues
+          - fuzz_relations
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust nightly
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz --locked
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            crosslink/target/
+            crosslink/fuzz/target/
+          key: ${{ runner.os }}-cargo-fuzz-nightly-${{ hashFiles('crosslink/Cargo.lock') }}
+
+      - name: Fuzz ${{ matrix.target }} (300s)
+        run: cargo +nightly fuzz run ${{ matrix.target }} -- -max_total_time=300

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -32,7 +35,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Package dry run
-        run: cargo publish --dry-run
+        run: cargo publish --locked --dry-run
 
   publish:
     name: Publish

--- a/.github/workflows/release-builds.yml
+++ b/.github/workflows/release-builds.yml
@@ -10,6 +10,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -49,7 +52,7 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Build release
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --locked --release --target ${{ matrix.target }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/crosslink/fuzz/Cargo.lock
+++ b/crosslink/fuzz/Cargo.lock
@@ -3,16 +3,19 @@
 version = 4
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
+name = "aho-corasick"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
+ "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -89,10 +92,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -101,10 +140,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -125,28 +188,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "crosslink"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "chrono",
- "clap",
- "rusqlite",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "crosslink-fuzz"
-version = "0.0.0"
-dependencies = [
- "arbitrary",
- "crosslink",
- "libfuzzer-sys",
- "serde",
- "serde_json",
- "tempfile",
-]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -193,7 +238,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -209,10 +254,166 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crosslink"
+version = "0.1.3-beta.1"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "crossterm",
+ "ratatui",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "signal-hook",
+ "uuid",
+]
+
+[[package]]
+name = "crosslink-fuzz"
+version = "0.0.0"
+dependencies = [
+ "arbitrary",
+ "crosslink",
+ "libfuzzer-sys",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.10.0",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "derive_arbitrary"
@@ -222,8 +423,61 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.112",
 ]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -233,6 +487,15 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "euclid"
+version = "0.22.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df61bf483e837f88d5c2291dcf55c67be7e676b3a51acc48db3a7b163b91ed63"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -248,16 +511,77 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
@@ -272,21 +596,45 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.14.5"
+name = "getrandom"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
 dependencies = [
- "ahash",
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -294,6 +642,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "iana-time-zone"
@@ -320,10 +674,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -337,7 +746,7 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
  "libc",
 ]
 
@@ -350,6 +759,35 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "kasuari"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fe90c1150662e858c7d5f945089b7517b0a80d8bf7ba4b1b5ffc984e7230a5b"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -369,13 +807,22 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "95b4103cffefa72eb8428cb6b47d6627161e51c2739fc5e3b734584157bc642a"
 dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "line-clipping"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
+dependencies = [
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -385,10 +832,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix",
+ "winapi",
+]
 
 [[package]]
 name = "memchr"
@@ -397,12 +878,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -418,10 +981,159 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.112",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -448,17 +1160,175 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rusqlite"
-version = "0.32.1"
+name = "rand"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "bitflags",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "ratatui"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+dependencies = [
+ "bitflags 2.10.0",
+ "compact_str",
+ "hashbrown 0.16.1",
+ "indoc",
+ "itertools",
+ "kasuari",
+ "lru",
+ "strum",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+dependencies = [
+ "bitflags 2.10.0",
+ "hashbrown 0.16.1",
+ "indoc",
+ "instability",
+ "itertools",
+ "line-clipping",
+ "ratatui-core",
+ "strum",
+ "time",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.10.0",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rsqlite-vfs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1c93dd1c9683b438c392c492109cb702b8090b2bfc8fed6f6e4eb4523f17af3"
+dependencies = [
+ "bitflags 2.10.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+ "sqlite-wasm-rs",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -467,7 +1337,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -479,6 +1349,24 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -507,7 +1395,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -524,10 +1412,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "smallvec"
@@ -536,10 +1472,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4206ed3a67690b9c29b77d728f6acc3ce78f16bf846d83c94f76400320181b"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -559,11 +1545,147 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys",
 ]
+
+[[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bitflags 2.10.0",
+ "fancy-regex",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf",
+ "sha2",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
@@ -572,10 +1694,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-truncate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+dependencies = [
+ "atomic",
+ "getrandom 0.4.1",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "vcpkg"
@@ -590,12 +1754,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
 name = "wasip2"
 version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -630,7 +1818,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.112",
  "wasm-bindgen-shared",
 ]
 
@@ -642,6 +1830,134 @@ checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.10.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -664,7 +1980,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -675,7 +1991,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -718,23 +2034,91 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
-name = "zerocopy"
-version = "0.8.31"
+name = "wit-bindgen"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
- "zerocopy-derive",
+ "wit-bindgen-rust-macro",
 ]
 
 [[package]]
-name = "zerocopy-derive"
-version = "0.8.31"
+name = "wit-bindgen-core"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.112",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.112",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.10.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]

--- a/crosslink/fuzz/Cargo.toml
+++ b/crosslink/fuzz/Cargo.toml
@@ -66,3 +66,45 @@ path = "fuzz_targets/fuzz_cli_output.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "fuzz_comments"
+path = "fuzz_targets/fuzz_comments.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_labels"
+path = "fuzz_targets/fuzz_labels.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_update_operations"
+path = "fuzz_targets/fuzz_update_operations.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_milestones"
+path = "fuzz_targets/fuzz_milestones.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_subissues"
+path = "fuzz_targets/fuzz_subissues.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_relations"
+path = "fuzz_targets/fuzz_relations.rs"
+test = false
+doc = false
+bench = false

--- a/crosslink/fuzz/fuzz_targets/fuzz_cli_output.rs
+++ b/crosslink/fuzz/fuzz_targets/fuzz_cli_output.rs
@@ -79,7 +79,7 @@ fuzz_target!(|input: CliOutputInput| {
     // Test comments with Unicode
     if let Some(id) = created_ids.first() {
         if let Some(desc) = &input.description {
-            let _ = db.add_comment(*id, desc);
+            let _ = db.add_comment(*id, desc, "note");
         }
         let _ = db.get_comments(*id);
     }

--- a/crosslink/fuzz/fuzz_targets/fuzz_comments.rs
+++ b/crosslink/fuzz/fuzz_targets/fuzz_comments.rs
@@ -1,0 +1,64 @@
+#![no_main]
+
+//! Fuzz target for comment operations.
+//!
+//! Tests add_comment, get_comments, update_comment_content with arbitrary
+//! Unicode content and comment kinds.
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use tempfile::tempdir;
+
+use crosslink::db::Database;
+
+#[derive(Arbitrary, Debug)]
+struct CommentInput {
+    content: String,
+    kind: String,
+    update_content: Option<String>,
+    num_comments: u8,
+}
+
+fuzz_target!(|input: CommentInput| {
+    let dir = match tempdir() {
+        Ok(d) => d,
+        Err(_) => return,
+    };
+    let db_path = dir.path().join("issues.db");
+
+    let db = match Database::open(&db_path) {
+        Ok(d) => d,
+        Err(_) => return,
+    };
+
+    let issue_id = match db.create_issue("Fuzz test issue", None, "medium") {
+        Ok(id) => id,
+        Err(_) => return,
+    };
+
+    // Fuzz adding comments with arbitrary content and kinds
+    let num = (input.num_comments % 10).max(1);
+    let mut comment_ids = Vec::new();
+    for _ in 0..num {
+        if let Ok(id) = db.add_comment(issue_id, &input.content, &input.kind) {
+            comment_ids.push(id);
+        }
+    }
+
+    // Fuzz retrieving comments
+    let _ = db.get_comments(issue_id);
+
+    // Fuzz updating comment content
+    if let Some(new_content) = &input.update_content {
+        for cid in &comment_ids {
+            let _ = db.update_comment_content(*cid, new_content);
+        }
+    }
+
+    // Verify retrieval after updates
+    let _ = db.get_comments(issue_id);
+
+    // Fuzz with nonexistent issue IDs
+    let _ = db.add_comment(999999, &input.content, &input.kind);
+    let _ = db.get_comments(999999);
+});

--- a/crosslink/fuzz/fuzz_targets/fuzz_labels.rs
+++ b/crosslink/fuzz/fuzz_targets/fuzz_labels.rs
@@ -1,0 +1,76 @@
+#![no_main]
+
+//! Fuzz target for label operations.
+//!
+//! Tests add_label, remove_label, get_labels with arbitrary Unicode label
+//! names including edge cases like empty strings, very long labels, and
+//! special characters.
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use tempfile::tempdir;
+
+use crosslink::db::Database;
+
+#[derive(Arbitrary, Debug)]
+struct LabelInput {
+    labels: Vec<String>,
+    remove_indices: Vec<u8>,
+}
+
+fuzz_target!(|input: LabelInput| {
+    let dir = match tempdir() {
+        Ok(d) => d,
+        Err(_) => return,
+    };
+    let db_path = dir.path().join("issues.db");
+
+    let db = match Database::open(&db_path) {
+        Ok(d) => d,
+        Err(_) => return,
+    };
+
+    let issue_id = match db.create_issue("Fuzz label test", None, "medium") {
+        Ok(id) => id,
+        Err(_) => return,
+    };
+
+    // Add arbitrary labels (limit to 20 to prevent timeout)
+    let labels: Vec<&String> = input.labels.iter().take(20).collect();
+    for label in &labels {
+        let _ = db.add_label(issue_id, label);
+    }
+
+    // Check labels after adding
+    let _ = db.get_labels(issue_id);
+
+    // Remove some labels
+    for idx in input.remove_indices.iter().take(10) {
+        if !labels.is_empty() {
+            let label = &labels[(*idx as usize) % labels.len()];
+            let _ = db.remove_label(issue_id, label);
+        }
+    }
+
+    // Check labels after removal
+    let _ = db.get_labels(issue_id);
+
+    // Try adding duplicate labels
+    if let Some(label) = labels.first() {
+        let _ = db.add_label(issue_id, label);
+        let _ = db.add_label(issue_id, label);
+    }
+
+    // Try operations on nonexistent issue
+    if let Some(label) = labels.first() {
+        let _ = db.add_label(999999, label);
+        let _ = db.remove_label(999999, label);
+    }
+    let _ = db.get_labels(999999);
+
+    // Test listing issues filtered by label
+    if let Some(label) = labels.first() {
+        let label_str: &str = label;
+        let _ = db.list_issues(None, Some(label_str), None);
+    }
+});

--- a/crosslink/fuzz/fuzz_targets/fuzz_milestones.rs
+++ b/crosslink/fuzz/fuzz_targets/fuzz_milestones.rs
@@ -1,0 +1,111 @@
+#![no_main]
+
+//! Fuzz target for milestone operations.
+//!
+//! Tests create_milestone, close_milestone, delete_milestone,
+//! add/remove issues to milestones, and listing operations.
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use tempfile::tempdir;
+
+use crosslink::db::Database;
+
+#[derive(Arbitrary, Debug, Clone)]
+enum MilestoneOp {
+    CreateMilestone { name: String, description: Option<String> },
+    CloseMilestone { idx: usize },
+    DeleteMilestone { idx: usize },
+    AddIssue { milestone_idx: usize, issue_idx: usize },
+    RemoveIssue { milestone_idx: usize, issue_idx: usize },
+    ListMilestones,
+    GetMilestoneIssues { idx: usize },
+    GetIssueMilestone { issue_idx: usize },
+    CreateIssue { title: String },
+}
+
+#[derive(Arbitrary, Debug)]
+struct MilestoneInput {
+    ops: Vec<MilestoneOp>,
+}
+
+fuzz_target!(|input: MilestoneInput| {
+    let dir = match tempdir() {
+        Ok(d) => d,
+        Err(_) => return,
+    };
+    let db_path = dir.path().join("issues.db");
+
+    let db = match Database::open(&db_path) {
+        Ok(d) => d,
+        Err(_) => return,
+    };
+
+    let mut milestone_ids: Vec<i64> = Vec::new();
+    let mut issue_ids: Vec<i64> = Vec::new();
+
+    for op in input.ops.iter().take(50) {
+        match op {
+            MilestoneOp::CreateMilestone { name, description } => {
+                if let Ok(id) = db.create_milestone(name, description.as_deref()) {
+                    milestone_ids.push(id);
+                }
+            }
+            MilestoneOp::CloseMilestone { idx } => {
+                if !milestone_ids.is_empty() {
+                    let id = milestone_ids[*idx % milestone_ids.len()];
+                    let _ = db.close_milestone(id);
+                }
+            }
+            MilestoneOp::DeleteMilestone { idx } => {
+                if !milestone_ids.is_empty() {
+                    let idx_val = *idx % milestone_ids.len();
+                    let id = milestone_ids[idx_val];
+                    if db.delete_milestone(id).is_ok() {
+                        milestone_ids.remove(idx_val);
+                    }
+                }
+            }
+            MilestoneOp::AddIssue { milestone_idx, issue_idx } => {
+                if !milestone_ids.is_empty() && !issue_ids.is_empty() {
+                    let mid = milestone_ids[*milestone_idx % milestone_ids.len()];
+                    let iid = issue_ids[*issue_idx % issue_ids.len()];
+                    let _ = db.add_issue_to_milestone(mid, iid);
+                }
+            }
+            MilestoneOp::RemoveIssue { milestone_idx, issue_idx } => {
+                if !milestone_ids.is_empty() && !issue_ids.is_empty() {
+                    let mid = milestone_ids[*milestone_idx % milestone_ids.len()];
+                    let iid = issue_ids[*issue_idx % issue_ids.len()];
+                    let _ = db.remove_issue_from_milestone(mid, iid);
+                }
+            }
+            MilestoneOp::ListMilestones => {
+                let _ = db.list_milestones(None);
+                let _ = db.list_milestones(Some("open"));
+                let _ = db.list_milestones(Some("closed"));
+            }
+            MilestoneOp::GetMilestoneIssues { idx } => {
+                if !milestone_ids.is_empty() {
+                    let id = milestone_ids[*idx % milestone_ids.len()];
+                    let _ = db.get_milestone_issues(id);
+                }
+            }
+            MilestoneOp::GetIssueMilestone { issue_idx } => {
+                if !issue_ids.is_empty() {
+                    let id = issue_ids[*issue_idx % issue_ids.len()];
+                    let _ = db.get_issue_milestone(id);
+                }
+            }
+            MilestoneOp::CreateIssue { title } => {
+                if let Ok(id) = db.create_issue(title, None, "medium") {
+                    issue_ids.push(id);
+                }
+            }
+        }
+    }
+
+    // Final consistency checks
+    let _ = db.list_milestones(None);
+    let _ = db.list_issues(None, None, None);
+});

--- a/crosslink/fuzz/fuzz_targets/fuzz_relations.rs
+++ b/crosslink/fuzz/fuzz_targets/fuzz_relations.rs
@@ -1,0 +1,96 @@
+#![no_main]
+
+//! Fuzz target for issue relation operations.
+//!
+//! Tests add_relation, remove_relation, get_related_issues with arbitrary
+//! relation graphs including self-relations, duplicates, and relations
+//! on deleted/closed issues.
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use tempfile::tempdir;
+
+use crosslink::db::Database;
+
+#[derive(Arbitrary, Debug, Clone)]
+enum RelationOp {
+    CreateIssue { title: String },
+    AddRelation { idx_a: usize, idx_b: usize },
+    RemoveRelation { idx_a: usize, idx_b: usize },
+    GetRelated { idx: usize },
+    CloseIssue { idx: usize },
+    DeleteIssue { idx: usize },
+}
+
+#[derive(Arbitrary, Debug)]
+struct RelationInput {
+    ops: Vec<RelationOp>,
+}
+
+fuzz_target!(|input: RelationInput| {
+    let dir = match tempdir() {
+        Ok(d) => d,
+        Err(_) => return,
+    };
+    let db_path = dir.path().join("issues.db");
+
+    let db = match Database::open(&db_path) {
+        Ok(d) => d,
+        Err(_) => return,
+    };
+
+    let mut issue_ids: Vec<i64> = Vec::new();
+
+    for op in input.ops.iter().take(50) {
+        match op {
+            RelationOp::CreateIssue { title } => {
+                if let Ok(id) = db.create_issue(title, None, "medium") {
+                    issue_ids.push(id);
+                }
+            }
+            RelationOp::AddRelation { idx_a, idx_b } => {
+                if issue_ids.len() >= 2 {
+                    let a = issue_ids[*idx_a % issue_ids.len()];
+                    let b = issue_ids[*idx_b % issue_ids.len()];
+                    // Should handle self-relations and duplicates gracefully
+                    let _ = db.add_relation(a, b);
+                }
+            }
+            RelationOp::RemoveRelation { idx_a, idx_b } => {
+                if issue_ids.len() >= 2 {
+                    let a = issue_ids[*idx_a % issue_ids.len()];
+                    let b = issue_ids[*idx_b % issue_ids.len()];
+                    let _ = db.remove_relation(a, b);
+                }
+            }
+            RelationOp::GetRelated { idx } => {
+                if !issue_ids.is_empty() {
+                    let id = issue_ids[*idx % issue_ids.len()];
+                    let _ = db.get_related_issues(id);
+                    let _ = db.get_related_issue_ids(id);
+                }
+            }
+            RelationOp::CloseIssue { idx } => {
+                if !issue_ids.is_empty() {
+                    let id = issue_ids[*idx % issue_ids.len()];
+                    let _ = db.close_issue(id);
+                }
+            }
+            RelationOp::DeleteIssue { idx } => {
+                if !issue_ids.is_empty() {
+                    let idx_val = *idx % issue_ids.len();
+                    let id = issue_ids[idx_val];
+                    if db.delete_issue(id).is_ok() {
+                        issue_ids.remove(idx_val);
+                    }
+                }
+            }
+        }
+    }
+
+    // Final consistency checks
+    let _ = db.list_issues(None, None, None);
+    for id in &issue_ids {
+        let _ = db.get_related_issues(*id);
+    }
+});

--- a/crosslink/fuzz/fuzz_targets/fuzz_state_machine.rs
+++ b/crosslink/fuzz/fuzz_targets/fuzz_state_machine.rs
@@ -90,7 +90,7 @@ fuzz_target!(|input: StateMachineInput| {
                 }
             }
             StateOp::StartSession => {
-                if let Ok(id) = db.start_session() {
+                if let Ok(id) = db.start_session_with_agent(None) {
                     session_id = Some(id);
                 }
             }
@@ -121,7 +121,7 @@ fuzz_target!(|input: StateMachineInput| {
                 }
             }
             StateOp::GetCurrentSession => {
-                let _ = db.get_current_session();
+                let _ = db.get_current_session_for_agent(None);
             }
             StateOp::GetActiveTimer => {
                 let _ = db.get_active_timer();
@@ -136,7 +136,7 @@ fuzz_target!(|input: StateMachineInput| {
     }
 
     // Final consistency checks - should never panic
-    let _ = db.get_current_session();
+    let _ = db.get_current_session_for_agent(None);
     let _ = db.get_active_timer();
     let _ = db.list_issues(None, None, None);
     let _ = db.list_archived_issues();

--- a/crosslink/fuzz/fuzz_targets/fuzz_subissues.rs
+++ b/crosslink/fuzz/fuzz_targets/fuzz_subissues.rs
@@ -1,0 +1,102 @@
+#![no_main]
+
+//! Fuzz target for subissue (parent-child) operations.
+//!
+//! Tests create_subissue, get_subissues, update_parent with arbitrary
+//! nesting and reparenting sequences.
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use tempfile::tempdir;
+
+use crosslink::db::Database;
+
+#[derive(Arbitrary, Debug, Clone)]
+enum SubissueOp {
+    CreateRoot { title: String },
+    CreateSubissue { parent_idx: usize, title: String },
+    Reparent { child_idx: usize, new_parent_idx: usize },
+    Unparent { child_idx: usize },
+    GetSubissues { parent_idx: usize },
+    CloseIssue { idx: usize },
+    DeleteIssue { idx: usize },
+}
+
+#[derive(Arbitrary, Debug)]
+struct SubissueInput {
+    ops: Vec<SubissueOp>,
+}
+
+fuzz_target!(|input: SubissueInput| {
+    let dir = match tempdir() {
+        Ok(d) => d,
+        Err(_) => return,
+    };
+    let db_path = dir.path().join("issues.db");
+
+    let db = match Database::open(&db_path) {
+        Ok(d) => d,
+        Err(_) => return,
+    };
+
+    let mut issue_ids: Vec<i64> = Vec::new();
+
+    for op in input.ops.iter().take(50) {
+        match op {
+            SubissueOp::CreateRoot { title } => {
+                if let Ok(id) = db.create_issue(title, None, "medium") {
+                    issue_ids.push(id);
+                }
+            }
+            SubissueOp::CreateSubissue { parent_idx, title } => {
+                if !issue_ids.is_empty() {
+                    let parent_id = issue_ids[*parent_idx % issue_ids.len()];
+                    if let Ok(id) = db.create_subissue(parent_id, title, None, "medium") {
+                        issue_ids.push(id);
+                    }
+                }
+            }
+            SubissueOp::Reparent { child_idx, new_parent_idx } => {
+                if issue_ids.len() >= 2 {
+                    let child_id = issue_ids[*child_idx % issue_ids.len()];
+                    let parent_id = issue_ids[*new_parent_idx % issue_ids.len()];
+                    let _ = db.update_parent(child_id, Some(parent_id));
+                }
+            }
+            SubissueOp::Unparent { child_idx } => {
+                if !issue_ids.is_empty() {
+                    let child_id = issue_ids[*child_idx % issue_ids.len()];
+                    let _ = db.update_parent(child_id, None);
+                }
+            }
+            SubissueOp::GetSubissues { parent_idx } => {
+                if !issue_ids.is_empty() {
+                    let parent_id = issue_ids[*parent_idx % issue_ids.len()];
+                    let _ = db.get_subissues(parent_id);
+                }
+            }
+            SubissueOp::CloseIssue { idx } => {
+                if !issue_ids.is_empty() {
+                    let id = issue_ids[*idx % issue_ids.len()];
+                    let _ = db.close_issue(id);
+                }
+            }
+            SubissueOp::DeleteIssue { idx } => {
+                if !issue_ids.is_empty() {
+                    let idx_val = *idx % issue_ids.len();
+                    let id = issue_ids[idx_val];
+                    if db.delete_issue(id).is_ok() {
+                        issue_ids.remove(idx_val);
+                    }
+                }
+            }
+        }
+    }
+
+    // Final consistency checks
+    let _ = db.list_issues(None, None, None);
+    for id in &issue_ids {
+        let _ = db.get_issue(*id);
+        let _ = db.get_subissues(*id);
+    }
+});

--- a/crosslink/fuzz/fuzz_targets/fuzz_update_operations.rs
+++ b/crosslink/fuzz/fuzz_targets/fuzz_update_operations.rs
@@ -1,0 +1,79 @@
+#![no_main]
+
+//! Fuzz target for issue update operations.
+//!
+//! Tests update_issue with arbitrary combinations of title, description,
+//! and priority changes.
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use tempfile::tempdir;
+
+use crosslink::db::Database;
+
+#[derive(Arbitrary, Debug)]
+struct UpdateInput {
+    initial_title: String,
+    initial_description: Option<String>,
+    initial_priority: String,
+    new_title: Option<String>,
+    new_description: Option<String>,
+    new_priority: Option<String>,
+    num_updates: u8,
+}
+
+fuzz_target!(|input: UpdateInput| {
+    let dir = match tempdir() {
+        Ok(d) => d,
+        Err(_) => return,
+    };
+    let db_path = dir.path().join("issues.db");
+
+    let db = match Database::open(&db_path) {
+        Ok(d) => d,
+        Err(_) => return,
+    };
+
+    // Create issue with arbitrary initial values
+    let issue_id = match db.create_issue(
+        &input.initial_title,
+        input.initial_description.as_deref(),
+        &input.initial_priority,
+    ) {
+        Ok(id) => id,
+        Err(_) => return,
+    };
+
+    // Repeatedly update with arbitrary values
+    let num = (input.num_updates % 10).max(1);
+    for _ in 0..num {
+        let _ = db.update_issue(
+            issue_id,
+            input.new_title.as_deref(),
+            input.new_description.as_deref(),
+            input.new_priority.as_deref(),
+        );
+    }
+
+    // Verify issue is still readable after updates
+    let _ = db.get_issue(issue_id);
+
+    // Update with all None (no-op update)
+    let _ = db.update_issue(issue_id, None, None, None);
+
+    // Update nonexistent issue
+    let _ = db.update_issue(999999, Some("new title"), None, None);
+
+    // Update after close
+    let _ = db.close_issue(issue_id);
+    let _ = db.update_issue(
+        issue_id,
+        input.new_title.as_deref(),
+        input.new_description.as_deref(),
+        input.new_priority.as_deref(),
+    );
+
+    // Verify still readable
+    let _ = db.get_issue(issue_id);
+    let _ = db.list_issues(None, None, None);
+});


### PR DESCRIPTION
## Summary

Implements all 5 adversarial review findings (T1-T5) from ADR.md:

- **T4**: Add explicit `permissions: contents: read` to all CI workflow files for least-privilege GitHub Actions
- **T5**: Add `--locked` to cargo build/publish commands in CI to enforce Cargo.lock consistency
- **T2**: Remove `continue-on-error: true` from fuzz steps — crashes now fail CI instead of being silently swallowed
- **T3**: Increase fuzz durations from 30s to 60s in regular CI; add `fuzz-nightly.yml` with 300s/target on daily cron schedule
- **T1**: Add 6 new fuzz targets (comments, labels, update_operations, milestones, subissues, relations) — total coverage from 6 to 12 targets

Also fixes 3 compilation errors in existing fuzz targets (`fuzz_cli_output`, `fuzz_state_machine`) caused by API signature changes.

## Test plan

- [x] All 889 unit tests pass
- [x] Clippy clean (`cargo clippy -- -D warnings`)
- [x] Formatting clean (`cargo fmt --check`)
- [x] All 12 fuzz targets build with `cargo +nightly fuzz build`
- [x] All 6 new fuzz targets smoke-tested (5s each, no crashes)
- [ ] Verify CI passes on this branch
- [ ] Validate YAML syntax of `fuzz-nightly.yml` in Actions tab

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)