### PR TITLE
feat: add /design skill for interactive design document authoring

### DIFF
--- a/crosslink/resources/claude/commands/design.md
+++ b/crosslink/resources/claude/commands/design.md
@@ -1,0 +1,176 @@
+---
+allowed-tools: Bash(crosslink *), Bash(git *), Bash(gh *), Bash(ls *), Bash(mkdir *), Read, Grep, Glob, Write
+description: Interactive, iterative design document authoring grounded in codebase exploration
+---
+
+## Context
+
+- Current repo root: !`git rev-parse --show-toplevel`
+- Current branch: !`git branch --show-current`
+- Active session: !`crosslink session status`
+- Existing design docs: !`ls .design/*.md 2>/dev/null || echo "(none)"`
+- Architecture files: !`ls README.md CLAUDE.md ARCHITECTURE.md ADR.md 2>/dev/null || echo "(none found)"`
+
+## Your task
+
+You are an interactive design document author. You help the user go from a rough feature idea to a validated, codebase-grounded design document ready for `crosslink kickoff --doc`.
+
+### Arguments
+
+The user may pass these after `/design`:
+
+- A quoted feature description: `/design "add batch retry logic for sync"`
+- `--issue <id>`: Pull context from a crosslink issue
+- `--gh-issue <number>`: Pull context from a GitHub issue
+- `--continue <slug>`: Resume iteration on an existing draft in `.design/<slug>.md`
+
+If no arguments are given, ask the user what feature they want to design.
+
+### Phase 1: Explore & Interview (skip if `--continue`)
+
+1. **Gather context** from all available sources:
+   - If `--issue <id>`: run `crosslink show <id>` to read the issue
+   - If `--gh-issue <number>`: run `gh issue view <number>`
+   - Read architecture files (README.md, CLAUDE.md, ARCHITECTURE.md) if they exist
+   - Search for related code using `Grep` and `Glob` — find modules, types, functions, and test patterns related to the feature
+   - Check existing knowledge: `crosslink knowledge search "<keywords>"`
+   - Check existing design docs in `.design/`
+
+2. **Ask 3-5 clarifying questions** grounded in what you found:
+   - Reference specific files, functions, or patterns you discovered
+   - Ask about ambiguities that affect architecture decisions
+   - Ask about scope boundaries
+   - Do NOT ask generic questions — every question must reference something concrete from the codebase
+
+3. **Wait for the user to answer** before proceeding to Phase 2.
+
+### Phase 2: Draft
+
+4. **Create the `.design/` directory** if it doesn't exist:
+   ```bash
+   mkdir -p .design
+   ```
+
+5. **Derive the slug** from the feature title: lowercase, spaces to hyphens, strip special chars.
+   Example: "Add batch retry logic" → `add-batch-retry-logic`
+
+6. **Write the design document** to `.design/<slug>.md` using this exact format:
+
+```markdown
+# Feature: <title>
+
+## Summary
+1-3 sentence overview of what this feature does and why.
+
+## Requirements
+- REQ-1: <specific, measurable requirement grounded in codebase>
+- REQ-2: ...
+
+## Acceptance Criteria
+- [ ] AC-1: <mechanically testable criterion>
+- [ ] AC-2: ...
+
+## Architecture
+Freeform prose referencing actual files, modules, types, and patterns.
+Describes what gets modified, how it fits existing architecture, key
+data structures, and error handling approach.
+
+## Open Questions
+
+<!-- OPEN: Q1 -->
+### Q1: <question title>
+<context and options>
+**To resolve**: Edit this section with your decision and remove the `<!-- OPEN -->` marker.
+<!-- /OPEN -->
+
+## Out of Scope
+- <explicit exclusion to prevent scope creep>
+```
+
+**Quality standards — enforce all of these:**
+- Requirements reference real codebase concepts (not generic "should handle errors")
+- Acceptance criteria are mechanically testable (a CI system could verify)
+- Architecture references actual file paths discovered during exploration
+- No placeholder text (`<...>`, `TODO`, `TBD`)
+- Every requirement maps to at least one acceptance criterion
+- Genuine ambiguities become `<!-- OPEN -->` blocks, not guesses
+
+### Phase 3: Iterate (when `--continue` is used)
+
+7. **Read the existing draft**: `Read .design/<slug>.md`
+
+8. **Detect resolved questions**: Scan for `<!-- OPEN: ... -->` blocks. If a block's marker has been removed or the section has been rewritten by the user, treat it as resolved.
+
+9. **Re-explore if scope changed**: If the user's answers to open questions change the feature's scope, search the codebase again for newly relevant code.
+
+10. **Update the document**:
+    - Strengthen sections based on resolved questions
+    - Update requirements and acceptance criteria if scope changed
+    - Add new `<!-- OPEN -->` blocks if new ambiguities surfaced
+    - Remove resolved `<!-- OPEN -->` markers
+
+11. **Write the updated document** back to `.design/<slug>.md`
+
+### Validation
+
+After writing (or updating) the document, run validation and print results:
+
+```
+Design doc validation:
+  [PASS] Summary present
+  [PASS] Requirements: N items
+  [PASS] Acceptance Criteria: N items
+  [PASS] Architecture references real files
+  [WARN] REQ-X has no matching acceptance criterion  (if applicable)
+  [PASS] No placeholder text
+  [OPEN] N unresolved open questions remain  (if applicable)
+```
+
+Check these:
+- Summary section is non-empty
+- At least 2 requirements exist
+- At least 2 acceptance criteria exist
+- Architecture section references at least one real file path (verify with `ls`)
+- No `<...>`, `TODO`, or `TBD` in the document
+- Each REQ-N has at least one AC-N that addresses it
+- Count remaining `<!-- OPEN -->` blocks
+
+### Knowledge Integration
+
+After validation:
+
+1. **Store as knowledge page**:
+   ```bash
+   crosslink knowledge add "<slug>" --from-doc .design/<slug>.md --tag design-doc
+   ```
+
+2. **If `--issue` was provided**, comment on the issue:
+   ```bash
+   crosslink comment <id> "Design doc drafted: .design/<slug>.md" --kind plan
+   ```
+
+### Summary Output
+
+Print this summary after every invocation:
+
+```
+Design document written: .design/<slug>.md
+
+Validation: N requirements, N acceptance criteria, N open questions
+Knowledge:  Stored as "<slug>" (tagged: design-doc)
+Issue:      Commented on #<id>  (if applicable)
+
+Next steps:
+  - Edit in your editor:  $EDITOR .design/<slug>.md
+  - Continue iterating:   /design --continue <slug>
+  - Run gap analysis:     crosslink kickoff plan .design/<slug>.md
+  - Start implementation: crosslink kickoff run "<feature>" --doc .design/<slug>.md
+```
+
+### Rules
+
+- Do NOT modify any source code files. You only write to `.design/`.
+- Do NOT automatically run `kickoff plan` or `kickoff run`. Suggest them in the output.
+- Do NOT auto-create crosslink issues. The user manages issue lifecycle.
+- Every question you ask must be grounded in specific codebase findings.
+- A document with unresolved `<!-- OPEN -->` blocks is valid but flagged.

--- a/crosslink/src/commands/init.rs
+++ b/crosslink/src/commands/init.rs
@@ -312,6 +312,7 @@ const PREFLIGHT_CMD_MD: &str = include_str!("../../resources/claude/commands/pre
 const REVIEW_CMD_MD: &str = include_str!("../../resources/claude/commands/review.md");
 const AUDIT_CMD_MD: &str = include_str!("../../resources/claude/commands/audit.md");
 const MAINTAIN_CMD_MD: &str = include_str!("../../resources/claude/commands/maintain.md");
+const DESIGN_CMD_MD: &str = include_str!("../../resources/claude/commands/design.md");
 
 // Embed sanitization patterns
 const SANITIZE_PATTERNS: &str =
@@ -1446,6 +1447,8 @@ pub fn run(path: &Path, opts: &InitOpts<'_>) -> Result<()> {
             .context("Failed to write audit.md")?;
         fs::write(commands_dir.join("maintain.md"), MAINTAIN_CMD_MD)
             .context("Failed to write maintain.md")?;
+        fs::write(commands_dir.join("design.md"), DESIGN_CMD_MD)
+            .context("Failed to write design.md")?;
 
         let warnings =
             write_mcp_json_merged(&path.join(".mcp.json")).context("Failed to write .mcp.json")?;
@@ -1918,6 +1921,7 @@ mod tests {
         assert!(!PREFLIGHT_CMD_MD.is_empty());
         assert!(!REVIEW_CMD_MD.is_empty());
         assert!(!AUDIT_CMD_MD.is_empty());
+        assert!(!DESIGN_CMD_MD.is_empty());
         assert!(!SANITIZE_PATTERNS.is_empty());
         assert!(!HOOK_CONFIG_JSON.is_empty());
         assert!(!RULE_TRACKING_STRICT.is_empty());


### PR DESCRIPTION
## Summary
- Add `/design` Claude Code skill for interactive, iterative design document authoring grounded in codebase exploration
- Three-phase interaction model: Explore & Interview → Draft → Iterate
- Produces `.design/<slug>.md` files compatible with `parse_design_doc()` and `kickoff --doc`
- Supports `--issue`, `--gh-issue` for context injection and `--continue` for multi-session iteration
- Validates requirements, acceptance criteria, architecture references, and `<!-- OPEN -->` question blocks
- Integrates with `crosslink knowledge` on each iteration
- Skill-only implementation: `.md` prompt file compiled via `include_str!()` and deployed by `crosslink init`

### Files
- **New**: `crosslink/resources/claude/commands/design.md` — the skill prompt
- **Modified**: `crosslink/src/commands/init.rs` — `include_str!()` const + `fs::write` deploy line + test assertion

Closes #220

## Test plan
- [x] All 149 integration tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `DESIGN_CMD_MD` const non-empty assertion added

🤖 Generated with [Claude Code](https://claude.com/claude-code)