### PR TITLE
fix: render local issues as Ln instead of #-n across all commands

### DIFF
--- a/crosslink/src/commands/import.rs
+++ b/crosslink/src/commands/import.rs
@@ -68,7 +68,7 @@ fn import_issue_files(db: &Database, issues: &[IssueFile], input_path: &Path) ->
                 "  Imported: {} -> {} {}",
                 issue
                     .display_id
-                    .map(|id| format!("#{}", id))
+                    .map(format_issue_id)
                     .unwrap_or_else(|| issue.uuid.to_string()),
                 format_issue_id(new_id),
                 issue.title

--- a/crosslink/src/commands/kickoff/helpers.rs
+++ b/crosslink/src/commands/kickoff/helpers.rs
@@ -627,7 +627,7 @@ pub(super) fn read_agent_issue(wt_path: &Path, _crosslink_dir: &Path) -> Option<
             if let Ok(val) = serde_json::from_str::<serde_json::Value>(&content) {
                 // The criteria file might have issue_id in extracted metadata
                 if let Some(id) = val.get("issue_id").and_then(|v| v.as_i64()) {
-                    return Some(format!("#{}", id));
+                    return Some(crate::utils::format_issue_id(id));
                 }
             }
         }
@@ -638,7 +638,7 @@ pub(super) fn read_agent_issue(wt_path: &Path, _crosslink_dir: &Path) -> Option<
         if let Ok(content) = std::fs::read_to_string(&agent_json) {
             if let Ok(val) = serde_json::from_str::<serde_json::Value>(&content) {
                 if let Some(id) = val.get("issue_id").and_then(|v| v.as_i64()) {
-                    return Some(format!("#{}", id));
+                    return Some(crate::utils::format_issue_id(id));
                 }
             }
         }

--- a/crosslink/src/commands/kickoff/plan.rs
+++ b/crosslink/src/commands/kickoff/plan.rs
@@ -159,7 +159,7 @@ pub fn plan(crosslink_dir: &Path, db: &Database, opts: &PlanOpts) -> Result<()> 
     // 2. Create or find issue (optional for plan mode)
     let issue_id = if let Some(id) = opts.issue {
         if db.get_issue(id)?.is_none() {
-            bail!("Issue #{} not found", id);
+            bail!("Issue {} not found", crate::utils::format_issue_id(id));
         }
         Some(id)
     } else {

--- a/crosslink/src/commands/kickoff/run.rs
+++ b/crosslink/src/commands/kickoff/run.rs
@@ -41,7 +41,7 @@ pub fn run(
     let issue_id = if let Some(id) = opts.issue {
         // Verify the issue exists
         if db.get_issue(id)?.is_none() {
-            bail!("Issue #{} not found", id);
+            bail!("Issue {} not found", crate::utils::format_issue_id(id));
         }
         id
     } else {

--- a/crosslink/src/db/issues.rs
+++ b/crosslink/src/db/issues.rs
@@ -108,7 +108,7 @@ impl Database {
     /// Use this instead of get_issue when you need the issue to exist.
     pub fn require_issue(&self, id: i64) -> Result<Issue> {
         self.get_issue(id)?
-            .ok_or_else(|| anyhow::anyhow!("Issue #{} not found", id))
+            .ok_or_else(|| anyhow::anyhow!("Issue {} not found", crate::utils::format_issue_id(id)))
     }
 
     pub fn list_issues(

--- a/crosslink/src/lock_check.rs
+++ b/crosslink/src/lock_check.rs
@@ -192,17 +192,17 @@ pub fn enforce_lock(crosslink_dir: &Path, issue_id: i64, db: &Database) -> Resul
                 }
 
                 tracing::warn!(
-                    "Issue #{} is locked by '{}' but the lock appears STALE. Proceeding.",
-                    issue_id,
+                    "Issue {} is locked by '{}' but the lock appears STALE. Proceeding.",
+                    crate::utils::format_issue_id(issue_id),
                     agent_id
                 );
                 Ok(())
             } else {
                 bail!(
-                    "Issue #{} is locked by agent '{}'. \
+                    "Issue {} is locked by agent '{}'. \
                      Use 'crosslink locks check {}' for details. \
                      Ask the human to release it or wait for the lock to expire.",
-                    issue_id,
+                    crate::utils::format_issue_id(issue_id),
                     agent_id,
                     issue_id
                 )

--- a/crosslink/src/shared_writer/core.rs
+++ b/crosslink/src/shared_writer/core.rs
@@ -600,7 +600,10 @@ impl SharedWriter {
                 }
             }
         }
-        bail!("Issue #{} not found in shared cache", display_id)
+        bail!(
+            "Issue {} not found in shared cache",
+            crate::utils::format_issue_id(display_id)
+        )
     }
 
     /// Load an issue by ID, supporting both positive (real) and negative (offline) IDs.

--- a/crosslink/src/sync/locks.rs
+++ b/crosslink/src/sync/locks.rs
@@ -97,9 +97,9 @@ impl SyncManager {
                 }
                 if !force {
                     bail!(
-                        "Issue #{} is locked by '{}' (claimed {}). \
+                        "Issue {} is locked by '{}' (claimed {}). \
                          Use 'crosslink locks steal {}' if the lock is stale.",
-                        issue_id,
+                        crate::utils::format_issue_id(issue_id),
                         existing.agent_id,
                         existing.claimed_at.format("%Y-%m-%d %H:%M"),
                         issue_id
@@ -155,8 +155,8 @@ impl SyncManager {
             Some(existing) => {
                 if existing.agent_id != agent.agent_id && !force {
                     bail!(
-                        "Issue #{} is locked by '{}', not by you ('{}').",
-                        issue_id,
+                        "Issue {} is locked by '{}', not by you ('{}').",
+                        crate::utils::format_issue_id(issue_id),
                         existing.agent_id,
                         agent.agent_id
                     );

--- a/crosslink/src/tui/agents_tab.rs
+++ b/crosslink/src/tui/agents_tab.rs
@@ -511,7 +511,7 @@ impl AgentsTab {
                     };
 
                     Row::new(vec![
-                        format!("#{}", lock.issue_id),
+                        crate::utils::format_issue_id(lock.issue_id),
                         truncate_str(&lock.agent_id, 35),
                         truncate_str(lock.branch.as_deref().unwrap_or("—"), 22),
                         lock.claimed_ago.clone(),


### PR DESCRIPTION
## Summary

Fixes #424 — Local issues rendered as `#-n` (e.g. `#-3`) instead of `Ln` (e.g. `L3`) in several commands because raw `format!("#{}", id)` was used instead of `format_issue_id()`.

Replaced 9 call sites across the codebase:
- **kickoff helpers**: agent issue display in worktree metadata
- **kickoff run/plan**: "issue not found" error messages
- **TUI agents tab**: lock issue display
- **lock_check**: stale/active lock warnings
- **sync/locks**: lock contention error messages
- **shared_writer**: "not found in shared cache" error
- **db/issues**: `require_issue` error message
- **import**: imported issue display

## Test plan

- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean
- [x] Mechanical change — all sites now use `format_issue_id()` which has existing unit tests for both positive and negative IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)