### PR TITLE
fix: persist tmux session name so kickoff list detects swarm-launched agents

### DIFF
--- a/crosslink/src/commands/kickoff/monitor.rs
+++ b/crosslink/src/commands/kickoff/monitor.rs
@@ -157,8 +157,13 @@ pub(super) fn discover_agents(crosslink_dir: &Path) -> Result<Vec<AgentInfo>> {
             let agent_id = read_agent_id(&wt_path, crosslink_dir)
                 .unwrap_or_else(|| format!("driver--{}", dir_name));
 
-            // Check tmux session
-            let session_name = tmux_session_name(&dir_name);
+            // Check tmux session — prefer stored name (may include collision suffix),
+            // fall back to derived name for backward compatibility (#507).
+            let session_name = std::fs::read_to_string(wt_path.join(".kickoff-session"))
+                .ok()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| tmux_session_name(&dir_name));
             let tmux_active = tmux_session_exists(&session_name);
 
             // Reconcile status: check timeout, then tmux liveness

--- a/crosslink/src/commands/kickoff/plan.rs
+++ b/crosslink/src/commands/kickoff/plan.rs
@@ -271,6 +271,9 @@ pub fn plan(crosslink_dir: &Path, db: &Database, opts: &PlanOpts) -> Result<()> 
         bail!("Failed to send keys to tmux: {}", stderr.trim());
     }
 
+    // Persist the actual session name so kickoff list can find it
+    let _ = std::fs::write(worktree_dir.join(".kickoff-session"), &session_name);
+
     // Spawn watchdog sidecar to nudge idle agents
     let watchdog_cfg = read_watchdog_config(crosslink_dir);
     if watchdog_cfg.enabled {

--- a/crosslink/src/commands/kickoff/run.rs
+++ b/crosslink/src/commands/kickoff/run.rs
@@ -178,6 +178,9 @@ pub fn run(
                 opts.skip_permissions,
             )?;
 
+            // Persist the actual session name so kickoff list can find it
+            let _ = std::fs::write(worktree_dir.join(".kickoff-session"), &session_name);
+
             // 10. Report
             if !opts.quiet {
                 println!("Feature agent launched.");


### PR DESCRIPTION
## Summary
- `kickoff list` showed swarm-launched agents as "stopped" because it re-derived the tmux session name instead of reading the actual name used at launch
- When a session name gets a collision suffix (e.g. `name-1234`), the derived base name didn't match
- Now the actual session name is persisted to `.kickoff-session` in the worktree during launch (both `run.rs` and `plan.rs`)
- `discover_agents` reads the stored name first, falling back to derived name for backward compatibility

Closes #507

## Test plan
- [x] `cargo clippy -- -D warnings -W clippy::unwrap_used -W clippy::expect_used` — clean
- [x] `cargo fmt -- --check` — clean
- [x] All kickoff unit and smoke tests pass
- [x] Manual: `crosslink swarm launch` then `crosslink kickoff list` — agents should show as running

🤖 Generated with [Claude Code](https://claude.com/claude-code)