### PR TITLE
feat: add watchdog sidecar to nudge idle kickoff agents

### DIFF
--- a/crosslink/src/commands/kickoff.rs
+++ b/crosslink/src/commands/kickoff.rs
@@ -1250,11 +1250,7 @@ fn read_watchdog_config(crosslink_dir: &Path) -> WatchdogConfig {
 
 /// Build the watchdog shell script that monitors heartbeat staleness and
 /// nudges idle agents by sending "continue" via tmux send-keys.
-fn build_watchdog_script(
-    session_name: &str,
-    worktree_dir: &Path,
-    cfg: &WatchdogConfig,
-) -> String {
+fn build_watchdog_script(session_name: &str, worktree_dir: &Path, cfg: &WatchdogConfig) -> String {
     // Use portable stat command — try GNU stat first, fall back to BSD
     format!(
         r#"NUDGES=0
@@ -1287,11 +1283,7 @@ done
 
 /// Spawn a background watchdog process that monitors the agent's heartbeat
 /// and sends "continue" to the tmux session if the agent goes idle.
-fn spawn_watchdog(
-    session_name: &str,
-    worktree_dir: &Path,
-    cfg: &WatchdogConfig,
-) -> Result<()> {
+fn spawn_watchdog(session_name: &str, worktree_dir: &Path, cfg: &WatchdogConfig) -> Result<()> {
     let script = build_watchdog_script(session_name, worktree_dir, cfg);
 
     Command::new("bash")


### PR DESCRIPTION
## Summary

- Spawns a lightweight background bash process alongside each kickoff agent that monitors the heartbeat file for staleness
- When an agent goes idle without writing `.kickoff-status`, the watchdog sends "continue" to the tmux session via `tmux send-keys`
- Configurable via `hook-config.json` `watchdog` key: `staleness_secs`, `max_nudges`, `check_interval_secs`, `grace_period_secs`
- Enabled by default — no new dependencies, no daemon, just a bash sidecar

## How it works

1. `launch_local()` spawns the watchdog after launching the claude agent
2. Watchdog sleeps for a grace period (default 5 min), then checks every 2 min
3. If the heartbeat file (written by the PostToolUse hook) is older than the staleness threshold (default 5 min), it sends "continue working, the task is not yet complete" to the tmux session
4. Stops after max nudges (default 5) or when `.kickoff-status` is written
5. Also applied to `plan` agent launches

## Config example

```json
{
  "watchdog": {
    "enabled": true,
    "staleness_secs": 300,
    "max_nudges": 5,
    "check_interval_secs": 120,
    "grace_period_secs": 300
  }
}
```

## Test plan

- [x] All 156 existing tests pass
- [x] Clippy clean
- [x] New unit tests for `WatchdogConfig` defaults, config parsing, and script generation
- [x] Manual: launch a kickoff agent, verify watchdog process spawns alongside it

Closes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)