### PR TITLE
fix: resolve main repo root in kickoff show-plan for worktree support

### DIFF
--- a/crosslink/src/commands/kickoff.rs
+++ b/crosslink/src/commands/kickoff.rs
@@ -3311,9 +3311,11 @@ pub fn plan(crosslink_dir: &Path, db: &Database, opts: &PlanOpts) -> Result<()> 
 
 /// Display a gap report from a previous plan analysis.
 pub fn show_plan(crosslink_dir: &Path, agent: &str) -> Result<()> {
-    let root = crosslink_dir
+    let local_root = crosslink_dir
         .parent()
         .ok_or_else(|| anyhow::anyhow!("Cannot determine repo root"))?;
+    let root = crate::utils::resolve_main_repo_root(local_root)
+        .unwrap_or_else(|| local_root.to_path_buf());
 
     let slug = agent
         .strip_prefix("feature/")


### PR DESCRIPTION
## Summary
- `crosslink kickoff show-plan` failed when run from an agent worktree because it used `crosslink_dir.parent()` to find the repo root
- Now uses `resolve_main_repo_root()` to find the main repository, matching how `sync` and `knowledge` commands already handle worktrees

Closes #374

## Test plan
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt` — clean
- [x] 135 kickoff unit tests pass
- [x] Run `crosslink kickoff show-plan <agent>` from within an agent worktree — should resolve plan from main repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)