### PR TITLE
fix: add pre-flight check for required external commands in kickoff

### DIFF
--- a/crosslink/src/commands/kickoff.rs
+++ b/crosslink/src/commands/kickoff.rs
@@ -940,10 +940,7 @@ fn preflight_check(container: &ContainerMode, need_gh: bool) -> Result<()> {
         });
     } else {
         let (name, hint): (&'static str, &'static str) = match container {
-            ContainerMode::Docker => (
-                "docker",
-                "install from https://docs.docker.com/get-docker/",
-            ),
+            ContainerMode::Docker => ("docker", "install from https://docs.docker.com/get-docker/"),
             ContainerMode::Podman => (
                 "podman",
                 "install from https://podman.io/getting-started/installation",
@@ -1256,8 +1253,7 @@ pub fn run(
 ) -> Result<()> {
     // 1. Pre-flight: check all required external commands (skip for dry-run)
     if !opts.dry_run {
-        let need_gh =
-            opts.verify == VerifyLevel::Ci || opts.verify == VerifyLevel::Thorough;
+        let need_gh = opts.verify == VerifyLevel::Ci || opts.verify == VerifyLevel::Thorough;
         preflight_check(&opts.container, need_gh)?;
     }
 


### PR DESCRIPTION
## Summary

- Adds `preflight_check()` that validates **all** required external commands before creating worktree/branch/session, reporting every missing dependency at once with platform-specific install hints
- Adds missing `timeout` check for local mode (was silently failing on macOS)
- Makes `command_available()` cross-platform (`which` on Unix, `where.exe` on Windows)
- Applies to both `kickoff run` and `kickoff plan` entry points

### Install hints by platform

| Command | macOS | Linux |
|---------|-------|-------|
| `timeout` | `brew install coreutils` + alias | `apt install coreutils` |
| `tmux` | `brew install tmux` | `apt install tmux` |
| `claude` | docs link | docs link |
| `gh` | `brew install gh` | cli.github.com |

## Test plan

- [x] All 149 integration tests pass
- [x] 4 new unit tests for `preflight_check` and `command_available`
- [x] Manual test on macOS with `timeout` missing — should show install hint

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)