### PR TITLE
Fix milestone add/remove not persisting to coordination branch

### DIFF
--- a/crosslink/src/commands/milestone.rs
+++ b/crosslink/src/commands/milestone.rs
@@ -90,7 +90,12 @@ pub fn show(db: &Database, id: i64) -> Result<()> {
     Ok(())
 }
 
-pub fn add(db: &Database, milestone_id: i64, issue_ids: &[i64]) -> Result<()> {
+pub fn add(
+    db: &Database,
+    shared: Option<&SharedWriter>,
+    milestone_id: i64,
+    issue_ids: &[i64],
+) -> Result<()> {
     let milestone = db.get_milestone(milestone_id)?;
     if milestone.is_none() {
         bail!("Milestone #{} not found", milestone_id);
@@ -120,16 +125,28 @@ pub fn add(db: &Database, milestone_id: i64, issue_ids: &[i64]) -> Result<()> {
         }
     }
 
+    if let Some(sw) = shared {
+        sw.set_milestone_on_issues(db, milestone_id, issue_ids)?;
+    }
+
     Ok(())
 }
 
-pub fn remove(db: &Database, milestone_id: i64, issue_id: i64) -> Result<()> {
+pub fn remove(
+    db: &Database,
+    shared: Option<&SharedWriter>,
+    milestone_id: i64,
+    issue_id: i64,
+) -> Result<()> {
     if db.remove_issue_from_milestone(milestone_id, issue_id)? {
         println!(
             "Removed {} from milestone #{}",
             format_issue_id(issue_id),
             milestone_id
         );
+        if let Some(sw) = shared {
+            sw.clear_milestone_on_issue(db, issue_id)?;
+        }
     } else {
         println!(
             "Issue {} not in milestone #{}",
@@ -238,7 +255,7 @@ mod tests {
         let (db, _dir) = setup_test_db();
         let milestone_id = db.create_milestone("v1.0", None).unwrap();
         let issue_id = db.create_issue("Test issue", None, "medium").unwrap();
-        add(&db, milestone_id, &[issue_id]).unwrap();
+        add(&db, None, milestone_id, &[issue_id]).unwrap();
         let issues = db.get_milestone_issues(milestone_id).unwrap();
         assert_eq!(issues.len(), 1);
         assert_eq!(issues[0].id, issue_id);
@@ -248,7 +265,7 @@ mod tests {
     fn test_add_to_nonexistent_milestone() {
         let (db, _dir) = setup_test_db();
         let issue_id = db.create_issue("Test issue", None, "medium").unwrap();
-        let result = add(&db, 99999, &[issue_id]);
+        let result = add(&db, None, 99999, &[issue_id]);
         assert!(result.is_err());
     }
 
@@ -258,7 +275,7 @@ mod tests {
         let milestone_id = db.create_milestone("v1.0", None).unwrap();
         let issue_id = db.create_issue("Test issue", None, "medium").unwrap();
         db.add_issue_to_milestone(milestone_id, issue_id).unwrap();
-        remove(&db, milestone_id, issue_id).unwrap();
+        remove(&db, None, milestone_id, issue_id).unwrap();
         let issues = db.get_milestone_issues(milestone_id).unwrap();
         assert!(issues.is_empty(), "Issue should be removed from milestone");
     }

--- a/crosslink/src/main.rs
+++ b/crosslink/src/main.rs
@@ -1403,9 +1403,11 @@ fn main() -> Result<()> {
                 }
                 MilestoneCommands::List { status } => commands::milestone::list(&db, Some(&status)),
                 MilestoneCommands::Show { id } => commands::milestone::show(&db, id),
-                MilestoneCommands::Add { id, issues } => commands::milestone::add(&db, id, &issues),
+                MilestoneCommands::Add { id, issues } => {
+                    commands::milestone::add(&db, shared_ref, id, &issues)
+                }
                 MilestoneCommands::Remove { id, issue } => {
-                    commands::milestone::remove(&db, id, issue)
+                    commands::milestone::remove(&db, shared_ref, id, issue)
                 }
                 MilestoneCommands::Close { id } => commands::milestone::close(&db, shared_ref, id),
                 MilestoneCommands::Delete { id } => {

--- a/crosslink/src/shared_writer.rs
+++ b/crosslink/src/shared_writer.rs
@@ -974,6 +974,66 @@ impl SharedWriter {
         Ok(())
     }
 
+    /// Set `milestone_uuid` on issue JSON files for the given issue IDs.
+    ///
+    /// Loads the milestone to get its UUID, then patches each issue file.
+    pub fn set_milestone_on_issues(
+        &self,
+        db: &Database,
+        milestone_id: i64,
+        issue_ids: &[i64],
+    ) -> Result<()> {
+        let milestone = self.load_milestone_by_id(milestone_id)?;
+        let ms_uuid = milestone.uuid;
+
+        let ids: Vec<i64> = issue_ids.to_vec();
+        let _ = self.write_commit_push(
+            |writer| {
+                let mut files = Vec::new();
+                for &issue_id in &ids {
+                    if let Ok(mut issue) = writer.load_issue_by_id(issue_id, db) {
+                        issue.milestone_uuid = Some(ms_uuid);
+                        issue.updated_at = Utc::now();
+                        let json = serde_json::to_vec_pretty(&issue)?;
+                        let rel_path = writer.issue_rel_path(&issue.uuid);
+                        files.push((rel_path, json));
+                    }
+                }
+                Ok(WriteSet {
+                    files,
+                    counters: None,
+                    use_git_rm: false,
+                })
+            },
+            &format!("add {} issue(s) to milestone #{}", ids.len(), milestone_id),
+        )?;
+
+        hydrate_to_sqlite(&self.cache_dir, db)?;
+        Ok(())
+    }
+
+    /// Clear `milestone_uuid` on an issue JSON file.
+    pub fn clear_milestone_on_issue(&self, db: &Database, issue_id: i64) -> Result<()> {
+        let _ = self.write_commit_push(
+            |writer| {
+                let mut issue = writer.load_issue_by_id(issue_id, db)?;
+                issue.milestone_uuid = None;
+                issue.updated_at = Utc::now();
+                let json = serde_json::to_vec_pretty(&issue)?;
+                let rel_path = writer.issue_rel_path(&issue.uuid);
+                Ok(WriteSet {
+                    files: vec![(rel_path, json)],
+                    counters: None,
+                    use_git_rm: false,
+                })
+            },
+            &format!("remove issue #{} from milestone", issue_id),
+        )?;
+
+        hydrate_to_sqlite(&self.cache_dir, db)?;
+        Ok(())
+    }
+
     /// Promote offline issues (`display_id: null`) to real display IDs.
     ///
     /// Called during sync when connectivity is restored. Scans the cache for


### PR DESCRIPTION
Closes #170

## Summary

`milestone add` and `milestone remove` only wrote to the local SQLite `milestone_issues` table, not to the issue JSON files on the `crosslink/hub` coordination branch. When `sync` hydrated SQLite from those files, the milestone associations were silently lost.

The root cause: `add()` and `remove()` in `commands/milestone.rs` only received `&Database`, while `create()`, `close()`, and `delete()` all received `Option<&SharedWriter>` and wrote to the coordination branch.

## Changes

- **`main.rs`**: Pass `shared_ref` to `milestone add` and `milestone remove` dispatch (matching `create`/`close`/`delete`)
- **`commands/milestone.rs`**: Update `add()` and `remove()` signatures to accept `Option<&SharedWriter>`
- **`shared_writer.rs`**: Add `set_milestone_on_issues()` — patches `milestone_uuid` on each issue JSON file after SQLite update. Add `clear_milestone_on_issue()` for the remove path.
- Test call sites updated for new signatures

## Test plan

- [x] All 76 milestone-related unit tests pass
- [x] All 11 milestone CLI integration tests pass
- [x] Clippy clean (`cargo clippy -- -D warnings`)
- [x] Manual verification: `milestone add` → `milestone_uuid` appears in issue JSON → `sync` → associations survive hydration