### PR TITLE
fix: resolve V1/V2 hub layout coexistence and inconsistent write paths

### DIFF
--- a/crosslink/src/compaction.rs
+++ b/crosslink/src/compaction.rs
@@ -518,6 +518,10 @@ fn apply(
 }
 
 /// Materialize checkpoint state to disk (issue.json + lock files).
+///
+/// Respects the hub layout version: writes V1 flat files or V2 directory
+/// files accordingly. Cleans up stale V1 flat files when writing V2 (#428).
+/// Writes `meta/version.json` if missing to prevent layout drift.
 fn materialize(
     cache_dir: &Path,
     state: &CheckpointState,
@@ -526,19 +530,40 @@ fn materialize(
 ) -> Result<()> {
     let issues_dir = cache_dir.join("issues");
     let locks_dir = cache_dir.join("locks");
+    let meta_dir = cache_dir.join("meta");
+
+    let layout_version = crate::issue_file::read_layout_version(&meta_dir)
+        .unwrap_or(crate::issue_file::CURRENT_LAYOUT_VERSION);
 
     // Materialize changed issues
     for uuid in changed_issues {
         if let Some(compact) = state.issues.get(uuid) {
-            let issue_dir = issues_dir.join(uuid.to_string());
-            std::fs::create_dir_all(&issue_dir)
-                .with_context(|| format!("Failed to create issue dir: {}", issue_dir.display()))?;
-
             let issue_file = compact_to_issue_file(compact);
-            let path = issue_dir.join("issue.json");
             let content = serde_json::to_string_pretty(&issue_file)?;
-            crate::utils::atomic_write(&path, content.as_bytes())?;
+
+            if layout_version >= 2 {
+                let issue_dir = issues_dir.join(uuid.to_string());
+                std::fs::create_dir_all(&issue_dir).with_context(|| {
+                    format!("Failed to create issue dir: {}", issue_dir.display())
+                })?;
+                let path = issue_dir.join("issue.json");
+                crate::utils::atomic_write(&path, content.as_bytes())?;
+
+                // Clean up stale V1 flat file if it exists (#428)
+                let v1_path = issues_dir.join(format!("{}.json", uuid));
+                if v1_path.exists() {
+                    let _ = std::fs::remove_file(&v1_path);
+                }
+            } else {
+                let path = issues_dir.join(format!("{}.json", uuid));
+                crate::utils::atomic_write(&path, content.as_bytes())?;
+            }
         }
+    }
+
+    // Ensure version marker exists to prevent layout drift (#428)
+    if !meta_dir.join("version.json").exists() {
+        let _ = crate::issue_file::write_layout_version(&meta_dir, layout_version);
     }
 
     // Materialize changed locks
@@ -711,6 +736,12 @@ mod tests {
         std::fs::create_dir_all(dir.join("issues")).unwrap();
         std::fs::create_dir_all(dir.join("locks")).unwrap();
         std::fs::create_dir_all(dir.join("checkpoint")).unwrap();
+        // Write V2 layout marker — matches real hub initialization
+        crate::issue_file::write_layout_version(
+            &dir.join("meta"),
+            crate::issue_file::CURRENT_LAYOUT_VERSION,
+        )
+        .unwrap();
     }
 
     #[test]

--- a/crosslink/src/issue_file.rs
+++ b/crosslink/src/issue_file.rs
@@ -174,19 +174,29 @@ pub fn write_issue_file(path: &std::path::Path, issue: &IssueFile) -> anyhow::Re
 /// Read all issue files from a directory.
 ///
 /// Handles both v1 layout (`issues/{uuid}.json`) and v2 layout
-/// (`issues/{uuid}/issue.json`).
+/// (`issues/{uuid}/issue.json`). When both exist for the same UUID,
+/// the V2 version takes precedence (#428).
 pub fn read_all_issue_files(issues_dir: &std::path::Path) -> anyhow::Result<Vec<IssueFile>> {
-    let mut issues = Vec::new();
+    use std::collections::HashMap;
+
     if !issues_dir.exists() {
-        return Ok(issues);
+        return Ok(Vec::new());
     }
+
+    // Two-pass collection: V1 first, then V2 overwrites any duplicates
+    let mut by_uuid: HashMap<uuid::Uuid, IssueFile> = HashMap::new();
+    let mut v1_paths: HashMap<uuid::Uuid, std::path::PathBuf> = HashMap::new();
+
     for entry in std::fs::read_dir(issues_dir)? {
         let entry = entry?;
         let path = entry.path();
         if path.is_file() && path.extension().and_then(|e| e.to_str()) == Some("json") {
             // V1 layout: issues/{uuid}.json
             match read_issue_file(&path) {
-                Ok(issue) => issues.push(issue),
+                Ok(issue) => {
+                    v1_paths.insert(issue.uuid, path);
+                    by_uuid.entry(issue.uuid).or_insert(issue);
+                }
                 Err(e) => {
                     tracing::warn!("skipping malformed issue file {}: {e}", path.display());
                 }
@@ -196,10 +206,13 @@ pub fn read_all_issue_files(issues_dir: &std::path::Path) -> anyhow::Result<Vec<
             let issue_path = path.join("issue.json");
             if issue_path.exists() {
                 match read_issue_file(&issue_path) {
-                    Ok(issue) => issues.push(issue),
+                    Ok(issue) => {
+                        // V2 always wins over V1 for the same UUID
+                        by_uuid.insert(issue.uuid, issue);
+                    }
                     Err(e) => {
-                        eprintln!(
-                            "Warning: skipping malformed issue file {}: {e}",
+                        tracing::warn!(
+                            "skipping malformed issue file {}: {e}",
                             issue_path.display()
                         );
                     }
@@ -207,7 +220,8 @@ pub fn read_all_issue_files(issues_dir: &std::path::Path) -> anyhow::Result<Vec<
             }
         }
     }
-    Ok(issues)
+
+    Ok(by_uuid.into_values().collect())
 }
 
 /// Read counters from `meta/counters.json`, returning defaults if missing.
@@ -372,17 +386,42 @@ pub fn read_comment_files(comments_dir: &std::path::Path) -> anyhow::Result<Vec<
 
 /// Read the layout version from `meta/version.json`.
 ///
-/// Returns `1` if the file is absent, indicating a v1 (flat-file) layout.
+/// If the version file is missing, inspects the `issues/` directory for V2-style
+/// subdirectories (containing `issue.json`). If any exist, returns `2` to avoid
+/// silently reverting to V1 flat-file writes on a hub that lost its version marker
+/// during a rebase or merge conflict (#428).
 pub fn read_layout_version(meta_dir: &std::path::Path) -> anyhow::Result<u32> {
     let path = meta_dir.join("version.json");
-    if !path.exists() {
-        return Ok(1);
+    if path.exists() {
+        let content = std::fs::read_to_string(&path)
+            .with_context(|| format!("Failed to read layout version: {}", path.display()))?;
+        let version: LayoutVersion = serde_json::from_str(&content)
+            .with_context(|| format!("Failed to parse layout version: {}", path.display()))?;
+        return Ok(version.layout_version);
     }
-    let content = std::fs::read_to_string(&path)
-        .with_context(|| format!("Failed to read layout version: {}", path.display()))?;
-    let version: LayoutVersion = serde_json::from_str(&content)
-        .with_context(|| format!("Failed to parse layout version: {}", path.display()))?;
-    Ok(version.layout_version)
+
+    // Version file missing — detect layout from directory structure.
+    // If any issues/{uuid}/issue.json directories exist, this is a V2 hub
+    // that lost its version marker.
+    let issues_dir = meta_dir
+        .parent()
+        .map(|p| p.join("issues"))
+        .unwrap_or_default();
+    if issues_dir.is_dir() {
+        if let Ok(entries) = std::fs::read_dir(&issues_dir) {
+            for entry in entries.flatten() {
+                if entry.path().is_dir() && entry.path().join("issue.json").exists() {
+                    tracing::warn!(
+                        "meta/version.json missing but V2-style issue directories found; \
+                         treating as V2 layout (#428)"
+                    );
+                    return Ok(CURRENT_LAYOUT_VERSION);
+                }
+            }
+        }
+    }
+
+    Ok(1)
 }
 
 /// Write the layout version to `meta/version.json`.

--- a/crosslink/src/shared_writer/core.rs
+++ b/crosslink/src/shared_writer/core.rs
@@ -671,6 +671,18 @@ impl SharedWriter {
                         std::fs::create_dir_all(parent)?;
                     }
                     std::fs::write(&full, content)?;
+
+                    // Clean up stale V1 flat file when writing V2 directory
+                    // format, preventing both from coexisting (#428).
+                    // V2 path: issues/{uuid}/issue.json → stale V1: issues/{uuid}.json
+                    if rel_path.ends_with("/issue.json") {
+                        if let Some(uuid_dir) = rel_path.strip_suffix("/issue.json") {
+                            let v1_path = self.cache_dir.join(format!("{}.json", uuid_dir));
+                            if v1_path.exists() {
+                                let _ = std::fs::remove_file(&v1_path);
+                            }
+                        }
+                    }
                 }
             }
             if let Some(ref c) = write_set.counters {

--- a/crosslink/src/shared_writer/offline.rs
+++ b/crosslink/src/shared_writer/offline.rs
@@ -99,7 +99,7 @@ impl SharedWriter {
                     let mut issue = read_issue_file(&path)?;
                     issue.display_id = Some(start_id + i as i64);
                     let json = serde_json::to_vec_pretty(&issue)?;
-                    files.push((format!("issues/{}.json", uuid), json));
+                    files.push((writer.issue_rel_path(uuid), json));
                 }
 
                 Ok(WriteSet {


### PR DESCRIPTION
## Summary

Fixes #428 — Six interacting bugs caused V1 flat files (`issues/{uuid}.json`) and V2 directory files (`issues/{uuid}/issue.json`) to coexist on the hub branch, producing hydration warnings and data divergence.

- **`read_layout_version()`** now detects V2 layout from directory structure when `meta/version.json` is missing (e.g. lost in rebase), instead of silently falling back to V1
- **`promote_offline_issues()`** uses `issue_rel_path()` instead of hardcoded V1 path format
- **`read_all_issue_files()`** deduplicates by UUID, preferring V2 when both formats exist for the same issue
- **Compaction `materialize()`** respects the hub layout version instead of always writing V2, and writes `meta/version.json` if missing to prevent layout drift
- **All V2 write paths** (SharedWriter, compaction) clean up stale V1 flat files for the same UUID

## Test plan

- [x] 68 compaction tests pass (including updated `setup_cache` with V2 version marker)
- [x] 125 shared_writer tests pass
- [x] 41 hydration tests pass
- [x] 36 issue_file tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)