### PR TITLE
feat: add unified preflight check with macOS gtimeout support for kickoff command

### DIFF
--- a/crosslink/src/commands/kickoff.rs
+++ b/crosslink/src/commands/kickoff.rs
@@ -1392,6 +1392,9 @@ pub fn run(
     // 8. Initialize crosslink + agent in worktree (only for real launches)
     let agent_id = init_worktree_agent(&worktree_dir, crosslink_dir, &slug)?;
 
+    // preflight is guaranteed Some after the dry-run early return above
+    let preflight = preflight.context("preflight check was skipped unexpectedly")?;
+
     // 9. Launch the agent
     let allowed_tools = build_allowed_tools(&conventions, &opts.verify);
 
@@ -1411,7 +1414,7 @@ pub fn run(
                 opts.model,
                 &allowed_tools,
                 opts.timeout,
-                preflight.as_ref().unwrap().timeout_cmd,
+                preflight.timeout_cmd,
             )?;
 
             // 10. Report
@@ -1917,6 +1920,9 @@ pub fn plan(crosslink_dir: &Path, db: &Database, opts: &PlanOpts) -> Result<()> 
     // 7. Init worktree agent
     let agent_id = init_worktree_agent(&worktree_dir, crosslink_dir, &slug)?;
 
+    // preflight is guaranteed Some after the dry-run early return above
+    let preflight = preflight.context("preflight check was skipped unexpectedly")?;
+
     // 8. Launch with read-only tools
     let allowed_tools = build_allowed_tools_plan();
     let mut session_name = tmux_session_name(&slug);
@@ -1927,7 +1933,7 @@ pub fn plan(crosslink_dir: &Path, db: &Database, opts: &PlanOpts) -> Result<()> 
 
     // Plan mode reads PLAN_KICKOFF.md instead of KICKOFF.md
     let timeout_secs = opts.timeout.as_secs();
-    let timeout_cmd = preflight.as_ref().unwrap().timeout_cmd;
+    let timeout_cmd = preflight.timeout_cmd;
     let cmd = format!(
         "{} {}s env -u CLAUDECODE claude --model {} --allowedTools '{}' -- \"$(cat PLAN_KICKOFF.md)\"",
         timeout_cmd, timeout_secs, opts.model, allowed_tools


### PR DESCRIPTION
## Summary

- Consolidate inline prerequisite checks in `run()` and `plan()` into a unified `preflight_check()` function
- Add `resolve_timeout_command()` for macOS `gtimeout` support (GNU coreutils via Homebrew)
- Introduce `PreflightResult` struct that threads `timeout_cmd` through to `launch_local()` and `plan()`
- Provide detailed platform-specific install instructions for all missing commands
- Accumulate multiple missing-command errors into a single report instead of failing on the first one

## Test plan

- [x] All 1081 unit tests pass
- [x] All 149 integration tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Existing kickoff dry-run tests remain intact

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)