### PR TITLE
fix: degrade gracefully when gpg.ssh.allowedSignersFile is not configured

### DIFF
--- a/crosslink/src/sync.rs
+++ b/crosslink/src/sync.rs
@@ -565,6 +565,12 @@ impl SyncManager {
                 SignatureVerification::Unsigned {
                     commit: commit.to_string(),
                 }
+            } else if stderr.contains("allowedSignersFile needs to be configured") {
+                // gpg.ssh.allowedSignersFile not set — verification is not possible,
+                // but this doesn't mean the signature is invalid. Degrade gracefully.
+                SignatureVerification::Unsigned {
+                    commit: commit.to_string(),
+                }
             } else {
                 SignatureVerification::Invalid {
                     commit: commit.to_string(),
@@ -679,6 +685,9 @@ impl SyncManager {
             })
         } else if stderr.contains("NODATA") || stderr.contains("no signature") || stderr.is_empty()
         {
+            Ok(SignatureVerification::Unsigned { commit })
+        } else if stderr.contains("allowedSignersFile needs to be configured") {
+            // gpg.ssh.allowedSignersFile not set — cannot verify, degrade gracefully
             Ok(SignatureVerification::Unsigned { commit })
         } else {
             Ok(SignatureVerification::Invalid {


### PR DESCRIPTION
## Summary
- Fix false "invalid signature" warnings on every `crosslink sync` when `gpg.ssh.allowedSignersFile` is not configured in git
- Detect the specific git error and classify commits as `Unsigned` (unverifiable) instead of `Invalid` (signature known bad)
- Fixes both `verify_recent_commits` and `verify_locks_signature` in `sync.rs`

Closes https://github.com/forecast-bio/crosslink/issues/262

## Test plan
- [x] All 156 existing tests pass
- [x] Clippy clean (`-D warnings`)
- [x] `cargo fmt --check` clean
- [ ] Manual: run `crosslink sync` on a repo without `gpg.ssh.allowedSignersFile` configured — should no longer report invalid signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)