### PR TITLE
Add custom sandbox wrapper support for agent isolation

### DIFF
--- a/crosslink/src/commands/kickoff.rs
+++ b/crosslink/src/commands/kickoff.rs
@@ -1613,7 +1613,11 @@ pub fn run(
 ) -> Result<()> {
     // 1. Pre-flight: validate all required external commands are present
     let preflight = if !opts.dry_run {
-        Some(preflight_check(&opts.container, &opts.verify, crosslink_dir)?)
+        Some(preflight_check(
+            &opts.container,
+            &opts.verify,
+            crosslink_dir,
+        )?)
     } else {
         None
     };


### PR DESCRIPTION
## Summary
- Adds `sandbox.command` config in `hook-config.json` that wraps the claude invocation inside the local tmux mode, enabling lightweight isolation tools (Bubblewrap, Firejail, systemd-run, etc.) without requiring Docker
- Extracts `build_agent_command()` helper shared by `launch_local()` and `plan()`, reducing command-building duplication
- Preflight validates the sandbox binary exists on PATH when configured
- `{{worktree}}` template variable in the sandbox command expands to the actual worktree path

Closes #265

## Test plan
- [x] Configure `sandbox.command` in hook-config.json, run `crosslink kickoff run` — verify sandbox wraps the claude invocation
- [x] Run without `sandbox.command` configured — verify behavior is identical to before
- [x] Configure a nonexistent sandbox binary — verify preflight check fails with clear error
- [x] Run `crosslink kickoff plan` with sandbox configured — verify it also wraps correctly
- [x] Verify `cargo test` passes (156 tests, 8 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)