### PR TITLE
Fix: propagate .claude/hooks into hub cache worktree

### DIFF
--- a/crosslink/src/sync.rs
+++ b/crosslink/src/sync.rs
@@ -268,6 +268,11 @@ impl SyncManager {
         // in the cache (e.g. bootstrap step 7) don't fail in CI.
         self.ensure_cache_git_identity()?;
 
+        // Propagate .claude/hooks into the cache worktree so that PreToolUse
+        // hooks (which resolve via `git rev-parse --show-toplevel`) still work
+        // when an agent's CWD lands inside the hub cache.
+        self.propagate_claude_hooks()?;
+
         Ok(())
     }
 
@@ -1009,6 +1014,33 @@ impl SyncManager {
             bail!("git {:?} failed: {}", args, stderr);
         }
         Ok(output)
+    }
+
+    /// Copy `.claude/hooks/` from the repo root into the hub cache worktree.
+    ///
+    /// PreToolUse hooks resolve their path via `git rev-parse --show-toplevel`.
+    /// When an agent's CWD is inside the hub cache, that resolves to the cache
+    /// root instead of the main repo, so the hooks must exist there too.
+    /// This is a best-effort operation — if `.claude/hooks/` doesn't exist in
+    /// the repo root, we silently skip.
+    fn propagate_claude_hooks(&self) -> Result<()> {
+        let src = self.repo_root.join(".claude").join("hooks");
+        if !src.is_dir() {
+            return Ok(());
+        }
+        let dst = self.cache_dir.join(".claude").join("hooks");
+        if dst.is_dir() {
+            return Ok(()); // already propagated
+        }
+        std::fs::create_dir_all(&dst)?;
+        for entry in std::fs::read_dir(&src)? {
+            let entry = entry?;
+            let ty = entry.file_type()?;
+            if ty.is_file() {
+                std::fs::copy(entry.path(), dst.join(entry.file_name()))?;
+            }
+        }
+        Ok(())
     }
 
     /// Ensure the cache worktree has a git identity configured so commits


### PR DESCRIPTION
## Summary
  - Adds propagate_claude_hooks() to SyncManager::init_cache()
  - Copies .claude/hooks/ from repo root into the hub cache worktree
  - Skips silently if no hooks exist or already propagated

  ## Root Cause
  PreToolUse hooks resolve via git rev-parse --show-toplevel. When CWD is inside the hub cache worktree, that resolves to the cache root, not the main repo. The hook script
  doesn't exist there, permanently locking out all Bash/Write/Edit tools.

  Closes #211

  🤖 Generated with [Claude Code](https://claude.com/claude-code)