### PR TITLE
feat: include git commit hash in version string

### DIFF
--- a/crosslink/build.rs
+++ b/crosslink/build.rs
@@ -1,7 +1,30 @@
-//! Build script to track include_str! dependencies.
+//! Build script to track include_str! dependencies and inject git metadata.
 //! This ensures cargo rebuilds when template files change.
 
 fn main() {
+    // Inject git commit hash into the binary for `crosslink --version`
+    println!("cargo:rerun-if-changed=../.git/HEAD");
+    println!("cargo:rerun-if-changed=../.git/refs/");
+    if let Ok(output) = std::process::Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+    {
+        if output.status.success() {
+            let hash = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            let dirty = std::process::Command::new("git")
+                .args(["status", "--porcelain"])
+                .output()
+                .map(|o| !o.stdout.is_empty())
+                .unwrap_or(false);
+            let suffix = if dirty {
+                format!("{}+{}-dirty", env!("CARGO_PKG_VERSION"), hash)
+            } else {
+                format!("{}+{}", env!("CARGO_PKG_VERSION"), hash)
+            };
+            println!("cargo:rustc-env=CROSSLINK_VERSION={}", suffix);
+        }
+    }
+
     // Track claude resource files
     println!("cargo:rerun-if-changed=resources/claude/settings.json");
     println!("cargo:rerun-if-changed=resources/claude/hooks/prompt-guard.py");

--- a/crosslink/src/main.rs
+++ b/crosslink/src/main.rs
@@ -35,7 +35,7 @@ use db::Database;
 #[derive(Parser)]
 #[command(name = "crosslink")]
 #[command(about = "A simple, lean issue tracker CLI")]
-#[command(version)]
+#[command(version = option_env!("CROSSLINK_VERSION").unwrap_or(env!("CARGO_PKG_VERSION")))]
 struct Cli {
     /// Quiet mode: only output essential data (IDs, counts)
     #[arg(short, long, global = true)]


### PR DESCRIPTION
## Summary
- `crosslink --version` now shows `crosslink 0.4.0+9bbee93` (or `+9bbee93-dirty` with uncommitted changes)
- Git hash captured at compile time via `build.rs` — zero new dependencies
- Falls back to plain `CARGO_PKG_VERSION` if git is unavailable (e.g. tarball builds)

Closes #339

## Test plan
- [x] `cargo clippy -- -D warnings` clean
- [x] 2142 tests passing
- [x] `crosslink --version` outputs `crosslink 0.4.0+9bbee93-dirty` format
- [x] Graceful fallback when git not available (`option_env!` returns `None`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)