### PR TITLE
feat: add configurable auto-steal for stale locks

### DIFF
--- a/crosslink/resources/crosslink/hook-config.json
+++ b/crosslink/resources/crosslink/hook-config.json
@@ -5,6 +5,7 @@
   "comment_discipline": "encouraged",
   "kickoff_verification": "local",
   "signing_enforcement": "audit",
+  "auto_steal_stale_locks": false,
   "blocked_git_commands": [
     "git push", "git merge", "git rebase", "git cherry-pick",
     "git reset", "git checkout .", "git restore .", "git clean",

--- a/crosslink/src/commands/config.rs
+++ b/crosslink/src/commands/config.rs
@@ -59,6 +59,11 @@ static REGISTRY: &[ConfigKey] = &[
         description: "Prompts without crosslink usage before re-injecting reminder (0 = always)",
     },
     ConfigKey {
+        key: "auto_steal_stale_locks",
+        config_type: ConfigType::Enum(&["false", "2", "3", "5", "10"]),
+        description: "Auto-steal stale locks after N * stale_timeout minutes (false = disabled)",
+    },
+    ConfigKey {
         key: "blocked_git_commands",
         config_type: ConfigType::StringArray,
         description: "Git mutation commands blocked in all tracking modes",

--- a/crosslink/src/commands/create.rs
+++ b/crosslink/src/commands/create.rs
@@ -176,7 +176,7 @@ pub fn run(
     if opts.work {
         // Check lock status before allowing work on this issue
         if let Some(dir) = opts.crosslink_dir {
-            crate::lock_check::enforce_lock(dir, id)?;
+            crate::lock_check::enforce_lock(dir, id, db)?;
 
             // Auto-claim lock in multi-agent mode (same as session work)
             if let Ok(Some(agent)) = crate::identity::AgentConfig::load(dir) {
@@ -297,7 +297,7 @@ pub fn run_subissue(
     if opts.work {
         // Check lock status before allowing work on this issue
         if let Some(dir) = opts.crosslink_dir {
-            crate::lock_check::enforce_lock(dir, id)?;
+            crate::lock_check::enforce_lock(dir, id, db)?;
 
             // Auto-claim lock in multi-agent mode (same as session work)
             if let Ok(Some(agent)) = crate::identity::AgentConfig::load(dir) {

--- a/crosslink/src/commands/session.rs
+++ b/crosslink/src/commands/session.rs
@@ -180,7 +180,7 @@ pub fn work(db: &Database, issue_id: i64, crosslink_dir: &std::path::Path) -> Re
     };
 
     // Check lock status before allowing work
-    crate::lock_check::enforce_lock(crosslink_dir, issue_id)?;
+    crate::lock_check::enforce_lock(crosslink_dir, issue_id, db)?;
 
     // Auto-claim lock in multi-agent mode
     if let Ok(Some(agent)) = crate::identity::AgentConfig::load(crosslink_dir) {

--- a/crosslink/src/issue_file.rs
+++ b/crosslink/src/issue_file.rs
@@ -82,6 +82,7 @@ const KNOWN_COMMENT_KINDS: &[&str] = &[
     "handoff",
     "human",
     "intervention",
+    "system",
 ];
 
 pub fn validate_comment_kind(kind: &str) -> bool {

--- a/crosslink/src/lock_check.rs
+++ b/crosslink/src/lock_check.rs
@@ -1,6 +1,7 @@
 use anyhow::{bail, Result};
 use std::path::Path;
 
+use crate::db::Database;
 use crate::identity::AgentConfig;
 use crate::sync::SyncManager;
 
@@ -71,14 +72,119 @@ pub fn check_lock(crosslink_dir: &Path, issue_id: i64) -> Result<LockStatus> {
     }
 }
 
+/// Read the `auto_steal_stale_locks` setting from hook-config.json.
+///
+/// Returns `None` if disabled or missing, `Some(multiplier)` if enabled.
+fn read_auto_steal_config(crosslink_dir: &Path) -> Option<u64> {
+    let config_path = crosslink_dir.join("hook-config.json");
+    let content = std::fs::read_to_string(&config_path).ok()?;
+    let parsed: serde_json::Value = serde_json::from_str(&content).ok()?;
+    match parsed.get("auto_steal_stale_locks")? {
+        serde_json::Value::Bool(false) => None,
+        serde_json::Value::Number(n) => n.as_u64().filter(|&v| v > 0),
+        serde_json::Value::String(s) if s == "false" => None,
+        serde_json::Value::String(s) => s.parse::<u64>().ok().filter(|&v| v > 0),
+        _ => None,
+    }
+}
+
+/// Attempt to auto-steal a stale lock if configured.
+///
+/// Returns `Ok(true)` if the lock was auto-stolen, `Ok(false)` if not eligible.
+fn auto_steal_if_configured(
+    crosslink_dir: &Path,
+    issue_id: i64,
+    stale_agent_id: &str,
+    db: &Database,
+) -> Result<bool> {
+    let multiplier = match read_auto_steal_config(crosslink_dir) {
+        Some(m) => m,
+        None => return Ok(false),
+    };
+
+    let sync = match SyncManager::new(crosslink_dir) {
+        Ok(s) => s,
+        Err(_) => return Ok(false),
+    };
+
+    if !sync.is_initialized() {
+        return Ok(false);
+    }
+
+    let stale_locks = sync.find_stale_locks_with_age()?;
+    let stale_minutes = match stale_locks.iter().find(|(id, _, _)| *id == issue_id) {
+        Some((_, _, mins)) => *mins,
+        None => return Ok(false),
+    };
+
+    // Threshold = multiplier × stale_timeout
+    let stale_timeout = if sync.is_v2_layout() {
+        30u64
+    } else {
+        sync.read_locks_auto()
+            .map(|l| l.settings.stale_lock_timeout_minutes)
+            .unwrap_or(60)
+    };
+    let auto_steal_threshold = multiplier.saturating_mul(stale_timeout);
+
+    if stale_minutes < auto_steal_threshold {
+        return Ok(false);
+    }
+
+    // Perform the steal
+    if sync.is_v2_layout() {
+        if let Ok(Some(writer)) = crate::shared_writer::SharedWriter::new(crosslink_dir) {
+            writer.steal_lock_v2(issue_id, stale_agent_id, None)?;
+            let comment = format!(
+                "[auto-steal] Lock auto-stolen from agent '{}' (stale for {} min, threshold: {} min)",
+                stale_agent_id, stale_minutes, auto_steal_threshold
+            );
+            let _ = writer.add_comment(db, issue_id, &comment, "system");
+        } else {
+            return Ok(false);
+        }
+    } else {
+        let agent = match AgentConfig::load(crosslink_dir)? {
+            Some(a) => a,
+            None => return Ok(false),
+        };
+        sync.claim_lock(&agent, issue_id, None, true)?;
+        let comment = format!(
+            "[auto-steal] Lock auto-stolen from agent '{}' (stale for {} min, threshold: {} min)",
+            stale_agent_id, stale_minutes, auto_steal_threshold
+        );
+        let _ = db.add_comment(issue_id, &comment, "system");
+    }
+
+    Ok(true)
+}
+
 /// Enforce lock check. Bails if another agent holds the lock (unless stale).
 ///
-/// Use this in commands that set the active work item (session work, create --work, quick).
-pub fn enforce_lock(crosslink_dir: &Path, issue_id: i64) -> Result<()> {
+/// When `auto_steal_stale_locks` is configured in hook-config.json and the lock
+/// has been stale long enough, automatically steals it and records an audit comment.
+pub fn enforce_lock(crosslink_dir: &Path, issue_id: i64, db: &Database) -> Result<()> {
     match check_lock(crosslink_dir, issue_id)? {
         LockStatus::NotConfigured | LockStatus::Available | LockStatus::LockedBySelf => Ok(()),
         LockStatus::LockedByOther { agent_id, stale } => {
             if stale {
+                match auto_steal_if_configured(crosslink_dir, issue_id, &agent_id, db) {
+                    Ok(true) => {
+                        eprintln!(
+                            "Auto-stole stale lock on issue #{} from '{}'.",
+                            issue_id, agent_id
+                        );
+                        return Ok(());
+                    }
+                    Ok(false) => {}
+                    Err(e) => {
+                        eprintln!(
+                            "Warning: Auto-steal of stale lock on #{} failed: {}. Proceeding.",
+                            issue_id, e
+                        );
+                    }
+                }
+
                 eprintln!(
                     "Warning: Issue #{} is locked by '{}' but the lock appears STALE. Proceeding.",
                     issue_id, agent_id
@@ -103,6 +209,10 @@ mod tests {
     use super::*;
     use tempfile::tempdir;
 
+    fn temp_db() -> Database {
+        Database::open(std::path::Path::new(":memory:")).unwrap()
+    }
+
     #[test]
     fn test_no_agent_config_returns_not_configured() {
         let dir = tempdir().unwrap();
@@ -119,8 +229,9 @@ mod tests {
         let crosslink_dir = dir.path().join(".crosslink");
         std::fs::create_dir_all(&crosslink_dir).unwrap();
 
+        let db = temp_db();
         // No agent.json → NotConfigured → allowed
-        assert!(enforce_lock(&crosslink_dir, 1).is_ok());
+        assert!(enforce_lock(&crosslink_dir, 1, &db).is_ok());
     }
 
     #[test]
@@ -134,7 +245,6 @@ mod tests {
 
     #[test]
     fn test_lock_status_debug() {
-        // Ensure all variants are debuggable
         let statuses = vec![
             LockStatus::NotConfigured,
             LockStatus::Available,
@@ -179,5 +289,75 @@ mod tests {
                 stale: false
             }
         );
+    }
+
+    // --- read_auto_steal_config tests ---
+
+    #[test]
+    fn test_auto_steal_config_disabled() {
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("hook-config.json"),
+            r#"{"auto_steal_stale_locks": false}"#,
+        )
+        .unwrap();
+        assert_eq!(read_auto_steal_config(dir.path()), None);
+    }
+
+    #[test]
+    fn test_auto_steal_config_enabled_int() {
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("hook-config.json"),
+            r#"{"auto_steal_stale_locks": 2}"#,
+        )
+        .unwrap();
+        assert_eq!(read_auto_steal_config(dir.path()), Some(2));
+    }
+
+    #[test]
+    fn test_auto_steal_config_enabled_string() {
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("hook-config.json"),
+            r#"{"auto_steal_stale_locks": "3"}"#,
+        )
+        .unwrap();
+        assert_eq!(read_auto_steal_config(dir.path()), Some(3));
+    }
+
+    #[test]
+    fn test_auto_steal_config_string_false() {
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("hook-config.json"),
+            r#"{"auto_steal_stale_locks": "false"}"#,
+        )
+        .unwrap();
+        assert_eq!(read_auto_steal_config(dir.path()), None);
+    }
+
+    #[test]
+    fn test_auto_steal_config_missing_key() {
+        let dir = tempdir().unwrap();
+        std::fs::write(dir.path().join("hook-config.json"), r#"{}"#).unwrap();
+        assert_eq!(read_auto_steal_config(dir.path()), None);
+    }
+
+    #[test]
+    fn test_auto_steal_config_no_file() {
+        let dir = tempdir().unwrap();
+        assert_eq!(read_auto_steal_config(dir.path()), None);
+    }
+
+    #[test]
+    fn test_auto_steal_config_zero_disabled() {
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("hook-config.json"),
+            r#"{"auto_steal_stale_locks": 0}"#,
+        )
+        .unwrap();
+        assert_eq!(read_auto_steal_config(dir.path()), None);
     }
 }

--- a/crosslink/src/sync.rs
+++ b/crosslink/src/sync.rs
@@ -770,6 +770,95 @@ impl SyncManager {
         Ok(stale)
     }
 
+    /// Find stale locks with their age in minutes.
+    ///
+    /// Returns `(issue_id, agent_id, stale_minutes)` for each stale lock.
+    /// Auto-dispatches based on hub layout version.
+    pub fn find_stale_locks_with_age(&self) -> Result<Vec<(i64, String, u64)>> {
+        if self.is_v2_layout() {
+            return self.find_stale_locks_with_age_v2();
+        }
+
+        let locks = self.read_locks_auto()?;
+        let heartbeats = self.read_heartbeats()?;
+        let timeout = chrono::Duration::minutes(locks.settings.stale_lock_timeout_minutes as i64);
+        let now = Utc::now();
+
+        let mut stale = Vec::new();
+        for (issue_id_str, lock) in &locks.locks {
+            let latest_heartbeat = heartbeats
+                .iter()
+                .filter(|hb| hb.agent_id == lock.agent_id)
+                .map(|hb| hb.last_heartbeat)
+                .max();
+
+            let age = match latest_heartbeat {
+                Some(hb_time) => now
+                    .signed_duration_since(hb_time)
+                    .max(chrono::Duration::zero()),
+                None => now
+                    .signed_duration_since(lock.claimed_at)
+                    .max(chrono::Duration::zero()),
+            };
+
+            if age >= timeout {
+                if let Ok(id) = issue_id_str.parse::<i64>() {
+                    stale.push((id, lock.agent_id.clone(), age.num_minutes() as u64));
+                }
+            }
+        }
+        Ok(stale)
+    }
+
+    fn find_stale_locks_with_age_v2(&self) -> Result<Vec<(i64, String, u64)>> {
+        let locks = self.read_locks_v2()?;
+        let now = Utc::now();
+        let threshold = chrono::Duration::minutes(30);
+        let mut stale = Vec::new();
+
+        for (issue_id_str, lock) in &locks.locks {
+            let heartbeat_path = self
+                .cache_dir
+                .join("agents")
+                .join(&lock.agent_id)
+                .join("heartbeat.json");
+
+            let age_minutes = if heartbeat_path.exists() {
+                match std::fs::read_to_string(&heartbeat_path) {
+                    Ok(content) => match serde_json::from_str::<serde_json::Value>(&content) {
+                        Ok(val) => match val.get("timestamp").and_then(|t| t.as_str()) {
+                            Some(ts) => match chrono::DateTime::parse_from_rfc3339(ts) {
+                                Ok(hb_time) => {
+                                    let age = now
+                                        .signed_duration_since(hb_time)
+                                        .max(chrono::Duration::zero());
+                                    if age > threshold {
+                                        Some(age.num_minutes() as u64)
+                                    } else {
+                                        None
+                                    }
+                                }
+                                Err(_) => Some(u64::MAX),
+                            },
+                            None => Some(u64::MAX),
+                        },
+                        Err(_) => Some(u64::MAX),
+                    },
+                    Err(_) => Some(u64::MAX),
+                }
+            } else {
+                Some(u64::MAX)
+            };
+
+            if let Some(mins) = age_minutes {
+                if let Ok(id) = issue_id_str.parse::<i64>() {
+                    stale.push((id, lock.agent_id.clone(), mins));
+                }
+            }
+        }
+        Ok(stale)
+    }
+
     /// Claim a lock on an issue for the given agent.
     ///
     /// Writes the lock to `locks.json`, commits, and pushes with retry.


### PR DESCRIPTION
## Summary
- Add `auto_steal_stale_locks` setting to `hook-config.json` — when set to a multiplier (e.g. `2`), stale locks are automatically reclaimed after N × stale_timeout minutes
- Auto-steal triggers just-in-time inside `enforce_lock()` when a stale lock is detected, with a `"system"` audit trail comment on the issue
- Supports both V1 and V2 lock layouts
- Default: `false` (disabled) — no behavior change for existing users

### Files changed
- `lock_check.rs` — core auto-steal logic (`read_auto_steal_config`, `auto_steal_if_configured`, updated `enforce_lock` signature)
- `sync.rs` — `find_stale_locks_with_age()` for V1/V2 age tracking
- `issue_file.rs` — `"system"` comment kind for audit trail
- `commands/config.rs` — config key registration
- `commands/create.rs`, `commands/session.rs` — updated `enforce_lock()` call sites
- `resources/crosslink/hook-config.json` — default template

Closes #201

## Test plan
- [x] 7 new unit tests for `read_auto_steal_config()` (disabled, int, string, false-string, missing, no-file, zero)
- [x] All 149 integration tests pass
- [x] All 12 lock_check unit tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)