### PR TITLE
feat: add CLI command and MCP tool for reliable tmux prompt delivery

### DIFF
--- a/.claude/mcp/agent-prompt-server.py
+++ b/.claude/mcp/agent-prompt-server.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""
+Crosslink Agent Prompt MCP Server
+
+An MCP server that provides reliable prompt delivery to tmux-based agent sessions.
+Wraps `crosslink agent prompt` to avoid the pitfalls of raw `tmux send-keys`.
+
+Usage:
+    Registered in .claude/settings.json as an MCP server.
+    Claude calls mcp__crosslink-agent-prompt__agent_prompt(session, prompt) to send prompts.
+"""
+
+import json
+import sys
+import io
+import subprocess
+from typing import Any
+
+# Fix Windows encoding issues
+sys.stdin = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
+sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8', line_buffering=True)
+sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8')
+
+
+def log(message: str) -> None:
+    """Log to stderr (visible in MCP server logs)."""
+    print(f"[agent-prompt] {message}", file=sys.stderr)
+
+
+TOOL_DEFINITION = {
+    'name': 'agent_prompt',
+    'description': (
+        'Send a prompt to a running tmux-based agent session. '
+        'Uses tmux load-buffer + paste-buffer for reliable delivery — '
+        'no newline mangling, no length limits, no shell escaping issues. '
+        'Prefer this over raw tmux send-keys for agent-to-agent communication.'
+    ),
+    'inputSchema': {
+        'type': 'object',
+        'properties': {
+            'session': {
+                'type': 'string',
+                'description': 'Agent slug or tmux session name'
+            },
+            'prompt': {
+                'type': 'string',
+                'description': 'The full prompt text to send (supports multiline, any length)'
+            },
+            'submit': {
+                'type': 'boolean',
+                'description': 'Whether to press Enter after pasting to submit the prompt (default: true)',
+                'default': True
+            }
+        },
+        'required': ['session', 'prompt']
+    }
+}
+
+
+def handle_agent_prompt(arguments: dict[str, Any]) -> dict[str, Any]:
+    """Handle the agent_prompt tool call by delegating to crosslink CLI."""
+    session = arguments.get('session', '').strip()
+    prompt = arguments.get('prompt', '')
+    submit = arguments.get('submit', True)
+
+    if not session:
+        return {
+            'content': [{'type': 'text', 'text': 'Error: session is required'}],
+            'isError': True
+        }
+
+    if not prompt:
+        return {
+            'content': [{'type': 'text', 'text': 'Error: prompt is required'}],
+            'isError': True
+        }
+
+    cmd = ['crosslink', 'agent', 'prompt', session, prompt]
+    if not submit:
+        cmd.append('--no-submit')
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=10
+        )
+
+        if result.returncode == 0:
+            output = result.stdout.strip() or f"Prompt sent to session '{session}'"
+            return {
+                'content': [{'type': 'text', 'text': output}]
+            }
+        else:
+            error = result.stderr.strip() or result.stdout.strip() or 'Unknown error'
+            return {
+                'content': [{'type': 'text', 'text': f'Error: {error}'}],
+                'isError': True
+            }
+
+    except subprocess.TimeoutExpired:
+        return {
+            'content': [{'type': 'text', 'text': 'Error: command timed out after 10 seconds'}],
+            'isError': True
+        }
+    except FileNotFoundError:
+        return {
+            'content': [{'type': 'text', 'text': 'Error: crosslink binary not found'}],
+            'isError': True
+        }
+
+
+def handle_request(request: dict[str, Any]) -> dict[str, Any] | None:
+    """Handle an MCP JSON-RPC request."""
+    method = request.get('method', '')
+    request_id = request.get('id')
+    params = request.get('params', {})
+
+    if method == 'initialize':
+        return {
+            'jsonrpc': '2.0',
+            'id': request_id,
+            'result': {
+                'protocolVersion': '2024-11-05',
+                'capabilities': {
+                    'tools': {}
+                },
+                'serverInfo': {
+                    'name': 'crosslink-agent-prompt',
+                    'version': '1.0.0'
+                }
+            }
+        }
+
+    elif method == 'notifications/initialized':
+        return None
+
+    elif method == 'tools/list':
+        return {
+            'jsonrpc': '2.0',
+            'id': request_id,
+            'result': {
+                'tools': [TOOL_DEFINITION]
+            }
+        }
+
+    elif method == 'tools/call':
+        tool_name = params.get('name', '')
+        arguments = params.get('arguments', {})
+
+        if tool_name == 'agent_prompt':
+            result = handle_agent_prompt(arguments)
+            return {
+                'jsonrpc': '2.0',
+                'id': request_id,
+                'result': result
+            }
+        else:
+            return {
+                'jsonrpc': '2.0',
+                'id': request_id,
+                'error': {
+                    'code': -32601,
+                    'message': f'Unknown tool: {tool_name}'
+                }
+            }
+
+    else:
+        return {
+            'jsonrpc': '2.0',
+            'id': request_id,
+            'error': {
+                'code': -32601,
+                'message': f'Method not found: {method}'
+            }
+        }
+
+
+def main():
+    """Main MCP server loop - reads JSON-RPC from stdin, writes to stdout."""
+    log("Starting agent-prompt MCP server")
+
+    while True:
+        try:
+            line = sys.stdin.readline()
+            if not line:
+                break
+
+            line = line.strip()
+            if not line:
+                continue
+
+            request = json.loads(line)
+            response = handle_request(request)
+
+            if response is not None:
+                print(json.dumps(response), flush=True)
+
+        except json.JSONDecodeError as e:
+            log(f"JSON decode error: {e}")
+            error_response = {
+                'jsonrpc': '2.0',
+                'id': None,
+                'error': {
+                    'code': -32700,
+                    'message': 'Parse error'
+                }
+            }
+            print(json.dumps(error_response), flush=True)
+        except Exception as e:
+            log(f"Unexpected error: {e}")
+
+
+if __name__ == '__main__':
+    main()

--- a/crosslink/resources/claude/mcp/agent-prompt-server.py
+++ b/crosslink/resources/claude/mcp/agent-prompt-server.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""
+Crosslink Agent Prompt MCP Server
+
+An MCP server that provides reliable prompt delivery to tmux-based agent sessions.
+Wraps `crosslink agent prompt` to avoid the pitfalls of raw `tmux send-keys`.
+
+Usage:
+    Registered in .claude/settings.json as an MCP server.
+    Claude calls mcp__crosslink-agent-prompt__agent_prompt(session, prompt) to send prompts.
+"""
+
+import json
+import sys
+import io
+import subprocess
+from typing import Any
+
+# Fix Windows encoding issues
+sys.stdin = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
+sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8', line_buffering=True)
+sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8')
+
+
+def log(message: str) -> None:
+    """Log to stderr (visible in MCP server logs)."""
+    print(f"[agent-prompt] {message}", file=sys.stderr)
+
+
+TOOL_DEFINITION = {
+    'name': 'agent_prompt',
+    'description': (
+        'Send a prompt to a running tmux-based agent session. '
+        'Uses tmux load-buffer + paste-buffer for reliable delivery — '
+        'no newline mangling, no length limits, no shell escaping issues. '
+        'Prefer this over raw tmux send-keys for agent-to-agent communication.'
+    ),
+    'inputSchema': {
+        'type': 'object',
+        'properties': {
+            'session': {
+                'type': 'string',
+                'description': 'Agent slug or tmux session name'
+            },
+            'prompt': {
+                'type': 'string',
+                'description': 'The full prompt text to send (supports multiline, any length)'
+            },
+            'submit': {
+                'type': 'boolean',
+                'description': 'Whether to press Enter after pasting to submit the prompt (default: true)',
+                'default': True
+            }
+        },
+        'required': ['session', 'prompt']
+    }
+}
+
+
+def handle_agent_prompt(arguments: dict[str, Any]) -> dict[str, Any]:
+    """Handle the agent_prompt tool call by delegating to crosslink CLI."""
+    session = arguments.get('session', '').strip()
+    prompt = arguments.get('prompt', '')
+    submit = arguments.get('submit', True)
+
+    if not session:
+        return {
+            'content': [{'type': 'text', 'text': 'Error: session is required'}],
+            'isError': True
+        }
+
+    if not prompt:
+        return {
+            'content': [{'type': 'text', 'text': 'Error: prompt is required'}],
+            'isError': True
+        }
+
+    cmd = ['crosslink', 'agent', 'prompt', session, prompt]
+    if not submit:
+        cmd.append('--no-submit')
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=10
+        )
+
+        if result.returncode == 0:
+            output = result.stdout.strip() or f"Prompt sent to session '{session}'"
+            return {
+                'content': [{'type': 'text', 'text': output}]
+            }
+        else:
+            error = result.stderr.strip() or result.stdout.strip() or 'Unknown error'
+            return {
+                'content': [{'type': 'text', 'text': f'Error: {error}'}],
+                'isError': True
+            }
+
+    except subprocess.TimeoutExpired:
+        return {
+            'content': [{'type': 'text', 'text': 'Error: command timed out after 10 seconds'}],
+            'isError': True
+        }
+    except FileNotFoundError:
+        return {
+            'content': [{'type': 'text', 'text': 'Error: crosslink binary not found'}],
+            'isError': True
+        }
+
+
+def handle_request(request: dict[str, Any]) -> dict[str, Any] | None:
+    """Handle an MCP JSON-RPC request."""
+    method = request.get('method', '')
+    request_id = request.get('id')
+    params = request.get('params', {})
+
+    if method == 'initialize':
+        return {
+            'jsonrpc': '2.0',
+            'id': request_id,
+            'result': {
+                'protocolVersion': '2024-11-05',
+                'capabilities': {
+                    'tools': {}
+                },
+                'serverInfo': {
+                    'name': 'crosslink-agent-prompt',
+                    'version': '1.0.0'
+                }
+            }
+        }
+
+    elif method == 'notifications/initialized':
+        return None
+
+    elif method == 'tools/list':
+        return {
+            'jsonrpc': '2.0',
+            'id': request_id,
+            'result': {
+                'tools': [TOOL_DEFINITION]
+            }
+        }
+
+    elif method == 'tools/call':
+        tool_name = params.get('name', '')
+        arguments = params.get('arguments', {})
+
+        if tool_name == 'agent_prompt':
+            result = handle_agent_prompt(arguments)
+            return {
+                'jsonrpc': '2.0',
+                'id': request_id,
+                'result': result
+            }
+        else:
+            return {
+                'jsonrpc': '2.0',
+                'id': request_id,
+                'error': {
+                    'code': -32601,
+                    'message': f'Unknown tool: {tool_name}'
+                }
+            }
+
+    else:
+        return {
+            'jsonrpc': '2.0',
+            'id': request_id,
+            'error': {
+                'code': -32601,
+                'message': f'Method not found: {method}'
+            }
+        }
+
+
+def main():
+    """Main MCP server loop - reads JSON-RPC from stdin, writes to stdout."""
+    log("Starting agent-prompt MCP server")
+
+    while True:
+        try:
+            line = sys.stdin.readline()
+            if not line:
+                break
+
+            line = line.strip()
+            if not line:
+                continue
+
+            request = json.loads(line)
+            response = handle_request(request)
+
+            if response is not None:
+                print(json.dumps(response), flush=True)
+
+        except json.JSONDecodeError as e:
+            log(f"JSON decode error: {e}")
+            error_response = {
+                'jsonrpc': '2.0',
+                'id': None,
+                'error': {
+                    'code': -32700,
+                    'message': 'Parse error'
+                }
+            }
+            print(json.dumps(error_response), flush=True)
+        except Exception as e:
+            log(f"Unexpected error: {e}")
+
+
+if __name__ == '__main__':
+    main()

--- a/crosslink/resources/mcp.json
+++ b/crosslink/resources/mcp.json
@@ -7,6 +7,10 @@
     "crosslink-knowledge": {
       "command": "uv",
       "args": ["run", ".claude/mcp/knowledge-server.py"]
+    },
+    "crosslink-agent-prompt": {
+      "command": "uv",
+      "args": ["run", ".claude/mcp/agent-prompt-server.py"]
     }
   }
 }

--- a/crosslink/src/commands/agent.rs
+++ b/crosslink/src/commands/agent.rs
@@ -23,6 +23,11 @@ pub fn run(command: AgentCommands, crosslink_dir: &Path) -> Result<()> {
             force,
         ),
         AgentCommands::Status => status(crosslink_dir),
+        AgentCommands::Prompt {
+            session,
+            message,
+            no_submit,
+        } => prompt(&session, &message, !no_submit),
         AgentCommands::Bootstrap {
             repo,
             identity,
@@ -135,6 +140,80 @@ pub fn init(
         "Ask your driver to approve this agent with `crosslink trust approve {}`",
         agent_id
     );
+    Ok(())
+}
+
+/// Send a prompt to a running tmux-based agent session.
+///
+/// Uses `tmux load-buffer` + `paste-buffer` instead of raw `send-keys` to
+/// avoid newline interpretation, length limits, and shell escaping issues (#503).
+fn prompt(session: &str, message: &str, submit: bool) -> Result<()> {
+    // Verify the tmux session exists
+    let check = Command::new("tmux")
+        .args(["has-session", "-t", session])
+        .output()
+        .context("tmux not found — is it installed?")?;
+
+    if !check.status.success() {
+        bail!(
+            "tmux session '{}' not found. Check `tmux list-sessions`.",
+            session
+        );
+    }
+
+    // Write prompt to a temp file to avoid shell escaping issues
+    let tmp = std::env::temp_dir().join(format!("crosslink-prompt-{}", std::process::id()));
+    std::fs::write(&tmp, message).context("Failed to write prompt to temp file")?;
+
+    // Load the file into a tmux buffer
+    let load = Command::new("tmux")
+        .args([
+            "load-buffer",
+            "-b",
+            "crosslink-prompt",
+            &tmp.to_string_lossy(),
+        ])
+        .output()
+        .context("Failed to load tmux buffer")?;
+
+    // Clean up temp file regardless of outcome
+    let _ = std::fs::remove_file(&tmp);
+
+    if !load.status.success() {
+        let stderr = String::from_utf8_lossy(&load.stderr);
+        bail!("tmux load-buffer failed: {}", stderr.trim());
+    }
+
+    // Paste the buffer into the target session
+    let paste = Command::new("tmux")
+        .args(["paste-buffer", "-b", "crosslink-prompt", "-t", session])
+        .output()
+        .context("Failed to paste tmux buffer")?;
+
+    if !paste.status.success() {
+        let stderr = String::from_utf8_lossy(&paste.stderr);
+        bail!("tmux paste-buffer failed: {}", stderr.trim());
+    }
+
+    // Delete the named buffer
+    let _ = Command::new("tmux")
+        .args(["delete-buffer", "-b", "crosslink-prompt"])
+        .output();
+
+    // Optionally press Enter to submit
+    if submit {
+        let enter = Command::new("tmux")
+            .args(["send-keys", "-t", session, "Enter"])
+            .output()
+            .context("Failed to send Enter key")?;
+
+        if !enter.status.success() {
+            let stderr = String::from_utf8_lossy(&enter.stderr);
+            bail!("tmux send-keys Enter failed: {}", stderr.trim());
+        }
+    }
+
+    println!("Prompt sent to session '{}'", session);
     Ok(())
 }
 

--- a/crosslink/src/main.rs
+++ b/crosslink/src/main.rs
@@ -991,6 +991,16 @@ enum AgentCommands {
     },
     /// Show current agent identity
     Status,
+    /// Send a prompt to a running tmux-based agent session
+    Prompt {
+        /// Agent slug or tmux session name
+        session: String,
+        /// Prompt text to send (supports multiline)
+        message: String,
+        /// Don't press Enter after pasting (just type, don't submit)
+        #[arg(long)]
+        no_submit: bool,
+    },
     /// Bootstrap agent identity in a new or existing repo clone
     Bootstrap {
         /// Git repository URL to clone


### PR DESCRIPTION
## Summary
- Adds `crosslink agent prompt <session> <message>` CLI command that uses `tmux load-buffer` + `paste-buffer` instead of raw `send-keys`
- Eliminates newline mangling, length limits, and shell escaping issues that made agent-to-agent tmux communication unreliable
- Adds MCP server (`agent-prompt-server.py`) wrapping the CLI, making prompt delivery discoverable as a tool and auditable in conversation logs
- `--no-submit` flag to paste without pressing Enter
- Resource templates + `mcp.json` updated so `crosslink init` deploys both

Closes #503

## Test plan
- [x] `cargo clippy -- -D warnings -W clippy::unwrap_used -W clippy::expect_used` — clean
- [x] `cargo fmt -- --check` — clean
- [x] MCP server Python syntax check passes
- [x] Manual: `crosslink agent prompt <session> "hello"` sends prompt reliably
- [x] Manual: multiline prompts delivered intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)