### PR TITLE
feat: add docs visual generation scripts

### DIFF
--- a/docs_src/scripts/README.md
+++ b/docs_src/scripts/README.md
@@ -1,0 +1,59 @@
+# Documentation Visual Asset Scripts
+
+Scripts for generating screenshots, terminal GIFs, and diagrams for the crosslink docs site.
+
+## Prerequisites
+
+```bash
+brew install vhs                      # Terminal GIF recorder
+brew install homeport/tap/termshot    # Terminal screenshot renderer
+```
+
+## Usage
+
+```bash
+# Generate all assets
+./docs_src/scripts/generate-all.sh
+
+# Or run individual scripts
+vhs docs_src/scripts/vhs/hero-demo.tape
+vhs docs_src/scripts/vhs/quickstart.tape
+# etc.
+```
+
+## Structure
+
+```
+scripts/
+├── generate-all.sh          # Master script — runs everything
+├── vhs/                     # VHS .tape files for terminal GIFs
+│   ├── hero-demo.tape       # Homepage hero GIF
+│   ├── quickstart.tape      # Quick start walkthrough
+│   ├── session-workflow.tape # Session lifecycle demo
+│   ├── kickoff.tape         # /kickoff flow demo
+│   ├── multi-agent.tape     # Multi-agent coordination demo
+│   └── tracking-modes.tape  # Tracking mode comparison
+├── termshot/                # Termshot commands for static screenshots
+│   └── generate.sh          # All termshot captures
+└── mermaid/                 # Mermaid diagram sources (.mmd)
+    ├── session-lifecycle.mmd
+    ├── kickoff-flow.mmd
+    ├── multi-agent-arch.mmd
+    ├── hook-pipeline.mmd
+    ├── hook-decision.mmd
+    └── tracking-modes.mmd
+```
+
+## Output
+
+All generated assets go to `docs_src/assets/img/`. The `.qmd` files can reference them as:
+
+```markdown
+![Description](../assets/img/filename.gif)
+```
+
+## Notes
+
+- VHS requires a working terminal (not headless CI) for font rendering
+- Mermaid diagrams are also embedded inline in `.qmd` files via Quarto's native mermaid support — the `.mmd` files here are for standalone SVG generation if preferred
+- Termshot captures use mock data so they produce consistent output

--- a/docs_src/scripts/mermaid/kickoff-flow.mmd
+++ b/docs_src/scripts/mermaid/kickoff-flow.mmd
@@ -1,0 +1,49 @@
+%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00a6db', 'primaryTextColor': '#fff', 'primaryBorderColor': '#00a6db', 'lineColor': '#56cfe1', 'secondaryColor': '#f95838', 'tertiaryColor': '#1a1a2e', 'fontSize': '14px' }}}%%
+flowchart TD
+    U["👤 User: /kickoff 'add batch retry logic'"] --> S1
+
+    subgraph Setup ["Setup Phase"]
+        S1["Create feature branch"] --> S2["Create git worktree"]
+        S2 --> S3["Initialize crosslink\n+ agent identity"]
+        S3 --> S4["Detect project tools\n(cargo, npm, pytest...)"]
+        S4 --> S5["Write KICKOFF.md prompt"]
+        S5 --> S6["Launch tmux session"]
+    end
+
+    S6 --> TRUST{"User approves\ntrust?"}
+    TRUST -- Yes --> AGENT
+
+    subgraph AGENT ["Background Agent (autonomous)"]
+        A1["Start crosslink session"] --> A2["Explore codebase"]
+        A2 --> A3["Document plan via comments"]
+        A3 --> A4["Implement feature"]
+        A4 --> A5["Run tests & linters"]
+        A5 --> A6{"Tests pass?"}
+        A6 -- No --> A4
+        A6 -- Yes --> A7["Commit with /commit"]
+        A7 --> A8["Self-review checklist"]
+    end
+
+    A8 --> V{"Verify level?"}
+    V -- local --> DONE["✅ Write DONE sentinel"]
+    V -- ci --> CI
+    V -- thorough --> CI
+
+    subgraph CI ["CI Verification"]
+        CI1["Push branch"] --> CI2["Open draft PR"]
+        CI2 --> CI3["Poll CI status"]
+        CI3 --> CI4{"CI green?"}
+        CI4 -- No --> CI5["Read logs, fix, re-push"]
+        CI5 --> CI3
+        CI4 -- Yes --> CI6{"thorough?"}
+        CI6 -- Yes --> CI7["Adversarial self-review"]
+        CI7 --> DONE
+        CI6 -- No --> DONE
+    end
+
+    DONE --> END["📋 End session\nwith handoff notes"]
+
+    style U fill:#f95838,stroke:#ff6b6b,color:#fff
+    style TRUST fill:#f0a500,stroke:#ffd43b,color:#1a1a2e
+    style DONE fill:#007c35,stroke:#51cf66,color:#fff
+    style END fill:#555555,stroke:#999,color:#fff

--- a/docs_src/scripts/mermaid/session-lifecycle.mmd
+++ b/docs_src/scripts/mermaid/session-lifecycle.mmd
@@ -1,0 +1,19 @@
+%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00a6db', 'primaryTextColor': '#fff', 'primaryBorderColor': '#00a6db', 'lineColor': '#56cfe1', 'secondaryColor': '#f95838', 'tertiaryColor': '#1a1a2e', 'noteTextColor': '#e0e0e0', 'noteBkgColor': '#2d2d44', 'fontSize': '14px' }}}%%
+flowchart LR
+    A["🟢 session start"] --> B["🎯 session work #id"]
+    B --> C["📝 session action '...'"]
+    C --> C
+    C --> D{"Context\ncompressed?"}
+    D -- Yes --> E["🔄 Hook restores\nlast breadcrumb"]
+    E --> C
+    D -- No --> F["🏁 session end\n--notes '...'"]
+    F --> G["📋 Handoff notes\nstored"]
+    G --> |"Next session"| A
+
+    style A fill:#007c35,stroke:#51cf66,color:#fff
+    style B fill:#00a6db,stroke:#74c0fc,color:#fff
+    style C fill:#00a6db,stroke:#74c0fc,color:#fff
+    style D fill:#f0a500,stroke:#ffd43b,color:#1a1a2e
+    style E fill:#c77dff,stroke:#d0a9f5,color:#1a1a2e
+    style F fill:#f95838,stroke:#ff6b6b,color:#fff
+    style G fill:#555555,stroke:#999,color:#fff

--- a/docs_src/scripts/vhs/hero-demo.tape
+++ b/docs_src/scripts/vhs/hero-demo.tape
@@ -1,0 +1,41 @@
+# Homepage hero GIF — 30-second crosslink workflow overview
+# Output: docs_src/assets/img/hero-demo.gif
+
+Output ../assets/img/hero-demo.gif
+
+Require crosslink
+
+Set Shell "bash"
+Set FontSize 15
+Set Width 900
+Set Height 500
+Set Padding 20
+Set Theme { "name": "crosslink", "black": "#1a1a2e", "red": "#f95838", "green": "#007c35", "yellow": "#f0a500", "blue": "#00a6db", "magenta": "#c77dff", "cyan": "#56cfe1", "white": "#e0e0e0", "brightBlack": "#555555", "brightRed": "#ff6b6b", "brightGreen": "#51cf66", "brightYellow": "#ffd43b", "brightBlue": "#74c0fc", "brightMagenta": "#d0a9f5", "brightCyan": "#99e9f2", "brightWhite": "#ffffff", "background": "#16161e", "foreground": "#e0e0e0", "selection": "#33467c", "cursor": "#f95838" }
+Set TypingSpeed 40ms
+Set WindowBar Colorful
+Set WindowBarSize 40
+
+# Initialize
+Type "crosslink init"
+Enter
+Sleep 2s
+
+# Start session
+Type "crosslink session start"
+Enter
+Sleep 2s
+
+# Create an issue and start working
+Type `crosslink quick "Fix auth token refresh" -p high -l bug`
+Enter
+Sleep 2s
+
+# Record a breadcrumb
+Type `crosslink session action "Found root cause in refresh_token()"`
+Enter
+Sleep 1.5s
+
+# End with handoff notes
+Type `crosslink session end --notes "Fixed token refresh. Dark mode is next."`
+Enter
+Sleep 3s

--- a/docs_src/scripts/vhs/kickoff.tape
+++ b/docs_src/scripts/vhs/kickoff.tape
@@ -1,0 +1,97 @@
+# Kickoff — autonomous feature agent launch demo
+# Output: docs_src/assets/img/kickoff.gif
+#
+# NOTE: This tape simulates the /kickoff output since it requires
+# tmux and a real Claude session. The commands shown demonstrate
+# the user-facing workflow.
+
+Output ../assets/img/kickoff.gif
+
+Set Shell "bash"
+Set FontSize 14
+Set Width 1000
+Set Height 600
+Set Padding 20
+Set Theme { "name": "crosslink", "black": "#1a1a2e", "red": "#f95838", "green": "#007c35", "yellow": "#f0a500", "blue": "#00a6db", "magenta": "#c77dff", "cyan": "#56cfe1", "white": "#e0e0e0", "brightBlack": "#555555", "brightRed": "#ff6b6b", "brightGreen": "#51cf66", "brightYellow": "#ffd43b", "brightBlue": "#74c0fc", "brightMagenta": "#d0a9f5", "brightCyan": "#99e9f2", "brightWhite": "#ffffff", "background": "#16161e", "foreground": "#e0e0e0", "selection": "#33467c", "cursor": "#f95838" }
+Set TypingSpeed 30ms
+Set WindowBar Colorful
+Set WindowBarSize 40
+
+# Show the kickoff command
+Type "# Launch an autonomous feature agent"
+Enter
+Sleep 1s
+
+Type `echo '/kickoff "add batch retry logic" --verify ci'`
+Enter
+Sleep 2s
+
+# Simulate the output
+Type "echo ''"
+Enter
+Type `echo "Creating feature branch..."`
+Enter
+Sleep 1s
+Type `echo "  Branch:   feature/add-batch-retry-logic"`
+Enter
+Type `echo "  Worktree: .worktrees/add-batch-retry-logic/"`
+Enter
+Type `echo "  Issue:    #42 — add batch retry logic"`
+Enter
+Sleep 1.5s
+Type `echo ""`
+Enter
+Type `echo "Detecting project tools..."`
+Enter
+Type `echo "  Found: Cargo.toml → cargo test, cargo clippy, cargo fmt"`
+Enter
+Sleep 1.5s
+Type `echo ""`
+Enter
+Type `echo "Writing agent prompt → KICKOFF.md"`
+Enter
+Type `echo "Launching tmux session → feat-add-batch-retry-logic"`
+Enter
+Sleep 2s
+Type `echo ""`
+Enter
+Type `echo "Feature agent launched."`
+Enter
+Type `echo ""`
+Enter
+Type `echo "  Worktree: .worktrees/add-batch-retry-logic"`
+Enter
+Type `echo "  Branch:   feature/add-batch-retry-logic"`
+Enter
+Type `echo "  Session:  feat-add-batch-retry-logic"`
+Enter
+Type `echo ""`
+Enter
+Type `echo "  Approve trust:  tmux attach -t feat-add-batch-retry-logic"`
+Enter
+Type `echo "  Check status:   /check feat-add-batch-retry-logic"`
+Enter
+Sleep 4s
+
+# Show checking on it later
+Type ""
+Enter
+Type "# Later — check on the agent's progress"
+Enter
+Sleep 1s
+Type `echo '/check feat-add-batch-retry-logic'`
+Enter
+Sleep 1s
+Type `echo ""`
+Enter
+Type `echo "Session: feat-add-batch-retry-logic"`
+Enter
+Type `echo "Status:  ✓ DONE"`
+Enter
+Type `echo "Issue:   #42 — add batch retry logic"`
+Enter
+Type `echo "Commits: 3 (feat: add retry logic, test: retry tests, fix: edge case)"`
+Enter
+Type `echo "PR:      #87 (draft, CI passing)"`
+Enter
+Sleep 4s

--- a/docs_src/scripts/vhs/multi-agent.tape
+++ b/docs_src/scripts/vhs/multi-agent.tape
@@ -1,0 +1,64 @@
+# Multi-Agent Coordination — lock management demo
+# Output: docs_src/assets/img/multi-agent.gif
+
+Output ../assets/img/multi-agent.gif
+
+Require crosslink
+
+Set Shell "bash"
+Set FontSize 14
+Set Width 950
+Set Height 550
+Set Padding 20
+Set Theme { "name": "crosslink", "black": "#1a1a2e", "red": "#f95838", "green": "#007c35", "yellow": "#f0a500", "blue": "#00a6db", "magenta": "#c77dff", "cyan": "#56cfe1", "white": "#e0e0e0", "brightBlack": "#555555", "brightRed": "#ff6b6b", "brightGreen": "#51cf66", "brightYellow": "#ffd43b", "brightBlue": "#74c0fc", "brightMagenta": "#d0a9f5", "brightCyan": "#99e9f2", "brightWhite": "#ffffff", "background": "#16161e", "foreground": "#e0e0e0", "selection": "#33467c", "cursor": "#f95838" }
+Set TypingSpeed 35ms
+Set WindowBar Colorful
+Set WindowBarSize 40
+
+# Register an agent
+Type "# Register this machine as an agent"
+Enter
+Type `crosslink agent init agent-alpha -d "Frontend specialist"`
+Enter
+Sleep 2s
+
+# Check agent status
+Type "crosslink agent status"
+Enter
+Sleep 2s
+
+# List locks
+Type "# See which issues are taken"
+Enter
+Type "crosslink locks list"
+Enter
+Sleep 2s
+
+# Check a specific issue
+Type "crosslink locks check 5"
+Enter
+Sleep 1.5s
+
+# Start working — lock is auto-claimed
+Type "# Start work — lock auto-claimed"
+Enter
+Type "crosslink session work 3"
+Enter
+Sleep 2s
+
+# Show locks again
+Type "crosslink locks list"
+Enter
+Sleep 2s
+
+# Sync coordination state
+Type "# Sync with other agents"
+Enter
+Type "crosslink sync"
+Enter
+Sleep 2s
+
+# Next — skips locked issues
+Type "crosslink next"
+Enter
+Sleep 3s

--- a/docs_src/scripts/vhs/quickstart.tape
+++ b/docs_src/scripts/vhs/quickstart.tape
@@ -1,0 +1,61 @@
+# Quick Start walkthrough — step-by-step tutorial
+# Output: docs_src/assets/img/quickstart.gif
+
+Output ../assets/img/quickstart.gif
+
+Require crosslink
+
+Set Shell "bash"
+Set FontSize 14
+Set Width 950
+Set Height 550
+Set Padding 20
+Set Theme { "name": "crosslink", "black": "#1a1a2e", "red": "#f95838", "green": "#007c35", "yellow": "#f0a500", "blue": "#00a6db", "magenta": "#c77dff", "cyan": "#56cfe1", "white": "#e0e0e0", "brightBlack": "#555555", "brightRed": "#ff6b6b", "brightGreen": "#51cf66", "brightYellow": "#ffd43b", "brightBlue": "#74c0fc", "brightMagenta": "#d0a9f5", "brightCyan": "#99e9f2", "brightWhite": "#ffffff", "background": "#16161e", "foreground": "#e0e0e0", "selection": "#33467c", "cursor": "#f95838" }
+Set TypingSpeed 35ms
+Set WindowBar Colorful
+Set WindowBarSize 40
+
+# Step 1: Install
+Type "# Step 1: Install crosslink"
+Enter
+Type "cargo install crosslink"
+Enter
+Sleep 2s
+
+# Step 2: Initialize
+Type "# Step 2: Initialize in your project"
+Enter
+Type "crosslink init"
+Enter
+Sleep 2s
+
+# Step 3: Start session
+Type "# Step 3: Start a session"
+Enter
+Type "crosslink session start"
+Enter
+Sleep 2.5s
+
+# Step 4: Create issues
+Type "# Step 4: Create and start working on an issue"
+Enter
+Type `crosslink quick "Fix login bug" -p high -l bug`
+Enter
+Sleep 2s
+
+# Step 5: Work on issues
+Type "# Step 5: Record breadcrumbs as you work"
+Enter
+Type `crosslink session action "Found root cause in refresh_token()"`
+Enter
+Sleep 1.5s
+Type `crosslink comment 1 "Token wasn't refreshed on 401 responses"`
+Enter
+Sleep 2s
+
+# Step 6: End session
+Type "# Step 6: End with handoff notes"
+Enter
+Type `crosslink session end --notes "Fixed auth bug #1. Dark mode (#2) is next."`
+Enter
+Sleep 3s

--- a/docs_src/scripts/vhs/session-workflow.tape
+++ b/docs_src/scripts/vhs/session-workflow.tape
@@ -1,0 +1,66 @@
+# Session Workflow — full lifecycle demo with handoff
+# Output: docs_src/assets/img/session-workflow.gif
+
+Output ../assets/img/session-workflow.gif
+
+Require crosslink
+
+Set Shell "bash"
+Set FontSize 14
+Set Width 950
+Set Height 600
+Set Padding 20
+Set Theme { "name": "crosslink", "black": "#1a1a2e", "red": "#f95838", "green": "#007c35", "yellow": "#f0a500", "blue": "#00a6db", "magenta": "#c77dff", "cyan": "#56cfe1", "white": "#e0e0e0", "brightBlack": "#555555", "brightRed": "#ff6b6b", "brightGreen": "#51cf66", "brightYellow": "#ffd43b", "brightBlue": "#74c0fc", "brightMagenta": "#d0a9f5", "brightCyan": "#99e9f2", "brightWhite": "#ffffff", "background": "#16161e", "foreground": "#e0e0e0", "selection": "#33467c", "cursor": "#f95838" }
+Set TypingSpeed 35ms
+Set WindowBar Colorful
+Set WindowBarSize 40
+
+# --- Session 1 ---
+Type "# ─── Session 1: Start work ───"
+Enter
+Sleep 1s
+
+Type "crosslink session start"
+Enter
+Sleep 2s
+
+Type `crosslink quick "Implement dark mode" -p medium -l feature`
+Enter
+Sleep 1.5s
+
+Type `crosslink session action "Added ThemeProvider wrapper to App.tsx"`
+Enter
+Sleep 1s
+
+Type `crosslink session action "Dark palette complete, testing toggle"`
+Enter
+Sleep 1s
+
+Type `crosslink session end --notes "Dark mode 80% done. Toggle works, need to persist preference in localStorage."`
+Enter
+Sleep 3s
+
+# --- Session 2: Pick up where we left off ---
+Type "# ─── Session 2: Continue from handoff ───"
+Enter
+Sleep 1s
+
+Type "crosslink session start"
+Enter
+Sleep 3s
+
+Type "crosslink session work 1"
+Enter
+Sleep 1.5s
+
+Type `crosslink session action "Added localStorage persistence for theme preference"`
+Enter
+Sleep 1s
+
+Type "crosslink close 1"
+Enter
+Sleep 1.5s
+
+Type `crosslink session end --notes "Dark mode complete and shipped. Next: notifications (#2)."`
+Enter
+Sleep 3s

--- a/docs_src/scripts/vhs/tracking-modes.tape
+++ b/docs_src/scripts/vhs/tracking-modes.tape
@@ -1,0 +1,49 @@
+# Tracking Modes — strict vs normal vs relaxed comparison
+# Output: docs_src/assets/img/tracking-modes.gif
+
+Output ../assets/img/tracking-modes.gif
+
+Require crosslink
+
+Set Shell "bash"
+Set FontSize 14
+Set Width 950
+Set Height 550
+Set Padding 20
+Set Theme { "name": "crosslink", "black": "#1a1a2e", "red": "#f95838", "green": "#007c35", "yellow": "#f0a500", "blue": "#00a6db", "magenta": "#c77dff", "cyan": "#56cfe1", "white": "#e0e0e0", "brightBlack": "#555555", "brightRed": "#ff6b6b", "brightGreen": "#51cf66", "brightYellow": "#ffd43b", "brightBlue": "#74c0fc", "brightMagenta": "#d0a9f5", "brightCyan": "#99e9f2", "brightWhite": "#ffffff", "background": "#16161e", "foreground": "#e0e0e0", "selection": "#33467c", "cursor": "#f95838" }
+Set TypingSpeed 35ms
+Set WindowBar Colorful
+Set WindowBarSize 40
+
+# Show current config
+Type "# View current tracking mode"
+Enter
+Type "crosslink config get tracking_mode"
+Enter
+Sleep 2s
+
+# Show config file
+Type `cat .crosslink/hook-config.json | head -3`
+Enter
+Sleep 2s
+
+# Switch modes
+Type "# Switch to normal mode"
+Enter
+Type `crosslink config set tracking_mode normal`
+Enter
+Sleep 2s
+
+# Switch to relaxed
+Type "# Switch to relaxed mode"
+Enter
+Type `crosslink config set tracking_mode relaxed`
+Enter
+Sleep 2s
+
+# Back to strict
+Type "# Back to strict"
+Enter
+Type `crosslink config set tracking_mode strict`
+Enter
+Sleep 3s


### PR DESCRIPTION
## Summary
- Add `docs_src/scripts/` directory with VHS `.tape` files for generating terminal GIFs
- 6 tape files covering: homepage hero, quickstart walkthrough, session lifecycle, kickoff flow, multi-agent coordination, and tracking modes
- README with prerequisites (`brew install vhs`, `brew install homeport/tap/termshot`) and usage instructions

## Context
The docs site currently has zero images. These scripts generate branded terminal GIFs (using crosslink color palette) that can be embedded in the Quarto docs pages. Mermaid diagrams and termshot scripts will follow in a subsequent PR.

## Test plan
- [ ] Run `vhs docs_src/scripts/vhs/hero-demo.tape` and verify GIF output
- [ ] Verify GIF dimensions and theme match the docs site branding
- [ ] Check that all 6 tape files reference correct crosslink commands

Generated with [Claude Code](https://claude.com/claude-code)