### PR TITLE
feat: add rules.local/ directory for gitignored local rule overrides

### DIFF
--- a/crosslink/resources/claude/hooks/pre-web-check.py
+++ b/crosslink/resources/claude/hooks/pre-web-check.py
@@ -47,10 +47,19 @@ def find_crosslink_dir():
 
 
 def load_web_rules(crosslink_dir):
-    """Load web.md rules from .crosslink/rules/."""
+    """Load web.md rules, preferring .crosslink/rules.local/ override."""
     if not crosslink_dir:
         return get_fallback_rules()
 
+    # Check rules.local/ first for a local override
+    local_path = os.path.join(crosslink_dir, 'rules.local', 'web.md')
+    try:
+        with open(local_path, 'r', encoding='utf-8') as f:
+            return f.read().strip()
+    except (OSError, IOError):
+        pass
+
+    # Fall back to rules/
     rules_path = os.path.join(crosslink_dir, 'rules', 'web.md')
     try:
         with open(rules_path, 'r', encoding='utf-8') as f:

--- a/crosslink/resources/claude/hooks/prompt-guard.py
+++ b/crosslink/resources/claude/hooks/prompt-guard.py
@@ -28,10 +28,19 @@ from crosslink_config import (
 )
 
 
-def load_rule_file(rules_dir, filename):
-    """Load a rule file and return its content, or empty string if not found."""
+def load_rule_file(rules_dir, filename, rules_local_dir=None):
+    """Load a rule file, preferring rules.local/ override if present."""
     if not rules_dir:
         return ""
+    # Check rules.local/ first for an override
+    if rules_local_dir:
+        local_path = os.path.join(rules_local_dir, filename)
+        try:
+            with open(local_path, 'r', encoding='utf-8') as f:
+                return f.read().strip()
+        except (OSError, IOError):
+            pass
+    # Fall back to rules/
     path = os.path.join(rules_dir, filename)
     try:
         with open(path, 'r', encoding='utf-8') as f:
@@ -41,19 +50,24 @@ def load_rule_file(rules_dir, filename):
 
 
 def load_all_rules(crosslink_dir):
-    """Load all rule files from .crosslink/rules/."""
+    """Load all rule files from .crosslink/rules/, with .crosslink/rules.local/ overrides."""
     if not crosslink_dir:
         return {}, "", ""
 
     rules_dir = os.path.join(crosslink_dir, 'rules')
-    if not os.path.isdir(rules_dir):
+    rules_local_dir = os.path.join(crosslink_dir, 'rules.local')
+    if not os.path.isdir(rules_dir) and not os.path.isdir(rules_local_dir):
         return {}, "", ""
 
+    # Make rules_local_dir None if it doesn't exist, so load_rule_file skips it
+    if not os.path.isdir(rules_local_dir):
+        rules_local_dir = None
+
     # Load global rules
-    global_rules = load_rule_file(rules_dir, 'global.md')
+    global_rules = load_rule_file(rules_dir, 'global.md', rules_local_dir)
 
     # Load project rules
-    project_rules = load_rule_file(rules_dir, 'project.md')
+    project_rules = load_rule_file(rules_dir, 'project.md', rules_local_dir)
 
     # Load language-specific rules
     language_rules = {}
@@ -79,9 +93,27 @@ def load_all_rules(crosslink_dir):
     ]
 
     for filename, lang_name in language_files:
-        content = load_rule_file(rules_dir, filename)
+        content = load_rule_file(rules_dir, filename, rules_local_dir)
         if content:
             language_rules[lang_name] = content
+
+    # Load additive rules from rules.local/ (files not in the standard set)
+    if rules_local_dir:
+        standard_files = {f for f, _ in language_files}
+        standard_files.update({'global.md', 'project.md', 'knowledge.md',
+                               'sanitize-patterns.txt', 'web.md',
+                               'tracking-strict.md', 'tracking-normal.md',
+                               'tracking-relaxed.md'})
+        try:
+            for entry in os.listdir(rules_local_dir):
+                if entry not in standard_files and entry.endswith('.md'):
+                    content = load_rule_file(rules_local_dir, entry)
+                    if content:
+                        # Use filename without extension as language name
+                        lang_name = os.path.splitext(entry)[0].replace('-', '/').title()
+                        language_rules[lang_name] = content
+        except OSError:
+            pass
 
     return language_rules, global_rules, project_rules
 
@@ -520,12 +552,22 @@ def mark_full_guard_sent(crosslink_dir):
 
 
 def load_tracking_rules(crosslink_dir, tracking_mode):
-    """Load the tracking rules markdown file for the given mode."""
+    """Load the tracking rules markdown file for the given mode.
+
+    Checks rules.local/ first for a local override, then falls back to rules/.
+    """
     if not crosslink_dir:
         return ""
-    rules_dir = os.path.join(crosslink_dir, "rules")
     filename = f"tracking-{tracking_mode}.md"
-    path = os.path.join(rules_dir, filename)
+    # Check rules.local/ first
+    local_path = os.path.join(crosslink_dir, "rules.local", filename)
+    try:
+        with open(local_path, "r", encoding="utf-8") as f:
+            return f.read().strip()
+    except (OSError, IOError):
+        pass
+    # Fall back to rules/
+    path = os.path.join(crosslink_dir, "rules", filename)
     try:
         with open(path, "r", encoding="utf-8") as f:
             return f.read().strip()

--- a/crosslink/src/commands/context.rs
+++ b/crosslink/src/commands/context.rs
@@ -88,9 +88,24 @@ fn measure(crosslink_dir: &Path, verbose: bool) -> Result<()> {
     // Detect active languages
     let active_langs = detect_active_languages(project_root);
 
+    let rules_local_dir = crosslink_dir.join("rules.local");
+
     println!("\n## Rule files (.crosslink/rules/)");
     println!("{:<35} {:>8} {:>8}  STATUS", "FILE", "BYTES", "~TOKENS");
     println!("{}", "-".repeat(65));
+
+    // Collect overridden filenames from rules.local/
+    let local_overrides: std::collections::HashSet<String> = if rules_local_dir.is_dir() {
+        fs::read_dir(&rules_local_dir)
+            .ok()
+            .into_iter()
+            .flatten()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .collect()
+    } else {
+        std::collections::HashSet::new()
+    };
 
     if rules_dir.is_dir() {
         let mut entries: Vec<_> = fs::read_dir(&rules_dir)
@@ -108,7 +123,18 @@ fn measure(crosslink_dir: &Path, verbose: bool) -> Result<()> {
         for entry in &entries {
             let path = entry.path();
             let filename = entry.file_name().to_string_lossy().to_string();
-            let size = fs::metadata(&path).map(|m| m.len() as usize).unwrap_or(0);
+
+            // If overridden by rules.local/, show the local version's size
+            let (size, suffix) = if local_overrides.contains(&filename) {
+                let local_path = rules_local_dir.join(&filename);
+                let s = fs::metadata(&local_path)
+                    .map(|m| m.len() as usize)
+                    .unwrap_or(0);
+                (s, " (local)")
+            } else {
+                let s = fs::metadata(&path).map(|m| m.len() as usize).unwrap_or(0);
+                (s, "")
+            };
             let tokens = size / 4;
             total_rules += size;
 
@@ -121,7 +147,52 @@ fn measure(crosslink_dir: &Path, verbose: bool) -> Result<()> {
                 "dormant"
             };
 
-            println!("{:<35} {:>8} {:>8}  {}", filename, size, tokens, status);
+            println!(
+                "{:<35} {:>8} {:>8}  {}{}",
+                filename, size, tokens, status, suffix
+            );
+        }
+    }
+
+    // Show additive rules from rules.local/ (files not present in rules/)
+    if rules_local_dir.is_dir() {
+        let base_files: std::collections::HashSet<String> = if rules_dir.is_dir() {
+            fs::read_dir(&rules_dir)
+                .ok()
+                .into_iter()
+                .flatten()
+                .filter_map(|e| e.ok())
+                .map(|e| e.file_name().to_string_lossy().to_string())
+                .collect()
+        } else {
+            std::collections::HashSet::new()
+        };
+
+        let mut local_entries: Vec<_> = fs::read_dir(&rules_local_dir)
+            .ok()
+            .into_iter()
+            .flatten()
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                let name = e.file_name().to_string_lossy().to_string();
+                !base_files.contains(&name)
+                    && e.path()
+                        .extension()
+                        .map(|ext| ext == "md" || ext == "txt")
+                        .unwrap_or(false)
+            })
+            .collect();
+        local_entries.sort_by_key(|e| e.file_name());
+
+        for entry in &local_entries {
+            let path = entry.path();
+            let filename = entry.file_name().to_string_lossy().to_string();
+            let size = fs::metadata(&path).map(|m| m.len() as usize).unwrap_or(0);
+            let tokens = size / 4;
+            total_rules += size;
+            active_rules += size;
+
+            println!("{:<35} {:>8} {:>8}  active (local)", filename, size, tokens);
         }
     }
 

--- a/crosslink/src/commands/init.rs
+++ b/crosslink/src/commands/init.rs
@@ -415,6 +415,7 @@ const GITIGNORE_MANAGED_SECTION: &str = "\
 .crosslink/.cache/
 .crosslink/hook-config.local.json
 .crosslink/integrations/
+.crosslink/rules.local/
 
 # .crosslink/ — DO track these (project-level policy):
 #   .crosslink/hook-config.json   — shared team configuration
@@ -1363,8 +1364,9 @@ pub fn run(path: &Path, opts: &InitOpts<'_>) -> Result<()> {
              keys/\n\
              integrations/\n\
              \n\
-             # Machine-local hook overrides\n\
-             hook-config.local.json\n",
+             # Machine-local overrides\n\
+             hook-config.local.json\n\
+             rules.local/\n",
         )
         .context("Failed to write .crosslink/.gitignore")?;
     }
@@ -1390,6 +1392,13 @@ pub fn run(path: &Path, opts: &InitOpts<'_>) -> Result<()> {
         } else {
             ui.step_ok(Some(&format!("{} files", RULE_FILES.len())));
         }
+    }
+
+    // Create rules.local directory for machine-local rule overrides
+    let rules_local_dir = crosslink_dir.join("rules.local");
+    if !rules_local_dir.exists() {
+        fs::create_dir_all(&rules_local_dir)
+            .context("Failed to create .crosslink/rules.local directory")?;
     }
 
     // Detect or use provided Python prefix (needed for settings.json and cpitd install)

--- a/crosslink/src/commands/workflow.rs
+++ b/crosslink/src/commands/workflow.rs
@@ -153,7 +153,17 @@ pub fn diff(
             println!("=== Rules ===");
         }
         let rules_dir = crosslink_dir.join("rules");
+        let rules_local_dir = crosslink_dir.join("rules.local");
         for (filename, default_content) in init::RULE_FILES {
+            // Check if this rule is overridden by rules.local/
+            let local_path = rules_local_dir.join(filename);
+            if local_path.exists() {
+                if !check {
+                    println!("  rules/{}: overridden by rules.local/", filename);
+                }
+                // Don't flag drift for files that have a local override
+                continue;
+            }
             let path = rules_dir.join(filename);
             let result = compare_file(&path, default_content);
             if !check {
@@ -162,6 +172,24 @@ pub fn diff(
             if let CompareResult::Customized(_) = result {
                 if check && !has_custom_marker(&path) {
                     drifted.push(format!(".crosslink/rules/{}", filename));
+                }
+            }
+        }
+        // Show additive local rules
+        if rules_local_dir.is_dir() {
+            let standard_files: std::collections::HashSet<&str> =
+                init::RULE_FILES.iter().map(|(f, _)| *f).collect();
+            if let Ok(entries) = std::fs::read_dir(&rules_local_dir) {
+                let mut local_only: Vec<_> = entries
+                    .filter_map(|e| e.ok())
+                    .filter(|e| !standard_files.contains(e.file_name().to_str().unwrap_or("")))
+                    .collect();
+                local_only.sort_by_key(|e| e.file_name());
+                for entry in &local_only {
+                    let name = entry.file_name();
+                    if !check {
+                        println!("  rules.local/{}: additive", name.to_string_lossy());
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Add `.crosslink/rules.local/` as a machine-local override layer alongside the shared `.crosslink/rules/` directory
- Files in `rules.local/` with the same name as those in `rules/` override them entirely; new files are additive
- `crosslink init` creates the `rules.local/` directory and both `.gitignore` files are updated to ignore it

## Changes

- **init.rs**: Create `rules.local/` on init, add to root and inner `.gitignore` managed sections
- **prompt-guard.py**: `load_rule_file()` checks `rules.local/` first; `load_all_rules()` picks up additive local-only `.md` files; `load_tracking_rules()` checks `rules.local/` first
- **pre-web-check.py**: `load_web_rules()` checks `rules.local/` first
- **context.rs**: Show `(local)` suffix for overridden rules in `crosslink context measure`
- **workflow.rs**: Skip drift flagging for locally-overridden rules, show additive local rules

## Test plan

- [x] `cargo test` — 149 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Manual: run `crosslink init` and verify `rules.local/` is created
- [ ] Manual: place a file in `rules.local/` and verify it overrides the `rules/` version
- [ ] Manual: run `crosslink workflow diff` and verify overridden files show correctly

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)