### PR TITLE
fix: add --json support to swarm status command

### DIFF
--- a/crosslink/src/commands/swarm.rs
+++ b/crosslink/src/commands/swarm.rs
@@ -508,6 +508,7 @@ fn slugify_phase(name: &str) -> String {
 // ---------------------------------------------------------------------------
 
 /// Resolved runtime status of an agent, combining phase definition + worktree state.
+#[derive(Serialize)]
 struct ResolvedAgent {
     slug: String,
     description: String,
@@ -517,7 +518,7 @@ struct ResolvedAgent {
 }
 
 /// Display the current state of the swarm.
-pub fn status(crosslink_dir: &Path) -> Result<()> {
+pub fn status(crosslink_dir: &Path, json: bool) -> Result<()> {
     let sync = SyncManager::new(crosslink_dir)?;
     if !sync.is_initialized() {
         bail!("Hub cache not initialized. Run `crosslink sync` first.");
@@ -529,6 +530,31 @@ pub fn status(crosslink_dir: &Path) -> Result<()> {
     let root = crosslink_dir
         .parent()
         .ok_or_else(|| anyhow::anyhow!("Cannot determine repo root"))?;
+
+    if json {
+        let mut phases_json = Vec::new();
+        for phase_name in &plan.phases {
+            let phase_file = format!("swarm/phases/{}.json", slugify_phase(phase_name));
+            let phase: PhaseDefinition = match read_hub_json(&sync, &phase_file) {
+                Ok(p) => p,
+                Err(_) => continue,
+            };
+            let resolved = resolve_agents(&phase, root);
+            phases_json.push(serde_json::json!({
+                "name": phase.name,
+                "status": phase.status,
+                "gate": phase.gate,
+                "depends_on": phase.depends_on,
+                "agents": resolved,
+            }));
+        }
+        let output = serde_json::json!({
+            "title": plan.title,
+            "phases": phases_json,
+        });
+        println!("{}", serde_json::to_string_pretty(&output)?);
+        return Ok(());
+    }
 
     println!("Swarm: {}", plan.title);
     println!();

--- a/crosslink/src/main.rs
+++ b/crosslink/src/main.rs
@@ -2315,7 +2315,7 @@ fn main() -> Result<()> {
             let crosslink_dir = find_crosslink_dir()?;
             match action {
                 SwarmCommands::Init { doc } => commands::swarm::init(&crosslink_dir, &doc),
-                SwarmCommands::Status => commands::swarm::status(&crosslink_dir),
+                SwarmCommands::Status => commands::swarm::status(&crosslink_dir, cli.json),
                 SwarmCommands::Resume => commands::swarm::resume(&crosslink_dir),
                 SwarmCommands::Launch {
                     phase,


### PR DESCRIPTION
## Summary
- `crosslink swarm status --json` ignored the global `--json` flag and always output human-readable text
- Now produces structured JSON with swarm title, phases, gate results, and resolved agent statuses

Closes #375

## Test plan
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt` — clean
- [x] 80 swarm unit tests pass
- [x] `crosslink swarm status --json | jq empty` with an active swarm — valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)