### PR TITLE
fix: recognize local issue L-prefix in work-check hook

### DIFF
--- a/crosslink/resources/claude/hooks/work-check.py
+++ b/crosslink/resources/claude/hooks/work-check.py
@@ -199,7 +199,7 @@ def main():
             # No crosslink dir — allow through (no enforcement possible)
             sys.exit(0)
         status = run_crosslink(["session", "status"], crosslink_dir)
-        if status and "Working on: #" in status:
+        if status and ("Working on: #" in status or "Working on: L" in status):
             sys.exit(0)
         print(
             "Git commit requires an active crosslink issue.\n\n"
@@ -233,7 +233,7 @@ def main():
         sys.exit(0)
 
     # If already working on an issue, allow
-    if "Working on: #" in status:
+    if "Working on: #" in status or "Working on: L" in status:
         sys.exit(0)
 
     # No active work item — behavior depends on mode


### PR DESCRIPTION
## Summary
- Fix work-check PreToolUse hook to recognize local (`L`-prefixed) issues as valid active work items
- Both the gated-git check (line 202) and strict-tracking check (line 236) now match `"Working on: L"` in addition to `"Working on: #"`

Closes #370

## Test plan
- [x] Create a local issue: `crosslink quick "test" -p low -l bug`
- [x] Verify `crosslink session status` shows `Working on: L...`
- [x] Confirm Write/Edit/Bash tool calls are not blocked by the hook
- [x] Run `crosslink init` in a fresh repo and verify the deployed hook has the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)