### PR TITLE
Surface visible warnings when hub sync push falls back to local-only

### DIFF
--- a/crosslink/src/shared_writer.rs
+++ b/crosslink/src/shared_writer.rs
@@ -270,6 +270,10 @@ impl SharedWriter {
                     if err_str.contains("Could not resolve host")
                         || err_str.contains("Could not read from remote")
                     {
+                        eprintln!(
+                            "Warning: push failed (offline), changes saved locally only: {}",
+                            message
+                        );
                         return Ok(PushOutcome::LocalOnly);
                     }
                     if err_str.contains("rejected") || err_str.contains("non-fast-forward") {
@@ -283,6 +287,10 @@ impl SharedWriter {
                             ])?;
                             continue;
                         }
+                        eprintln!(
+                            "Warning: push failed after {} retries (conflict), changes saved locally only: {}",
+                            MAX_RETRIES, message
+                        );
                         return Ok(PushOutcome::LocalOnly);
                     }
                     return Err(e);
@@ -1558,6 +1566,10 @@ impl SharedWriter {
                     if err_str.contains("Could not resolve host")
                         || err_str.contains("Could not read from remote")
                     {
+                        eprintln!(
+                            "Warning: push failed (offline), changes saved locally only: {}",
+                            message
+                        );
                         return Ok(PushOutcome::LocalOnly);
                     }
                     // Conflict — reset our commit, pull latest, then retry
@@ -1574,6 +1586,10 @@ impl SharedWriter {
                             continue;
                         }
                         // All retries exhausted — keep as local-only
+                        eprintln!(
+                            "Warning: push failed after {} retries (conflict), changes saved locally only: {}",
+                            MAX_RETRIES, message
+                        );
                         return Ok(PushOutcome::LocalOnly);
                     }
                     // Other error — propagate

--- a/crosslink/src/sync.rs
+++ b/crosslink/src/sync.rs
@@ -123,12 +123,22 @@ impl SyncManager {
             .map(|o| !String::from_utf8_lossy(&o.stdout).trim().is_empty())
             .unwrap_or(false);
         if !has_new_remote {
-            let _ = self.git_in_repo(&["push", "-u", "origin", HUB_BRANCH]);
+            if let Err(e) = self.git_in_repo(&["push", "-u", "origin", HUB_BRANCH]) {
+                eprintln!(
+                    "Warning: migration push failed, changes saved locally only: {}",
+                    e
+                );
+            }
         }
 
         // 4. Delete old remote branch (best-effort)
         if has_old_remote {
-            let _ = self.git_in_repo(&["push", "origin", "--delete", OLD_BRANCH]);
+            if let Err(e) = self.git_in_repo(&["push", "origin", "--delete", OLD_BRANCH]) {
+                eprintln!(
+                    "Warning: failed to delete old remote branch '{}': {}",
+                    OLD_BRANCH, e
+                );
+            }
         }
 
         // 5. Delete old local branch if still present
@@ -598,13 +608,18 @@ impl SyncManager {
             if err_str.contains("Could not resolve host")
                 || err_str.contains("Could not read from remote")
             {
-                // Offline — silently skip push
+                eprintln!("Warning: heartbeat push failed (offline), changes saved locally only");
                 return Ok(());
             }
             // If push is rejected (conflict), try pull+push once
             if err_str.contains("rejected") || err_str.contains("non-fast-forward") {
                 let _ = self.git_in_cache(&["pull", "--rebase", "origin", HUB_BRANCH]);
-                let _ = self.git_in_cache(&["push", "origin", HUB_BRANCH]);
+                if let Err(retry_err) = self.git_in_cache(&["push", "origin", HUB_BRANCH]) {
+                    eprintln!(
+                        "Warning: heartbeat push failed after retry (conflict), changes saved locally only: {}",
+                        retry_err
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- Adds `eprintln!` warnings at all 4 `PushOutcome::LocalOnly` return points in `shared_writer.rs`
- Adds warnings in `sync.rs` for migration push failure, old branch deletion failure, and heartbeat push failures
- Replaces silent `let _ =` error swallows with proper warning output so agents and users know when sync has degraded

## Closes
Closes #203

## Test plan
- [x] Simulate offline push (disconnect network) — verify warning is printed
- [x] Simulate push conflict (concurrent agents) — verify retry exhaustion warning
- [x] Normal operation — verify no spurious warnings
- [x] `cargo test` passes
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)