### PR TITLE
fix: add Windows clipboard support via clip.exe

### DIFF
--- a/crosslink/src/tui/mod.rs
+++ b/crosslink/src/tui/mod.rs
@@ -85,7 +85,18 @@ pub fn copy_to_clipboard(text: &str) -> bool {
             }
             child.wait()
         });
-    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    #[cfg(target_os = "windows")]
+    let result = std::process::Command::new("clip.exe")
+        .stdin(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            if let Some(ref mut stdin) = child.stdin {
+                stdin.write_all(text.as_bytes())?;
+            }
+            child.wait()
+        });
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
     let result: Result<std::process::ExitStatus, std::io::Error> = Err(std::io::Error::new(
         std::io::ErrorKind::Unsupported,
         "unsupported platform",


### PR DESCRIPTION
## Summary
- Add `#[cfg(target_os = "windows")]` block to `copy_to_clipboard()` using `clip.exe`
- Narrow the catch-all fallback to only truly unsupported platforms
- Fixes unused variable `text` build warning on Windows

## Test plan
- [x] `cargo clippy -- -D warnings` passes clean
- [x] Verify clipboard copy works on Windows with `clip.exe`

🤖 Generated with [Claude Code](https://claude.com/claude-code)