### PR TITLE
ci: restrict fuzz tests to release branches and PRs targeting main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,7 @@ jobs:
     needs: test
     name: Fuzz Tests
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/heads/release/') || (github.event_name == 'pull_request' && github.base_ref == 'main')
     defaults:
       run:
         working-directory: crosslink


### PR DESCRIPTION
## Summary
- Add branch guard to fuzz smoke test job in `ci.yml`, matching the existing proptest restriction from #228
- Fuzz tests now only run on `release/**` pushes and PRs targeting `main`
- Skipped on `develop` pushes and feature branch PRs to `develop`

Closes #238

## Test plan
- [x] Verify `if` condition matches proptest job exactly
- [x] CI on this PR should skip the fuzz job (PR targets develop, not main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)