### PR TITLE
fix: stage untracked files before fetch to prevent heartbeat race

### DIFF
--- a/crosslink/src/sync/cache.rs
+++ b/crosslink/src/sync/cache.rs
@@ -484,6 +484,12 @@ impl SyncManager {
         // Recover from broken git states before attempting fetch (#454, #455, #456)
         self.hub_health_check()?;
 
+        // Stage any untracked or modified files before fetch. Concurrent
+        // agents may have written heartbeat/lock files that aren't committed
+        // yet — these block rebase/reset with "untracked working tree files
+        // would be overwritten by merge" (#480).
+        self.clean_dirty_state()?;
+
         // Try fetching from remote. If no remote is configured, this is a no-op.
         let fetch_result = self.git_in_cache(&["fetch", &self.remote, HUB_BRANCH]);
         if let Err(e) = &fetch_result {


### PR DESCRIPTION
## Summary

Closes #480 — `swarm launch` fails when early agents push heartbeat files that conflict with later agents' hub cache fetch.

One-line fix: call `clean_dirty_state()` unconditionally at the start of `fetch()`, before any rebase/reset. This stages untracked files (heartbeats, locks) so they don't block incoming remote changes.

Previously, `clean_dirty_state()` was only called inside the rebase path (when unpushed local commits existed). Untracked files in the no-unpushed-commits path would block `git reset --hard`.

Made simple by the hub stability refactor (#449) — the lock, health check, and clean-dirty-state layers each do one job and compose cleanly.

## Test plan

- [x] 112 sync tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)