### PR TITLE
Harden VS Code extension: checksum verification, execFileSync, ANSI sanitization

### DIFF
--- a/vscode-extension/scripts/build-binaries.js
+++ b/vscode-extension/scripts/build-binaries.js
@@ -7,6 +7,7 @@
  */
 
 const { execSync } = require('child_process');
+const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
@@ -57,6 +58,14 @@ function checkCommand(cmd) {
     }
 }
 
+function writeChecksum(filePath) {
+    const hash = crypto.createHash('sha256');
+    hash.update(fs.readFileSync(filePath));
+    const checksum = hash.digest('hex');
+    fs.writeFileSync(filePath + '.sha256', checksum + '\n');
+    console.log(`  SHA256: ${checksum}`);
+}
+
 function buildWindows() {
     console.log('\n=== Building Windows binary ===');
     console.log('Cleaning previous build...');
@@ -67,6 +76,7 @@ function buildWindows() {
         const dest = path.join(BIN_DIR, 'crosslink-win.exe');
         if (fs.existsSync(src)) {
             fs.copyFileSync(src, dest);
+            writeChecksum(dest);
             console.log(`Copied: ${dest}`);
             return true;
         }
@@ -92,6 +102,7 @@ function buildLinux() {
             const dest = path.join(BIN_DIR, 'crosslink-linux');
             if (fs.existsSync(src)) {
                 fs.copyFileSync(src, dest);
+                writeChecksum(dest);
                 console.log(`Copied: ${dest}`);
                 run('wsl -d FedoraLinux-42 -- bash -c "chmod +x /mnt/c/Users/texas/crosslink/crosslink/vscode-extension/bin/crosslink-linux"');
                 return true;
@@ -111,6 +122,7 @@ function buildLinux() {
             if (fs.existsSync(src)) {
                 fs.copyFileSync(src, dest);
                 fs.chmodSync(dest, 0o755);
+                writeChecksum(dest);
                 console.log(`Copied: ${dest}`);
                 return true;
             }
@@ -151,6 +163,7 @@ function buildMacOS() {
         const dest = path.join(BIN_DIR, 'crosslink-darwin-arm64');
         if (fs.existsSync(src)) {
             fs.copyFileSync(src, dest);
+            writeChecksum(dest);
             console.log(`Copied: ${dest}`);
             arm64Ok = true;
         }
@@ -165,6 +178,7 @@ function buildMacOS() {
         const dest = path.join(BIN_DIR, 'crosslink-darwin');
         if (fs.existsSync(src)) {
             fs.copyFileSync(src, dest);
+            writeChecksum(dest);
             console.log(`Copied: ${dest}`);
             x64Ok = true;
         }
@@ -203,6 +217,7 @@ function main() {
             if (fs.existsSync(src)) {
                 fs.copyFileSync(src, dest);
                 fs.chmodSync(dest, 0o755);
+                writeChecksum(dest);
                 console.log(`Copied: ${dest}`);
                 macosOk = true;
             }

--- a/vscode-extension/src/daemon.ts
+++ b/vscode-extension/src/daemon.ts
@@ -4,6 +4,11 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { resolveBinaryPath, ensureExecutable } from './platform';
 
+/** Strip ANSI escape codes (SGR, cursor, OSC) from a string. */
+function stripAnsi(s: string): string {
+    return s.replace(/\x1b\[[0-9;]*[A-Za-z]|\x1b\][^\x07]*\x07/g, '');
+}
+
 export interface DaemonOptions {
     extensionPath: string;
     workspaceFolder: string;
@@ -71,7 +76,7 @@ export class DaemonManager {
         this.process.stdout?.on('data', (data: Buffer) => {
             const lines = data.toString().trim().split('\n');
             for (const line of lines) {
-                this.outputChannel.appendLine(`[daemon] ${line}`);
+                this.outputChannel.appendLine(`[daemon] ${stripAnsi(line)}`);
             }
         });
 
@@ -79,7 +84,7 @@ export class DaemonManager {
         this.process.stderr?.on('data', (data: Buffer) => {
             const lines = data.toString().trim().split('\n');
             for (const line of lines) {
-                this.outputChannel.appendLine(`[daemon:err] ${line}`);
+                this.outputChannel.appendLine(`[daemon:err] ${stripAnsi(line)}`);
             }
         });
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2,9 +2,9 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { DaemonManager } from './daemon';
-import { validateBinaries, resolveBinaryPath } from './platform';
+import { validateBinaries, resolveBinaryPath, verifyBinaryChecksum } from './platform';
 
 let daemonManager: DaemonManager | null = null;
 let outputChannel: vscode.OutputChannel;
@@ -659,8 +659,9 @@ async function installToUserBin(extensionPath: string, output: vscode.OutputChan
             path.join(homeDir, 'bin'),
         ];
 
-    // Find source binary
+    // Find and verify source binary
     const sourceBinary = resolveBinaryPath(extensionPath);
+    verifyBinaryChecksum(sourceBinary);
     const targetName = isWindows ? 'crosslink.exe' : 'crosslink';
 
     // Try each candidate directory
@@ -760,7 +761,7 @@ function checkPythonForHooks(workspaceFolder: string, output: vscode.OutputChann
     let pythonFound = false;
     for (const cmd of pythonCommands) {
         try {
-            execSync(`${cmd} --version`, {
+            execFileSync(cmd, ['--version'], {
                 stdio: 'pipe',
                 timeout: 5000
             });

--- a/vscode-extension/src/platform.ts
+++ b/vscode-extension/src/platform.ts
@@ -1,6 +1,7 @@
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs';
+import * as crypto from 'crypto';
 import { chmodSync } from 'fs';
 
 export type Platform = 'win32' | 'linux' | 'darwin';
@@ -123,6 +124,30 @@ export function ensureExecutable(binaryPath: string): void {
 }
 
 /**
+ * Verifies the SHA256 checksum of a bundled binary.
+ *
+ * If no .sha256 file exists (dev build or user-configured override),
+ * verification is silently skipped.
+ */
+export function verifyBinaryChecksum(binaryPath: string): void {
+    const checksumPath = binaryPath + '.sha256';
+    if (!fs.existsSync(checksumPath)) {
+        return;
+    }
+    const expected = fs.readFileSync(checksumPath, 'utf-8').trim();
+    const hash = crypto.createHash('sha256');
+    hash.update(fs.readFileSync(binaryPath));
+    const actual = hash.digest('hex');
+    if (actual !== expected) {
+        throw new Error(
+            `Binary integrity check failed for ${path.basename(binaryPath)}.\n` +
+            `Expected: ${expected}\nActual:   ${actual}\n` +
+            'The bundled binary may have been tampered with.'
+        );
+    }
+}
+
+/**
  * Validates that all required binaries are present for the current platform.
  * Useful for extension activation checks.
  */
@@ -130,6 +155,7 @@ export function validateBinaries(extensionPath: string): { valid: boolean; error
     try {
         const binaryPath = resolveBinaryPath(extensionPath);
         ensureExecutable(binaryPath);
+        verifyBinaryChecksum(binaryPath);
         return { valid: true };
     } catch (error) {
         return {


### PR DESCRIPTION
## Summary

- **E1**: Binary checksum verification — `build-binaries.js` generates SHA256 checksums alongside each compiled binary; `platform.ts` verifies integrity before installation and on activation
- **E2**: Safe command execution — replaced `execSync` with `execFileSync` in `checkPythonForHooks()` to avoid shell interpretation
- **E3**: Daemon output sanitization — `stripAnsi()` strips ANSI escape codes from daemon stdout/stderr before appending to VS Code OutputChannel

Addresses #128

## Test plan

- [x] `npx tsc --noEmit` — clean, no type errors
- [x] Build binaries and verify `.sha256` files are generated alongside each binary
- [x] Confirm Python hook check still detects Python via `execFileSync`
- [x] Confirm daemon output with ANSI codes renders as clean text in OutputChannel

🤖 Generated with [Claude Code](https://claude.com/claude-code)