### PR TITLE
fix: stabilize local ID assignment for offline issues across re-hydration

### DIFF
--- a/crosslink/src/hydration.rs
+++ b/crosslink/src/hydration.rs
@@ -375,6 +375,10 @@ fn topo_sort_issues<'a>(issues: &[&'a IssueFile]) -> Vec<&'a IssueFile> {
     // Simple two-pass: roots first, then children.
     // For deeper nesting, a full topo sort would be needed,
     // but crosslink typically has at most 1-2 levels of nesting.
+    //
+    // Sort roots by (created_at, uuid) so offline issues without display_id
+    // get assigned the same local IDs across re-hydration passes (#499).
+    roots.sort_by(|a, b| a.created_at.cmp(&b.created_at).then(a.uuid.cmp(&b.uuid)));
     let mut sorted = roots;
 
     // Multi-pass: keep appending children whose parent is already in sorted
@@ -384,9 +388,10 @@ fn topo_sort_issues<'a>(issues: &[&'a IssueFile]) -> Vec<&'a IssueFile> {
             break;
         }
         let sorted_uuids: std::collections::HashSet<_> = sorted.iter().map(|i| i.uuid).collect();
-        let (ready, still_remaining): (Vec<&'a IssueFile>, Vec<&'a IssueFile>) = remaining
+        let (mut ready, still_remaining): (Vec<&'a IssueFile>, Vec<&'a IssueFile>) = remaining
             .into_iter()
             .partition(|i| i.parent_uuid.is_none_or(|p| sorted_uuids.contains(&p)));
+        ready.sort_by(|a, b| a.created_at.cmp(&b.created_at).then(a.uuid.cmp(&b.uuid)));
         sorted.extend(ready);
         remaining = still_remaining;
     }


### PR DESCRIPTION
## Summary
- Sort issues by `(created_at, uuid)` in `topo_sort_issues` so offline issues without a server-assigned `display_id` get deterministic local IDs across re-hydration passes
- Previously, filesystem iteration order determined assignment, causing non-deterministic ID swaps that could make `issue show <id>` return the wrong issue

Closes #499

## Test plan
- [x] Ran `test_offline_local_operations_then_sync` 10 times in a loop — all pass
- [x] CI smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)