### PR TITLE
Fix kickoff agent key not being published after creation

### DIFF
--- a/crosslink/src/commands/kickoff.rs
+++ b/crosslink/src/commands/kickoff.rs
@@ -1098,6 +1098,34 @@ fn init_worktree_agent(worktree_dir: &Path, crosslink_dir: &Path, slug: &str) ->
                 true, // no-key: inherit parent's key
                 false,
             );
+
+            // Copy parent's SSH key info into the new agent config and publish
+            // the key under the new agent ID so `crosslink trust approve` can find it.
+            if let Some(parent_config) = AgentConfig::load(crosslink_dir)? {
+                if let Some(ref public_key) = parent_config.ssh_public_key {
+                    if let Ok(Some(mut child_config)) = AgentConfig::load(&wt_crosslink) {
+                        child_config.ssh_key_path = parent_config.ssh_key_path.clone();
+                        child_config.ssh_fingerprint = parent_config.ssh_fingerprint.clone();
+                        child_config.ssh_public_key = Some(public_key.clone());
+
+                        let agent_json = wt_crosslink.join("agent.json");
+                        if let Ok(json) = serde_json::to_string_pretty(&child_config) {
+                            let _ = std::fs::write(&agent_json, json);
+                        }
+
+                        // Publish the parent's public key under the new agent ID
+                        if let Err(e) =
+                            super::trust::publish_agent_key(&wt_crosslink, &agent_id, public_key)
+                        {
+                            eprintln!(
+                                "Warning: Could not publish key for agent '{}': {}",
+                                agent_id, e
+                            );
+                            eprintln!("Key will be auto-published on next `crosslink sync`.");
+                        }
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- When kickoff creates a child agent with `no_key: true` (inheriting the parent's key), the parent's public key was never published under the new agent ID to `trust/keys/<agent-id>.pub`
- This caused `crosslink trust approve <agent-id>` to fail with "No published key for agent"
- After `agent::init`, we now copy the parent's SSH key info into the child config and call `publish_agent_key()` to publish it under the new agent ID

Fixes #261

## Test plan
- [x] All 156 tests pass
- [x] Clippy clean (`cargo clippy -- -D warnings`)
- [x] `cargo fmt --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)