### PR TITLE
feat: add jj (Jujutsu) read-only commands to allowed_bash_prefixes

### DIFF
--- a/.claude/hooks/work-check.py
+++ b/.claude/hooks/work-check.py
@@ -52,6 +52,7 @@ DEFAULT_GATED_GIT = [
 DEFAULT_ALLOWED_BASH = [
     "crosslink ",
     "git status", "git diff", "git log", "git branch", "git show",
+    "jj log", "jj diff", "jj status", "jj show", "jj bookmark list",
     "cargo test", "cargo build", "cargo check", "cargo clippy", "cargo fmt",
     "npm test", "npm run", "npx ",
     "tsc", "node ", "python ",

--- a/crosslink/resources/claude/hooks/work-check.py
+++ b/crosslink/resources/claude/hooks/work-check.py
@@ -52,6 +52,7 @@ DEFAULT_GATED_GIT = [
 DEFAULT_ALLOWED_BASH = [
     "crosslink ",
     "git status", "git diff", "git log", "git branch", "git show",
+    "jj log", "jj diff", "jj status", "jj show", "jj bookmark list",
     "cargo test", "cargo build", "cargo check", "cargo clippy", "cargo fmt",
     "npm test", "npm run", "npx ",
     "tsc", "node ", "python ",

--- a/crosslink/resources/crosslink/hook-config.json
+++ b/crosslink/resources/crosslink/hook-config.json
@@ -18,6 +18,7 @@
   "allowed_bash_prefixes": [
     "crosslink ",
     "git status", "git diff", "git log", "git branch", "git show",
+    "jj log", "jj diff", "jj status", "jj show", "jj bookmark list",
     "cargo test", "cargo build", "cargo check", "cargo clippy", "cargo fmt",
     "npm test", "npm run", "npx ",
     "tsc", "node ", "python ",


### PR DESCRIPTION
## Summary
- Adds `jj log`, `jj diff`, `jj status`, `jj show`, `jj bookmark list` to default allowed bash prefixes
- Projects using Jujutsu VCS can now use read-only commands without needing an active crosslink issue
- Mutation commands (`jj commit`, `jj new`, `jj git push`) remain gated by default
- Updated both the deployed hook and the resource template

Closes #385

## Test plan
- [x] `cargo clippy` + `cargo fmt` — clean
- [x] Python syntax check passes
- [x] Compile check passes (hook-config.json template updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)