### PR TITLE
fix: hub structural fixes — lock serialization, promotion tracking, lock ownership refactor

### DIFF
--- a/crosslink/src/shared_writer/core.rs
+++ b/crosslink/src/shared_writer/core.rs
@@ -19,104 +19,7 @@ use crate::issue_file::{
 };
 use crate::sync::SyncManager;
 
-/// File-based lock for serializing hub cache writes.
-///
-/// Multiple agents launching simultaneously can race on git index.lock.
-/// This provides a higher-level lock that prevents concurrent write_commit_push
-/// operations from overlapping.
-pub(super) struct HubWriteLock {
-    path: PathBuf,
-}
-
-impl Drop for HubWriteLock {
-    fn drop(&mut self) {
-        if let Err(e) = std::fs::remove_file(&self.path) {
-            if e.kind() != std::io::ErrorKind::NotFound {
-                // If we can't remove a file in the hub cache directory,
-                // the cache has a filesystem-level problem. Log it — this
-                // will cause the next acquire to detect a stale lock and
-                // handle it via PID check + force-break (#475).
-                tracing::warn!(
-                    "failed to release hub write lock {}: {}",
-                    self.path.display(),
-                    e
-                );
-            }
-        }
-    }
-}
-
-pub(super) fn acquire_hub_lock(lock_path: &Path) -> Result<HubWriteLock> {
-    let max_wait = std::time::Duration::from_secs(30);
-    let poll_interval = std::time::Duration::from_millis(100);
-    let start = std::time::Instant::now();
-
-    loop {
-        // Try to create the lock file exclusively
-        match std::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(lock_path)
-        {
-            Ok(mut f) => {
-                use std::io::Write;
-                // PID must be written — without it, other processes can't
-                // determine if we're alive and fall back to 30s timeout (#476).
-                if let Err(e) = writeln!(f, "{}", std::process::id()) {
-                    // I/O failure on an open file in the hub cache means the
-                    // cache directory has a fundamental problem. Remove the
-                    // lock we just created and propagate.
-                    let _ = std::fs::remove_file(lock_path);
-                    bail!("Failed to write PID to hub lock file: {}", e);
-                }
-                return Ok(HubWriteLock {
-                    path: lock_path.to_path_buf(),
-                });
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-                // Check if the lock is stale (holder process dead)
-                if let Ok(content) = std::fs::read_to_string(lock_path) {
-                    if let Ok(pid) = content.trim().parse::<u32>() {
-                        let alive = std::process::Command::new("kill")
-                            .args(["-0", &pid.to_string()])
-                            .output()
-                            .map(|o| o.status.success())
-                            .unwrap_or(false);
-                        if !alive {
-                            // Dead process — remove stale lock (#479)
-                            if let Err(rm_err) = std::fs::remove_file(lock_path) {
-                                if rm_err.kind() == std::io::ErrorKind::NotFound {
-                                    continue; // Another process cleaned it up
-                                }
-                                bail!(
-                                    "Cannot remove stale hub lock (PID {} is dead): {}",
-                                    pid,
-                                    rm_err
-                                );
-                            }
-                            continue;
-                        }
-                    }
-                }
-
-                if start.elapsed() > max_wait {
-                    // Force-break after timeout — the holder may be wedged
-                    if let Err(rm_err) = std::fs::remove_file(lock_path) {
-                        if rm_err.kind() != std::io::ErrorKind::NotFound {
-                            bail!(
-                                "Hub lock held for >30s and cannot be force-removed: {}",
-                                rm_err
-                            );
-                        }
-                    }
-                    continue;
-                }
-                std::thread::sleep(poll_interval);
-            }
-            Err(e) => return Err(e.into()),
-        }
-    }
-}
+// Hub cache write lock is in sync/cache.rs — acquired via self.sync.acquire_lock()
 
 /// Content to write in a single atomic commit-push operation.
 pub(super) struct WriteSet {
@@ -698,10 +601,8 @@ impl SharedWriter {
     where
         F: FnMut(&Self) -> Result<WriteSet>,
     {
-        // Serialize access to the hub cache to prevent index.lock races
-        // when multiple agents launch simultaneously (#400)
-        let lock_path = self.cache_dir.join(".hub-write-lock");
-        let _lock_guard = acquire_hub_lock(&lock_path)?;
+        // Serialize access to the hub cache via SyncManager's lock (#400, #457)
+        let _lock_guard = self.sync.acquire_lock()?;
 
         for attempt in 0..MAX_RETRIES {
             // Recover from broken git states before attempting write (#454, #455, #456)

--- a/crosslink/src/shared_writer/offline.rs
+++ b/crosslink/src/shared_writer/offline.rs
@@ -135,11 +135,11 @@ impl SharedWriter {
         // Re-hydrate with new positive IDs
         self.hydrate_with_retry(db)?;
 
-        // Record promoted UUIDs so they are never re-promoted (gh#313).
+        // Record promoted UUIDs so they are never re-promoted (#451).
+        // This MUST succeed — if it fails, the next sync will re-promote
+        // the same UUIDs with new display IDs, creating duplicates.
         let promoted_uuids: Vec<Uuid> = offline_info.iter().map(|(uuid, _)| *uuid).collect();
-        if let Err(e) = self.record_promoted_uuids(&promoted_uuids) {
-            tracing::warn!("failed to record promoted UUIDs: {}", e);
-        }
+        self.record_promoted_uuids(&promoted_uuids)?;
 
         let start_id = first_id.get();
         let mapping: Vec<(i64, i64, String)> = offline_info

--- a/crosslink/src/sync/cache.rs
+++ b/crosslink/src/sync/cache.rs
@@ -1,11 +1,113 @@
 use anyhow::{bail, Result};
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use super::core::SyncManager;
 use super::HUB_BRANCH;
 use crate::locks::LocksFile;
 
+// ---------------------------------------------------------------------------
+// Hub cache write lock — serializes ALL mutations to the hub cache worktree.
+//
+// Used by fetch(), upgrade_to_v2(), and write_commit_push() to prevent
+// concurrent git operations from racing (#457, #459).
+// ---------------------------------------------------------------------------
+
+/// RAII guard for the hub cache write lock.
+pub(crate) struct HubWriteLock {
+    path: PathBuf,
+}
+
+impl Drop for HubWriteLock {
+    fn drop(&mut self) {
+        if let Err(e) = std::fs::remove_file(&self.path) {
+            if e.kind() != std::io::ErrorKind::NotFound {
+                tracing::warn!(
+                    "failed to release hub write lock {}: {}",
+                    self.path.display(),
+                    e
+                );
+            }
+        }
+    }
+}
+
+/// Acquire the hub cache write lock at the given path.
+///
+/// Blocks up to 30 seconds, checking for stale locks via PID liveness.
+/// Returns an RAII guard that releases the lock on drop.
+pub(crate) fn acquire_hub_lock(lock_path: &Path) -> Result<HubWriteLock> {
+    let max_wait = Duration::from_secs(30);
+    let poll_interval = Duration::from_millis(100);
+    let start = std::time::Instant::now();
+
+    loop {
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(lock_path)
+        {
+            Ok(mut f) => {
+                use std::io::Write;
+                if let Err(e) = writeln!(f, "{}", std::process::id()) {
+                    let _ = std::fs::remove_file(lock_path);
+                    bail!("Failed to write PID to hub lock file: {}", e);
+                }
+                return Ok(HubWriteLock {
+                    path: lock_path.to_path_buf(),
+                });
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                if let Ok(content) = std::fs::read_to_string(lock_path) {
+                    if let Ok(pid) = content.trim().parse::<u32>() {
+                        let alive = std::process::Command::new("kill")
+                            .args(["-0", &pid.to_string()])
+                            .output()
+                            .map(|o| o.status.success())
+                            .unwrap_or(false);
+                        if !alive {
+                            if let Err(rm_err) = std::fs::remove_file(lock_path) {
+                                if rm_err.kind() == std::io::ErrorKind::NotFound {
+                                    continue;
+                                }
+                                bail!(
+                                    "Cannot remove stale hub lock (PID {} is dead): {}",
+                                    pid,
+                                    rm_err
+                                );
+                            }
+                            continue;
+                        }
+                    }
+                }
+
+                if start.elapsed() > max_wait {
+                    if let Err(rm_err) = std::fs::remove_file(lock_path) {
+                        if rm_err.kind() != std::io::ErrorKind::NotFound {
+                            bail!(
+                                "Hub lock held for >30s and cannot be force-removed: {}",
+                                rm_err
+                            );
+                        }
+                    }
+                    continue;
+                }
+                std::thread::sleep(poll_interval);
+            }
+            Err(e) => return Err(e.into()),
+        }
+    }
+}
+
 impl SyncManager {
+    /// Acquire the hub cache write lock.
+    ///
+    /// All code that mutates the hub cache worktree (fetch, upgrade,
+    /// write_commit_push) must hold this lock to prevent races (#457, #459).
+    pub(crate) fn acquire_lock(&self) -> Result<HubWriteLock> {
+        let lock_path = self.cache_dir.join(".hub-write-lock");
+        acquire_hub_lock(&lock_path)
+    }
     /// Initialize the hub cache directory.
     ///
     /// If the `crosslink/hub` branch exists on the remote, fetches it and
@@ -106,6 +208,10 @@ impl SyncManager {
     /// automatically during init_cache, to avoid side-effects on hubs that
     /// intentionally use v1 layout.
     pub fn upgrade_to_v2(&self) -> Result<usize> {
+        // Acquire the hub write lock to prevent agents from writing V1 files
+        // while we're migrating to V2 (#459).
+        let _lock_guard = self.acquire_lock()?;
+
         let meta_dir = self.cache_dir.join("meta");
         let version = crate::issue_file::read_layout_version(&meta_dir).unwrap_or(1);
         if version >= 2 {
@@ -357,6 +463,11 @@ impl SyncManager {
     /// pushed yet. Only resets to the remote when there are definitively no
     /// unpushed commits.
     pub fn fetch(&self) -> Result<()> {
+        // Acquire the hub write lock to serialize with write_commit_push (#457).
+        // fetch() modifies the working directory (reset, rebase) which races
+        // with concurrent CLI writes if not serialized.
+        let _lock_guard = self.acquire_lock()?;
+
         // Recover from broken git states before attempting fetch (#454, #455, #456)
         self.hub_health_check()?;
 


### PR DESCRIPTION
## Summary

Closes #451, closes #457, closes #459

Structural fixes for the remaining hub concurrency issues from the fragility audit (#449). Also closes #450 and #453 which were verified safe by design during the audit.

### Lock ownership refactor (#457, #459)
Moved `HubWriteLock` and `acquire_hub_lock` from `shared_writer/core.rs` to `sync/cache.rs` where they belong — the lock protects SyncManager's hub cache, not SharedWriter specifically.

- `SyncManager::acquire_lock()` is now the single entry point
- **`fetch()`** acquires the lock before modifying the working directory, preventing daemon/CLI races where a daemon fetch could corrupt a CLI's pending commit (#457)
- **`upgrade_to_v2()`** acquires the lock before changing layout, preventing agents from writing V1 files while migration runs (#459)
- `write_commit_push()` uses `self.sync.acquire_lock()` instead of directly calling the lock function

### Promotion UUID tracking (#451)
`record_promoted_uuids()` error now propagates instead of being swallowed. If tracking fails, promotion returns Err so the caller knows the state is incomplete. Prevents re-promotion of already-promoted UUIDs on next sync.

### Verified safe (closed)
- **#450** (counter collisions): Counter claims re-read from disk inside the write lock on every retry — safe by design
- **#453** (compaction race): Materialization runs inside the compaction lock — safe by design

## Test plan

- [x] 278 tests pass (sync + shared_writer + hydration)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)