### PR TITLE
fix: integrity locks --repair releases stale locks instead of stealing them

### DIFF
--- a/crosslink/src/commands/integrity_cmd.rs
+++ b/crosslink/src/commands/integrity_cmd.rs
@@ -303,7 +303,7 @@ fn check_locks(crosslink_dir: &Path, repair: bool) -> Result<CheckResult> {
     if sync.is_v2_layout() {
         if let Ok(Some(writer)) = crate::shared_writer::SharedWriter::new(crosslink_dir) {
             for (id, stale_agent_id) in &stale {
-                match writer.steal_lock_v2(*id, stale_agent_id, None) {
+                match writer.force_release_lock_v2(*id, stale_agent_id) {
                     Ok(_) => released += 1,
                     Err(e) => tracing::warn!("Could not release stale lock #{}: {}", id, e),
                 }

--- a/crosslink/src/shared_writer/locks.rs
+++ b/crosslink/src/shared_writer/locks.rs
@@ -135,6 +135,42 @@ impl SharedWriter {
         self.claim_lock_v2(issue_display_id, branch)
     }
 
+    /// Force-release a stale lock without re-claiming it.
+    ///
+    /// Used by `integrity locks --repair` to actually free stale locks.
+    /// Unlike `steal_lock_v2`, this does NOT call `claim_lock_v2` afterwards.
+    pub fn force_release_lock_v2(
+        &self,
+        issue_display_id: i64,
+        stale_agent_id: &str,
+    ) -> Result<bool> {
+        // Prune stale agent's compacted events so they don't replay
+        crate::compaction::prune_events(&self.cache_dir, stale_agent_id)?;
+
+        // Clear lock from checkpoint state
+        let mut state = crate::checkpoint::read_checkpoint(&self.cache_dir)?;
+        state.locks.remove(&issue_display_id);
+        crate::checkpoint::write_checkpoint(&self.cache_dir, &state)?;
+
+        // Remove materialized lock file
+        let lock_path = self
+            .cache_dir
+            .join("locks")
+            .join(format!("{}.json", issue_display_id));
+        if lock_path.exists() {
+            std::fs::remove_file(&lock_path)?;
+        }
+
+        // Emit a release event and push
+        let event = crate::events::Event::LockReleased { issue_display_id };
+        self.emit_compact_push(
+            event,
+            &format!("force-release stale lock on #{}", issue_display_id),
+        )?;
+
+        Ok(true)
+    }
+
     /// Read a V2 lock file for a specific issue.
     ///
     /// Returns None if the lock file doesn't exist.


### PR DESCRIPTION
## Summary

- `crosslink integrity locks --repair` was calling `steal_lock_v2()` which prunes the stale agent's state but then re-claims the lock for the repairing agent — locks reappeared immediately with fresh timestamps
- Added `force_release_lock_v2()` that does cleanup (prune events, clear checkpoint, remove lock file) + emits `LockReleased` event without calling `claim_lock_v2()`
- Repair path now uses `force_release_lock_v2()` so stale locks are actually freed

Closes #496

## Changes

| File | What |
|------|------|
| `shared_writer/locks.rs` | Add `force_release_lock_v2()` method |
| `commands/integrity_cmd.rs` | Use `force_release_lock_v2` instead of `steal_lock_v2` |

## Test plan

- [x] `cargo clippy -- -D warnings -W clippy::unwrap_used -W clippy::expect_used` passes
- [x] Build succeeds
- [x] Manual: `crosslink integrity locks --repair` on repo with stale locks → locks are freed, not re-claimed

🤖 Generated with [Claude Code](https://claude.com/claude-code)