### PR TITLE
Add hook-based heartbeats for kickoff agent liveness

### DIFF
--- a/crosslink/resources/claude/hooks/heartbeat.py
+++ b/crosslink/resources/claude/hooks/heartbeat.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""
+PostToolUse hook that pushes agent heartbeats on a throttled interval.
+
+Fires on every tool call but only invokes `crosslink heartbeat` if at least
+2 minutes have elapsed since the last push. This gives accurate liveness
+detection: heartbeats flow when Claude is actively working, and stop when
+it hangs — which is exactly the staleness signal lock detection needs.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+HEARTBEAT_INTERVAL_SECONDS = 120  # 2 minutes
+
+
+def main():
+    # Find .crosslink directory
+    cwd = os.getcwd()
+    crosslink_dir = None
+    current = cwd
+    for _ in range(10):
+        candidate = os.path.join(current, ".crosslink")
+        if os.path.isdir(candidate):
+            crosslink_dir = candidate
+            break
+        parent = os.path.dirname(current)
+        if parent == current:
+            break
+        current = parent
+
+    if not crosslink_dir:
+        sys.exit(0)
+
+    # Only push heartbeats if we're in an agent context (agent.json exists)
+    if not os.path.exists(os.path.join(crosslink_dir, "agent.json")):
+        sys.exit(0)
+
+    # Throttle: check timestamp file
+    cache_dir = os.path.join(crosslink_dir, ".cache")
+    stamp_file = os.path.join(cache_dir, "last-heartbeat")
+
+    now = time.time()
+    try:
+        if os.path.exists(stamp_file):
+            last = os.path.getmtime(stamp_file)
+            if now - last < HEARTBEAT_INTERVAL_SECONDS:
+                sys.exit(0)
+    except OSError:
+        pass
+
+    # Update timestamp before pushing (avoid thundering herd on slow push)
+    try:
+        os.makedirs(cache_dir, exist_ok=True)
+        with open(stamp_file, "w") as f:
+            f.write(str(now))
+    except OSError:
+        pass
+
+    # Push heartbeat in background (don't block the tool call)
+    try:
+        subprocess.Popen(
+            ["crosslink", "heartbeat"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError:
+        pass
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/crosslink/resources/claude/settings.json
+++ b/crosslink/resources/claude/settings.json
@@ -48,6 +48,15 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "HOOK=\"$(git rev-parse --show-toplevel 2>/dev/null)/.claude/hooks/heartbeat.py\"; if [ -f \"$HOOK\" ]; then __PYTHON_PREFIX__ \"$HOOK\"; else exit 0; fi",
+            "timeout": 3
+          }
+        ]
       }
     ],
     "SessionStart": [

--- a/crosslink/src/commands/init.rs
+++ b/crosslink/src/commands/init.rs
@@ -295,6 +295,7 @@ pub(crate) const PRE_WEB_CHECK_PY: &str =
 pub(crate) const WORK_CHECK_PY: &str = include_str!("../../resources/claude/hooks/work-check.py");
 pub(crate) const CROSSLINK_CONFIG_PY: &str =
     include_str!("../../resources/claude/hooks/crosslink_config.py");
+pub(crate) const HEARTBEAT_PY: &str = include_str!("../../resources/claude/hooks/heartbeat.py");
 
 // Embed MCP servers
 const SAFE_FETCH_SERVER_PY: &str = include_str!("../../resources/claude/mcp/safe-fetch-server.py");
@@ -1426,6 +1427,8 @@ pub fn run(path: &Path, opts: &InitOpts<'_>) -> Result<()> {
             .context("Failed to write work-check.py")?;
         fs::write(hooks_dir.join("crosslink_config.py"), CROSSLINK_CONFIG_PY)
             .context("Failed to write crosslink_config.py")?;
+        fs::write(hooks_dir.join("heartbeat.py"), HEARTBEAT_PY)
+            .context("Failed to write heartbeat.py")?;
 
         let mcp_dir = claude_dir.join("mcp");
         fs::create_dir_all(&mcp_dir).context("Failed to create .claude/mcp directory")?;

--- a/crosslink/src/commands/workflow.rs
+++ b/crosslink/src/commands/workflow.rs
@@ -34,6 +34,7 @@ const HOOK_FILES: &[(&str, &str)] = &[
     ("session-start.py", init::SESSION_START_PY),
     ("pre-web-check.py", init::PRE_WEB_CHECK_PY),
     ("work-check.py", init::WORK_CHECK_PY),
+    ("heartbeat.py", init::HEARTBEAT_PY),
 ];
 
 /// The marker comment that acknowledges intentional customization.

--- a/crosslink/src/main.rs
+++ b/crosslink/src/main.rs
@@ -406,6 +406,9 @@ enum Commands {
         action: LocksCommands,
     },
 
+    /// Push a heartbeat for the current agent (used by hooks)
+    Heartbeat,
+
     /// Sync locks and issue state from remote
     Sync,
 
@@ -1632,6 +1635,28 @@ fn main() -> Result<()> {
             let crosslink_dir = find_crosslink_dir()?;
             let db = get_db()?;
             commands::locks_cmd::run(action, &crosslink_dir, &db, cli.json)
+        }
+
+        Commands::Heartbeat => {
+            let crosslink_dir = find_crosslink_dir()?;
+            let agent = crate::identity::AgentConfig::load(&crosslink_dir)?;
+            match agent {
+                Some(agent) => {
+                    let sync = crate::sync::SyncManager::new(&crosslink_dir)?;
+                    let _ = sync.init_cache();
+                    // Read active issue from session, if any
+                    let db = get_db()?;
+                    let active_issue = db
+                        .get_current_session_for_agent(None)?
+                        .and_then(|s| s.active_issue_id);
+                    sync.push_heartbeat(&agent, active_issue)?;
+                    Ok(())
+                }
+                None => {
+                    // No agent config — not an agent context, silently succeed
+                    Ok(())
+                }
+            }
         }
 
         Commands::Sync => {


### PR DESCRIPTION
## Summary
- Kickoff agents never started the daemon, so `push_heartbeat()` was never called and locks were immediately considered stale
- Add a PostToolUse hook that pushes heartbeats throttled to every 2 minutes — strictly better than daemon-based heartbeats because they only flow when Claude is actively making tool calls
- Add `crosslink heartbeat` CLI command as the lightweight backend
- Registered in settings.json, embedded/deployed via init.rs, tracked by workflow drift detection

Closes #275

## Test plan
- [x] Run `crosslink heartbeat` manually in a worktree with agent.json — verify heartbeat file appears in `.crosslink/.hub-cache/heartbeats/`
- [x] Run `crosslink heartbeat` without agent.json — verify it exits silently
- [x] Verify the PostToolUse hook fires during normal Claude usage and throttles correctly (no push if <2min elapsed)
- [x] Run `crosslink init --force` — verify `heartbeat.py` is deployed to `.claude/hooks/`
- [x] Run `crosslink workflow check` — verify heartbeat.py appears in drift detection
- [x] Run `cargo test` (156 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)