### PR TITLE
fix: prevent swarm agents from silently failing to launch

### DIFF
--- a/crosslink/src/commands/kickoff.rs
+++ b/crosslink/src/commands/kickoff.rs
@@ -1730,6 +1730,11 @@ fn launch_local(
         skip_permissions,
     );
 
+    // Write initial status sentinel BEFORE sending the command.
+    // This ensures we never have a worktree in limbo with no status.
+    std::fs::write(worktree_dir.join(".kickoff-status"), "LAUNCHING\n")
+        .context("Failed to write initial .kickoff-status")?;
+
     // Send the command to the tmux session
     let output = Command::new("tmux")
         .args(["send-keys", "-t", session_name, &cmd, "Enter"])
@@ -1737,9 +1742,14 @@ fn launch_local(
         .context("Failed to send command to tmux session")?;
 
     if !output.status.success() {
+        // Mark as failed before bailing
+        let _ = std::fs::write(worktree_dir.join(".kickoff-status"), "FAILED\n");
         let stderr = String::from_utf8_lossy(&output.stderr);
         bail!("Failed to send keys to tmux: {}", stderr.trim());
     }
+
+    // Update status to RUNNING now that the command has been sent
+    let _ = std::fs::write(worktree_dir.join(".kickoff-status"), "RUNNING\n");
 
     // Spawn watchdog sidecar to nudge idle agents
     let watchdog_cfg = read_watchdog_config(crosslink_dir);

--- a/crosslink/src/commands/swarm.rs
+++ b/crosslink/src/commands/swarm.rs
@@ -709,8 +709,9 @@ fn probe_agent_status(repo_root: &Path, slug: &str) -> String {
         }
     }
 
-    // Worktree exists but no status file and no tmux — stale or crashed
-    "unknown (worktree exists, no active session)".to_string()
+    // Worktree exists but no status file and no tmux — the session died
+    // before it could write any status. Treat as failed so gate can proceed.
+    "failed (session died)".to_string()
 }
 
 /// Check if a branch has been merged into the default branch (main/master).
@@ -3676,6 +3677,30 @@ mod tests {
         std::fs::create_dir_all(&wt).unwrap();
         std::fs::write(wt.join(".kickoff-status"), "FAILED\n").unwrap();
         assert_eq!(probe_agent_status(dir.path(), "bad-agent"), "FAILED");
+    }
+
+    #[test]
+    fn test_probe_agent_status_worktree_no_status_no_tmux() {
+        // Worktree exists but no .kickoff-status and no tmux session
+        // → should report "failed (session died)" not "unknown"
+        let dir = tempfile::tempdir().unwrap();
+        let wt = dir.path().join(".worktrees").join("dead-agent");
+        std::fs::create_dir_all(&wt).unwrap();
+        // No .kickoff-status file, no tmux → session died
+        assert_eq!(
+            probe_agent_status(dir.path(), "dead-agent"),
+            "failed (session died)"
+        );
+    }
+
+    #[test]
+    fn test_probe_agent_status_launching() {
+        // Agent wrote LAUNCHING status but tmux session has since exited
+        let dir = tempfile::tempdir().unwrap();
+        let wt = dir.path().join(".worktrees").join("launch-agent");
+        std::fs::create_dir_all(&wt).unwrap();
+        std::fs::write(wt.join(".kickoff-status"), "LAUNCHING\n").unwrap();
+        assert_eq!(probe_agent_status(dir.path(), "launch-agent"), "LAUNCHING");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fix swarm agents ending up in limbo when worktrees are created but tmux sessions fail to start or die immediately
- Write `.kickoff-status` sentinel at each launch stage so agents are never in an ambiguous state
- Treat worktrees with no status file and no tmux session as "failed" instead of "unknown"

Closes #359

## Changes
1. **`launch_local()`**: Writes `.kickoff-status` at each stage — `LAUNCHING` before send-keys, `RUNNING` after success, `FAILED` on error
2. **`probe_agent_status()`**: Returns `"failed (session died)"` instead of `"unknown (worktree exists, no active session)"` when worktree has no status and no tmux — unblocks swarm gate

## Test plan
- [x] `test_probe_agent_status_worktree_no_status_no_tmux` — verifies "failed (session died)"
- [x] `test_probe_agent_status_launching` — verifies LAUNCHING status reads correctly
- [x] All 7 probe_agent_status tests pass
- [x] 1613 lib tests pass
- [x] clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)