### PR TITLE
fix: QA batch 2 — orchestrator, pipeline, kickoff, swarm

### DIFF
--- a/crosslink/src/commands/kickoff/mod.rs
+++ b/crosslink/src/commands/kickoff/mod.rs
@@ -15,7 +15,10 @@ mod wizard;
 mod tests;
 
 // Re-export public types used by external callers (swarm, main, etc.)
-pub use types::{ContainerMode, KickoffOpts, KickoffReport, PlanOpts, ReportFormat, VerifyLevel};
+pub use types::{
+    ContainerMode, KickoffOpts, KickoffReport, PlanOpts, ReportFormat, VerifyLevel,
+    DEFAULT_AGENT_IMAGE,
+};
 
 // Re-export parse functions (used by dispatch and swarm)
 pub use types::{parse_container_mode, parse_duration, parse_verify_level};
@@ -263,7 +266,7 @@ fn dispatch_launch(
             container: parse_container_mode(&container)?,
             verify: parse_verify_level(&verify)?,
             model: &model,
-            image: "ghcr.io/forecast-bio/crosslink-agent:latest",
+            image: types::DEFAULT_AGENT_IMAGE,
             timeout: parse_duration(&timeout)?,
             dry_run,
             branch: None,
@@ -346,7 +349,7 @@ fn dispatch_launch(
                 container: parse_container_mode(&config.container)?,
                 verify: parse_verify_level(&config.verify)?,
                 model: &config.model,
-                image: "ghcr.io/forecast-bio/crosslink-agent:latest",
+                image: types::DEFAULT_AGENT_IMAGE,
                 timeout: parse_duration(&config.timeout)?,
                 dry_run: false,
                 branch: None,

--- a/crosslink/src/commands/kickoff/types.rs
+++ b/crosslink/src/commands/kickoff/types.rs
@@ -4,6 +4,12 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::time::Duration;
 
+/// Default container image for agent execution.
+///
+/// Consolidated here to avoid duplicating the string literal across kickoff,
+/// swarm, and CLI default values.
+pub const DEFAULT_AGENT_IMAGE: &str = "ghcr.io/forecast-bio/crosslink-agent:latest";
+
 /// Container runtime for agent execution.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ContainerMode {

--- a/crosslink/src/commands/swarm/budget.rs
+++ b/crosslink/src/commands/swarm/budget.rs
@@ -154,10 +154,7 @@ pub fn estimate(crosslink_dir: &Path, phase_slug: &str) -> Result<()> {
     let (phase, _) = load_phase(&sync, phase_slug)?;
 
     let budget_config: BudgetConfig =
-        read_hub_json(&sync, &ctx.budget_path()).unwrap_or(BudgetConfig {
-            budget_window_s: 18000, // default 5h
-            model: "opus".to_string(),
-        });
+        read_hub_json(&sync, &ctx.budget_path()).unwrap_or(BudgetConfig::default());
 
     let cost_log: CostLog = read_hub_json(&sync, &ctx.history_path()).unwrap_or_default();
 
@@ -243,10 +240,7 @@ pub fn launch_budget_aware(
     let (phase, _) = load_phase(&sync, phase_slug)?;
 
     let budget_config: BudgetConfig =
-        read_hub_json(&sync, &ctx.budget_path()).unwrap_or(BudgetConfig {
-            budget_window_s: 18000,
-            model: "opus".to_string(),
-        });
+        read_hub_json(&sync, &ctx.budget_path()).unwrap_or(BudgetConfig::default());
 
     let cost_log: CostLog = read_hub_json(&sync, &ctx.history_path()).unwrap_or_default();
 
@@ -432,7 +426,12 @@ pub(super) fn recompute_model_estimates(cost_log: &mut CostLog) {
     for (model, mut durations) in by_model {
         durations.sort();
         let len = durations.len();
-        let median = durations[len / 2];
+        // Correct median for even-length arrays: average the two middle values.
+        let median = if len % 2 == 0 && len >= 2 {
+            (durations[len / 2 - 1] + durations[len / 2]) / 2
+        } else {
+            durations[len / 2]
+        };
         let p90_idx = ((len as f64) * 0.9).ceil() as usize;
         let p90 = durations[p90_idx.min(len - 1)];
 
@@ -542,10 +541,7 @@ pub fn plan(crosslink_dir: &Path, budget_window: Option<&str>) -> Result<()> {
         .context("No swarm plan found. Run `crosslink swarm init --doc <file>` first.")?;
 
     let budget_config: BudgetConfig =
-        read_hub_json(&sync, &ctx.budget_path()).unwrap_or(BudgetConfig {
-            budget_window_s: 18000,
-            model: "opus".to_string(),
-        });
+        read_hub_json(&sync, &ctx.budget_path()).unwrap_or(BudgetConfig::default());
 
     let window_s = if let Some(w) = budget_window {
         kickoff::parse_duration(w)?.as_secs()

--- a/crosslink/src/commands/swarm/lifecycle.rs
+++ b/crosslink/src/commands/swarm/lifecycle.rs
@@ -90,10 +90,13 @@ pub fn archive(crosslink_dir: &Path) -> Result<()> {
         let _ = std::fs::remove_dir_all(sync.cache_path().join(ctx.base));
     }
 
+    // Stage all swarm/ changes (additions, modifications, and deletions) on the
+    // hub branch cache. This is safe because the cache is a dedicated worktree
+    // for crosslink/hub, not the user's working tree.
     let cache = sync.cache_path();
     if let Ok(o) = std::process::Command::new("git")
         .current_dir(cache)
-        .args(["add", "-A", "swarm/"])
+        .args(["add", "--all", "--", "swarm/"])
         .output()
     {
         if !o.status.success() {
@@ -165,10 +168,11 @@ pub fn reset(crosslink_dir: &Path, no_archive: bool) -> Result<()> {
         let _ = std::fs::remove_dir_all(sync.cache_path().join(ctx.base));
     }
 
+    // Stage all swarm/ changes on the hub branch cache (see archive() comment).
     let cache = sync.cache_path();
     if let Ok(o) = std::process::Command::new("git")
         .current_dir(cache)
-        .args(["add", "-A", "swarm/"])
+        .args(["add", "--all", "--", "swarm/"])
         .output()
     {
         if !o.status.success() {
@@ -750,7 +754,7 @@ pub fn launch(
             container: ContainerMode::None,
             verify: VerifyLevel::Local,
             model: "opus",
-            image: "ghcr.io/forecast-bio/crosslink-agent:latest",
+            image: kickoff::DEFAULT_AGENT_IMAGE,
             timeout: std::time::Duration::from_secs(3600),
             dry_run: false,
             branch: branch.as_deref(),

--- a/crosslink/src/commands/swarm/merge.rs
+++ b/crosslink/src/commands/swarm/merge.rs
@@ -92,11 +92,28 @@ fn discover_worktrees(repo_root: &Path) -> Result<Vec<MergeSource>> {
 }
 
 /// Extract line ranges modified by a diff for a specific file in a worktree.
+///
+/// Tries multiple base refs (develop, main, origin/develop, origin/main) to handle
+/// worktrees created from different bases, matching `discover_worktrees` behavior.
 fn extract_diff_ranges(worktree: &Path, file: &str) -> Result<Vec<(usize, usize)>> {
-    let output = std::process::Command::new("git")
-        .current_dir(worktree)
-        .args(["diff", "develop...HEAD", "--", file])
-        .output()
+    // Try multiple base refs instead of hardcoding "develop"
+    let base_refs = ["develop", "main", "origin/develop", "origin/main"];
+    let mut last_output = None;
+    for base in &base_refs {
+        let output = std::process::Command::new("git")
+            .current_dir(worktree)
+            .args(["diff", &format!("{}...HEAD", base), "--", file])
+            .output();
+        if let Ok(ref o) = output {
+            if o.status.success() && !o.stdout.is_empty() {
+                last_output = Some(output);
+                break;
+            }
+        }
+        last_output = Some(output);
+    }
+    let output = last_output
+        .ok_or_else(|| anyhow::anyhow!("No base ref available for diff"))?
         .context("Failed to run git diff")?;
 
     if !output.status.success() {

--- a/crosslink/src/commands/swarm/types.rs
+++ b/crosslink/src/commands/swarm/types.rs
@@ -135,6 +135,16 @@ pub struct BudgetConfig {
     pub model: String,
 }
 
+/// Default: 5-hour window, opus model (#521).
+impl Default for BudgetConfig {
+    fn default() -> Self {
+        Self {
+            budget_window_s: 18000,
+            model: "opus".to_string(),
+        }
+    }
+}
+
 /// Historical cost log stored at `swarm/history/cost-log.json`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct CostLog {

--- a/crosslink/src/orchestrator/dag.rs
+++ b/crosslink/src/orchestrator/dag.rs
@@ -46,6 +46,10 @@ pub struct Dag {
     forward: HashMap<String, HashSet<String>>,
     /// Reverse edges: `stage_id → set of stages it depends on`.
     reverse: HashMap<String, HashSet<String>>,
+    /// Cached topological sort result. Computed once after construction since
+    /// the graph structure (nodes/edges) never changes — only statuses do (#485).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    cached_topo_order: Option<Vec<String>>,
 }
 
 impl Dag {
@@ -55,6 +59,7 @@ impl Dag {
             nodes: HashMap::new(),
             forward: HashMap::new(),
             reverse: HashMap::new(),
+            cached_topo_order: None,
         }
     }
 
@@ -94,10 +99,9 @@ impl Dag {
             }
         }
 
-        // Validate acyclicity.
-        if dag.has_cycle() {
-            bail!("Dependency graph contains a cycle");
-        }
+        // Validate acyclicity and cache topological order (#485).
+        let topo = dag.topological_sort()?;
+        dag.cached_topo_order = Some(topo);
 
         Ok(dag)
     }
@@ -212,7 +216,14 @@ impl Dag {
         }
         node.status = StageStatus::Done;
 
-        // Find newly unblocked dependents.
+        Ok(self.find_newly_unblocked(id))
+    }
+
+    /// Find dependents of `id` that are now unblocked (all deps terminal and node pending).
+    ///
+    /// Shared by `mark_done` and `mark_skipped_and_unblock` to avoid duplicating
+    /// the unblocking logic (#483).
+    fn find_newly_unblocked(&self, id: &str) -> Vec<String> {
         let dependents = self.forward.get(id).cloned().unwrap_or_default();
         let mut newly_ready = Vec::new();
         for dep_id in dependents {
@@ -242,8 +253,16 @@ impl Dag {
                 }
             }
         }
+        newly_ready
+    }
 
-        Ok(newly_ready)
+    /// Mark a stage as skipped and return newly-unblocked dependents.
+    ///
+    /// Combines `mark_skipped` with the same unblocking logic used by `mark_done`
+    /// so callers don't need to reimplement it (#483).
+    pub fn mark_skipped_and_unblock(&mut self, id: &str) -> Result<Vec<String>> {
+        self.mark_skipped(id)?;
+        Ok(self.find_newly_unblocked(id))
     }
 
     /// Mark a stage as failed. Valid from `Pending` or `Running`.
@@ -435,17 +454,24 @@ impl Dag {
     }
 
     /// Return all stages grouped by phase ID, preserving topological order within each phase.
+    ///
+    /// Uses the cached topological sort computed at construction time (#485).
     pub fn stages_by_phase(&self) -> HashMap<String, Vec<String>> {
         let mut by_phase: HashMap<String, Vec<String>> = HashMap::new();
-        // Use topological order for consistent ordering.
-        if let Ok(order) = self.topological_sort() {
+        // Use cached topological order for consistent ordering without recomputation.
+        let order = self
+            .cached_topo_order
+            .as_ref()
+            .cloned()
+            .or_else(|| self.topological_sort().ok());
+        if let Some(order) = order {
             for id in order {
                 if let Some(node) = self.nodes.get(&id) {
                     by_phase.entry(node.phase_id.clone()).or_default().push(id);
                 }
             }
         } else {
-            // Fallback: arbitrary order.
+            // Fallback: arbitrary order (should not happen for valid DAGs).
             for (id, node) in &self.nodes {
                 by_phase
                     .entry(node.phase_id.clone())
@@ -553,7 +579,8 @@ mod tests {
             make_node("b", "p1", &["a"]),
         ]);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("cycle"));
+        let err_msg = result.unwrap_err().to_string().to_lowercase();
+        assert!(err_msg.contains("cycle"), "Expected 'cycle' in error: {}", err_msg);
     }
 
     #[test]

--- a/crosslink/src/orchestrator/decompose.rs
+++ b/crosslink/src/orchestrator/decompose.rs
@@ -10,9 +10,9 @@ use anyhow::{bail, Context, Result};
 use chrono::Utc;
 use uuid::Uuid;
 
-use crate::orchestrator::models::{LlmDecomposeResponse, StoredPlan};
-use crate::server::types::{
-    OrchestratorPhase, OrchestratorPlan, OrchestratorStage, OrchestratorTask,
+use crate::orchestrator::models::{
+    LlmDecomposeResponse, OrchestratorPhase, OrchestratorPlan, OrchestratorStage,
+    OrchestratorTask, StoredPlan,
 };
 
 // ---------------------------------------------------------------------------
@@ -251,12 +251,11 @@ fn transform_to_plan(response: LlmDecomposeResponse, slug: &str) -> Orchestrator
 // Plan storage
 // ---------------------------------------------------------------------------
 
-/// Directory within `.crosslink/` where orchestrator plans are stored.
-const PLANS_DIR: &str = "orchestrator";
+use crate::orchestrator::models::ORCHESTRATOR_DIR;
 
 /// Ensure the orchestrator storage directory exists.
 fn ensure_plans_dir(crosslink_dir: &Path) -> Result<PathBuf> {
-    let dir = crosslink_dir.join(PLANS_DIR);
+    let dir = crosslink_dir.join(ORCHESTRATOR_DIR);
     std::fs::create_dir_all(&dir)
         .with_context(|| format!("Failed to create orchestrator directory: {}", dir.display()))?;
     Ok(dir)
@@ -288,7 +287,7 @@ fn store_plan(
 
 /// Load a stored plan from disk by its ID.
 pub fn load_plan(crosslink_dir: &Path, plan_id: &str) -> Result<StoredPlan> {
-    let dir = crosslink_dir.join(PLANS_DIR);
+    let dir = crosslink_dir.join(ORCHESTRATOR_DIR);
     let path = dir.join(format!("{plan_id}.json"));
     let content = std::fs::read_to_string(&path)
         .with_context(|| format!("Plan not found: {}", path.display()))?;
@@ -297,7 +296,7 @@ pub fn load_plan(crosslink_dir: &Path, plan_id: &str) -> Result<StoredPlan> {
 
 /// List all stored plan IDs.
 pub fn list_plans(crosslink_dir: &Path) -> Result<Vec<String>> {
-    let dir = crosslink_dir.join(PLANS_DIR);
+    let dir = crosslink_dir.join(ORCHESTRATOR_DIR);
     if !dir.exists() {
         return Ok(vec![]);
     }
@@ -786,12 +785,12 @@ mod tests {
         };
 
         // The orchestrator directory should not exist yet
-        assert!(!crosslink_dir.join(PLANS_DIR).exists());
+        assert!(!crosslink_dir.join(ORCHESTRATOR_DIR).exists());
 
         store_plan(crosslink_dir, &plan, "content").unwrap();
 
         // Now it should exist
-        assert!(crosslink_dir.join(PLANS_DIR).exists());
+        assert!(crosslink_dir.join(ORCHESTRATOR_DIR).exists());
     }
 
     #[test]
@@ -800,7 +799,7 @@ mod tests {
         let crosslink_dir = dir.path();
 
         // Create the orchestrator directory
-        let orch_dir = crosslink_dir.join(PLANS_DIR);
+        let orch_dir = crosslink_dir.join(ORCHESTRATOR_DIR);
         std::fs::create_dir_all(&orch_dir).unwrap();
 
         // Write a json file and a non-json file
@@ -816,7 +815,7 @@ mod tests {
     fn test_load_plan_corrupt_json() {
         let dir = tempfile::tempdir().unwrap();
         let crosslink_dir = dir.path();
-        let orch_dir = crosslink_dir.join(PLANS_DIR);
+        let orch_dir = crosslink_dir.join(ORCHESTRATOR_DIR);
         std::fs::create_dir_all(&orch_dir).unwrap();
         std::fs::write(orch_dir.join("bad.json"), "not valid json!").unwrap();
 

--- a/crosslink/src/orchestrator/executor.rs
+++ b/crosslink/src/orchestrator/executor.rs
@@ -20,18 +20,15 @@ use std::path::{Path, PathBuf};
 use anyhow::{bail, Context, Result};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use tokio::sync::broadcast;
-
 use crate::db::Database;
 use crate::orchestrator::dag::{Dag, DagNode};
+use crate::orchestrator::models::{OrchestratorPlan, OrchestratorStage};
 use crate::server::types::{
-    ExecutionState, ExecutionStatus, OrchestratorPlan, OrchestratorStage, StageStatus,
-    WsExecutionProgressEvent,
+    ExecutionState, ExecutionStatus, StageStatus, WsExecutionProgressEvent,
 };
 use crate::server::ws::WsEvent;
 
-/// Directory within `.crosslink` for orchestrator state.
-const ORCHESTRATOR_DIR: &str = "orchestrator";
+use crate::orchestrator::models::ORCHESTRATOR_DIR;
 /// Filename for the persisted execution state.
 const EXECUTION_FILE: &str = "execution.json";
 /// Filename for the active plan.
@@ -340,6 +337,40 @@ impl OrchestratorExecutor {
         Ok(ready)
     }
 
+    /// Build a `WsExecutionProgressEvent` for the given stage and status (#481).
+    ///
+    /// Centralizes event construction so executor methods don't couple directly
+    /// to the WebSocket event shape.
+    fn build_progress_event(
+        &self,
+        stage_id: &str,
+        status: StageStatus,
+    ) -> WsExecutionProgressEvent {
+        let node = self.snapshot.dag.get(stage_id);
+        WsExecutionProgressEvent {
+            event_type: "execution_progress",
+            plan_id: self.snapshot.plan_id.clone(),
+            phase_id: node.map(|n| n.phase_id.clone()).unwrap_or_default(),
+            stage_id: stage_id.to_string(),
+            status,
+            agent_id: node.and_then(|n| n.agent_id.clone()),
+        }
+    }
+
+    /// Verify that execution is in a state that allows stage mutations.
+    ///
+    /// Returns an error if the execution is not Running (#486).
+    fn require_running_state(&self, action: &str) -> Result<()> {
+        if self.snapshot.state != ExecutionState::Running {
+            bail!(
+                "Cannot {} — execution state is {:?}, must be Running",
+                action,
+                self.snapshot.state
+            );
+        }
+        Ok(())
+    }
+
     /// Record that a stage has been launched with the given agent ID.
     ///
     /// Returns an event to broadcast over WebSocket.
@@ -348,6 +379,7 @@ impl OrchestratorExecutor {
         stage_id: &str,
         agent_id: &str,
     ) -> Result<WsExecutionProgressEvent> {
+        self.require_running_state("mark stage running")?;
         self.snapshot.dag.mark_running(stage_id, agent_id)?;
 
         // Update current phase if needed.
@@ -357,19 +389,7 @@ impl OrchestratorExecutor {
 
         self.persist()?;
 
-        Ok(WsExecutionProgressEvent {
-            event_type: "execution_progress",
-            plan_id: self.snapshot.plan_id.clone(),
-            phase_id: self
-                .snapshot
-                .dag
-                .get(stage_id)
-                .map(|n| n.phase_id.clone())
-                .unwrap_or_default(),
-            stage_id: stage_id.to_string(),
-            status: StageStatus::Running,
-            agent_id: Some(agent_id.to_string()),
-        })
+        Ok(self.build_progress_event(stage_id, StageStatus::Running))
     }
 
     /// Record that a stage has completed successfully.
@@ -380,6 +400,7 @@ impl OrchestratorExecutor {
         stage_id: &str,
         db: &Database,
     ) -> Result<(Vec<String>, WsExecutionProgressEvent, bool)> {
+        self.require_running_state("mark stage done")?;
         let phase_id = self
             .snapshot
             .dag
@@ -424,18 +445,7 @@ impl OrchestratorExecutor {
 
         self.persist()?;
 
-        let event = WsExecutionProgressEvent {
-            event_type: "execution_progress",
-            plan_id: self.snapshot.plan_id.clone(),
-            phase_id,
-            stage_id: stage_id.to_string(),
-            status: StageStatus::Done,
-            agent_id: self
-                .snapshot
-                .dag
-                .get(stage_id)
-                .and_then(|n| n.agent_id.clone()),
-        };
+        let event = self.build_progress_event(stage_id, StageStatus::Done);
 
         Ok((newly_ready, event, execution_complete))
     }
@@ -447,12 +457,7 @@ impl OrchestratorExecutor {
         &mut self,
         stage_id: &str,
     ) -> Result<(WsExecutionProgressEvent, bool)> {
-        let phase_id = self
-            .snapshot
-            .dag
-            .get(stage_id)
-            .map(|n| n.phase_id.clone())
-            .unwrap_or_default();
+        self.require_running_state("mark stage failed")?;
 
         self.snapshot.dag.mark_failed(stage_id)?;
 
@@ -465,18 +470,7 @@ impl OrchestratorExecutor {
 
         self.persist()?;
 
-        let event = WsExecutionProgressEvent {
-            event_type: "execution_progress",
-            plan_id: self.snapshot.plan_id.clone(),
-            phase_id,
-            stage_id: stage_id.to_string(),
-            status: StageStatus::Failed,
-            agent_id: self
-                .snapshot
-                .dag
-                .get(stage_id)
-                .and_then(|n| n.agent_id.clone()),
-        };
+        let event = self.build_progress_event(stage_id, StageStatus::Failed);
 
         Ok((event, execution_complete))
     }
@@ -486,48 +480,13 @@ impl OrchestratorExecutor {
         &mut self,
         stage_id: &str,
     ) -> Result<(Vec<String>, WsExecutionProgressEvent)> {
-        let phase_id = self
-            .snapshot
-            .dag
-            .get(stage_id)
-            .map(|n| n.phase_id.clone())
-            .unwrap_or_default();
-
-        self.snapshot.dag.mark_skipped(stage_id)?;
-
-        // Treat skipped the same as done for unblocking purposes: check dependents.
-        // We manually check since mark_skipped doesn't return unblocked nodes.
-        let dependents = self.snapshot.dag.dependents(stage_id);
-        let mut newly_ready = Vec::new();
-        for dep_id in dependents {
-            if let Some(dep_node) = self.snapshot.dag.get(&dep_id) {
-                if dep_node.status != StageStatus::Pending {
-                    continue;
-                }
-                let deps = self.snapshot.dag.dependencies(&dep_id);
-                let all_done = deps.iter().all(|d| {
-                    self.snapshot
-                        .dag
-                        .get(d)
-                        .map(|n| matches!(n.status, StageStatus::Done | StageStatus::Skipped))
-                        .unwrap_or(false)
-                });
-                if all_done {
-                    newly_ready.push(dep_id);
-                }
-            }
-        }
+        // Use mark_skipped_and_unblock which shares the same unblocking logic
+        // as mark_done via find_newly_unblocked (#483).
+        let newly_ready = self.snapshot.dag.mark_skipped_and_unblock(stage_id)?;
 
         self.persist()?;
 
-        let event = WsExecutionProgressEvent {
-            event_type: "execution_progress",
-            plan_id: self.snapshot.plan_id.clone(),
-            phase_id,
-            stage_id: stage_id.to_string(),
-            status: StageStatus::Skipped,
-            agent_id: None,
-        };
+        let event = self.build_progress_event(stage_id, StageStatus::Skipped);
 
         Ok((newly_ready, event))
     }
@@ -604,8 +563,14 @@ impl OrchestratorExecutor {
         completed
     }
 
-    /// Broadcast a WebSocket event through the given sender.
-    pub fn broadcast_event(tx: &broadcast::Sender<WsEvent>, event: WsExecutionProgressEvent) {
+    /// Broadcast a WebSocket event through the given sender (#493/#494).
+    ///
+    /// Import is scoped to the method body since it is the only consumer of
+    /// `tokio::sync::broadcast` in this module.
+    pub fn broadcast_event(
+        tx: &tokio::sync::broadcast::Sender<WsEvent>,
+        event: WsExecutionProgressEvent,
+    ) {
         // INTENTIONAL: broadcast failure is harmless when no WebSocket subscribers are connected
         let _ = tx.send(WsEvent::ExecutionProgress(event));
     }
@@ -662,7 +627,7 @@ fn build_stage_description(stage: &OrchestratorStage) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::server::types::{OrchestratorPhase, OrchestratorStage, OrchestratorTask};
+    use crate::orchestrator::models::{OrchestratorPhase, OrchestratorStage, OrchestratorTask};
     use tempfile::TempDir;
 
     fn make_test_plan() -> OrchestratorPlan {

--- a/crosslink/src/orchestrator/models.rs
+++ b/crosslink/src/orchestrator/models.rs
@@ -1,13 +1,18 @@
-//! Domain types for LLM-assisted document decomposition.
+//! Domain types for the orchestrator module.
 //!
-//! These types are the raw schema expected from the LLM (Claude CLI) output.
-//! [`crate::orchestrator::decompose`] transforms them into the API-facing
-//! [`OrchestratorPlan`](crate::server::types::OrchestratorPlan) types.
-//!
-//! They are also used for on-disk storage in `.crosslink/orchestrator/`.
+//! Contains both the raw LLM response schema and the canonical orchestrator
+//! plan types (`OrchestratorPlan`, `OrchestratorPhase`, `OrchestratorStage`,
+//! `OrchestratorTask`). These plan types are re-exported from
+//! `crate::server::types` for backward compatibility with the REST API.
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+
+/// Directory within `.crosslink/` for orchestrator state and plan storage.
+///
+/// Used by both `decompose` (plan files) and `executor` (execution state).
+/// Consolidated here to avoid duplication (#491).
+pub const ORCHESTRATOR_DIR: &str = "orchestrator";
 
 // ---------------------------------------------------------------------------
 // LLM response schema
@@ -69,6 +74,59 @@ fn default_agent_count() -> usize {
 }
 
 // ---------------------------------------------------------------------------
+// Orchestrator plan types (canonical definitions — #480)
+// ---------------------------------------------------------------------------
+// These types were previously defined in `server::types` but belong in the
+// orchestrator domain module. They are re-exported from `server::types` for
+// backward compatibility with existing API handlers and dashboard code.
+
+/// An atomic work item within an orchestration stage.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OrchestratorTask {
+    pub id: String,
+    pub title: String,
+    pub description: String,
+    /// Estimated complexity in agent-hours.
+    pub complexity_hours: f64,
+}
+
+/// A work unit within a phase — may have parallel agents.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OrchestratorStage {
+    pub id: String,
+    pub title: String,
+    pub description: String,
+    pub tasks: Vec<OrchestratorTask>,
+    /// IDs of stages that must complete before this one starts.
+    pub depends_on: Vec<String>,
+    /// Suggested number of parallel agents for this stage.
+    pub agent_count: usize,
+    pub complexity_hours: f64,
+}
+
+/// A major sequential milestone in the execution plan.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OrchestratorPhase {
+    pub id: String,
+    pub title: String,
+    pub description: String,
+    pub stages: Vec<OrchestratorStage>,
+    /// Criteria for declaring this phase complete (e.g. test pass, merge gate).
+    pub gate_criteria: Vec<String>,
+}
+
+/// The full LLM-decomposed execution plan.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OrchestratorPlan {
+    pub id: String,
+    pub document_slug: String,
+    pub phases: Vec<OrchestratorPhase>,
+    pub created_at: DateTime<Utc>,
+    pub total_stages: usize,
+    pub estimated_hours: f64,
+}
+
+// ---------------------------------------------------------------------------
 // Plan storage
 // ---------------------------------------------------------------------------
 
@@ -79,7 +137,7 @@ fn default_agent_count() -> usize {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StoredPlan {
     /// The plan itself (same shape as the API response).
-    pub plan: crate::server::types::OrchestratorPlan,
+    pub plan: OrchestratorPlan,
     /// The raw markdown document that was decomposed.
     pub source_document: String,
     /// When the plan was stored.
@@ -156,7 +214,6 @@ mod tests {
 
     #[test]
     fn stored_plan_round_trip() {
-        use crate::server::types::OrchestratorPlan;
         let plan = StoredPlan {
             plan: OrchestratorPlan {
                 id: "test-plan".to_string(),

--- a/crosslink/src/pipeline.rs
+++ b/crosslink/src/pipeline.rs
@@ -7,7 +7,7 @@
 // session boundaries and can be resumed after human checkpoints.
 
 use anyhow::{bail, Context, Result};
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 use uuid::Uuid;
@@ -20,7 +20,8 @@ use uuid::Uuid;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Pipeline {
     pub id: String,
-    pub created_at: String,
+    /// When the pipeline was created (#490: DateTime instead of String).
+    pub created_at: DateTime<Utc>,
     pub current_stage: PipelineStage,
     pub config: PipelineConfig,
     pub history: Vec<StageTransition>,
@@ -56,18 +57,19 @@ pub enum PipelineStage {
 }
 
 impl std::fmt::Display for PipelineStage {
+    /// Display uses snake_case to match the serde serialization format (#489).
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Partition => write!(f, "partition"),
             Self::Review => write!(f, "review"),
-            Self::AwaitReview => write!(f, "await-review"),
+            Self::AwaitReview => write!(f, "await_review"),
             Self::Consolidate => write!(f, "consolidate"),
-            Self::HumanCheckpoint => write!(f, "human-checkpoint"),
-            Self::FileIssues => write!(f, "file-issues"),
+            Self::HumanCheckpoint => write!(f, "human_checkpoint"),
+            Self::FileIssues => write!(f, "file_issues"),
             Self::Fix => write!(f, "fix"),
-            Self::AwaitFix => write!(f, "await-fix"),
+            Self::AwaitFix => write!(f, "await_fix"),
             Self::Merge => write!(f, "merge"),
-            Self::PullRequest => write!(f, "pull-request"),
+            Self::PullRequest => write!(f, "pull_request"),
             Self::Done => write!(f, "done"),
             Self::Failed => write!(f, "failed"),
         }
@@ -87,7 +89,8 @@ pub struct PipelineConfig {
 pub struct StageTransition {
     pub from: PipelineStage,
     pub to: PipelineStage,
-    pub timestamp: String,
+    /// When this transition occurred (#490: DateTime instead of String).
+    pub timestamp: DateTime<Utc>,
     pub notes: Option<String>,
 }
 
@@ -98,14 +101,15 @@ pub struct StageTransition {
 impl Pipeline {
     /// Create a new pipeline starting at the Partition stage.
     pub fn new(config: PipelineConfig) -> Self {
+        let now = Utc::now();
         let id = format!(
             "pipeline-{}-{}",
-            Utc::now().format("%Y%m%d-%H%M%S"),
+            now.format("%Y%m%d-%H%M%S"),
             &Uuid::new_v4().to_string()[..8],
         );
         Self {
             id,
-            created_at: Utc::now().to_rfc3339(),
+            created_at: now,
             current_stage: PipelineStage::Partition,
             config,
             history: Vec::new(),
@@ -190,7 +194,7 @@ impl Pipeline {
     pub fn summary(&self) -> String {
         let mut lines = Vec::new();
         lines.push(format!("Pipeline: {}", self.id));
-        lines.push(format!("Created:  {}", self.created_at));
+        lines.push(format!("Created:  {}", self.created_at.to_rfc3339()));
         lines.push(format!("Stage:    {}", self.current_stage));
         lines.push(format!("Agents:   {}", self.config.agent_count));
         lines.push(format!("Mandate:  {}", self.config.mandate));
@@ -212,7 +216,7 @@ impl Pipeline {
                     .unwrap_or_default();
                 lines.push(format!(
                     "  {} -> {} at {}{}",
-                    t.from, t.to, t.timestamp, notes
+                    t.from, t.to, t.timestamp.to_rfc3339(), notes
                 ));
             }
         }
@@ -229,7 +233,7 @@ impl Pipeline {
         self.history.push(StageTransition {
             from,
             to,
-            timestamp: Utc::now().to_rfc3339(),
+            timestamp: Utc::now(),
             notes: notes.map(|s| s.to_string()),
         });
         self.current_stage = to;
@@ -277,6 +281,20 @@ pub fn load_pipeline(crosslink_dir: &Path) -> Result<Option<Pipeline>> {
 pub fn run_pipeline(crosslink_dir: &Path, config: PipelineConfig) -> Result<()> {
     let mut pipeline = match load_pipeline(crosslink_dir)? {
         Some(p) => {
+            // Warn if the caller-supplied config differs from the persisted one (#487).
+            if p.config.agent_count != config.agent_count
+                || p.config.mandate != config.mandate
+                || p.config.auto_fix != config.auto_fix
+                || p.config.auto_file_issues != config.auto_file_issues
+                || p.config.target_branch != config.target_branch
+            {
+                tracing::warn!(
+                    "Resuming existing pipeline — config parameter ignored. \
+                     Using persisted config (agents={}, mandate='{}').",
+                    p.config.agent_count,
+                    p.config.mandate,
+                );
+            }
             println!("Resuming pipeline {} at stage: {}", p.id, p.current_stage);
             p
         }
@@ -523,7 +541,7 @@ mod tests {
         p.advance().unwrap(); // Review
         let summary = p.summary();
         assert!(summary.contains("Pipeline:"));
-        assert!(summary.contains("Stage:    review"));
+        assert!(summary.contains("Stage:    review"), "Summary: {}", summary);
         assert!(summary.contains("Agents:   4"));
         assert!(summary.contains("Mandate:  security review"));
         assert!(summary.contains("History:"));
@@ -531,22 +549,42 @@ mod tests {
     }
 
     #[test]
-    fn test_pipeline_stage_display() {
+    fn test_pipeline_stage_display_matches_serde() {
+        // Display must match serde rename_all = "snake_case" (#489)
         assert_eq!(PipelineStage::Partition.to_string(), "partition");
         assert_eq!(PipelineStage::Review.to_string(), "review");
-        assert_eq!(PipelineStage::AwaitReview.to_string(), "await-review");
+        assert_eq!(PipelineStage::AwaitReview.to_string(), "await_review");
         assert_eq!(PipelineStage::Consolidate.to_string(), "consolidate");
         assert_eq!(
             PipelineStage::HumanCheckpoint.to_string(),
-            "human-checkpoint"
+            "human_checkpoint"
         );
-        assert_eq!(PipelineStage::FileIssues.to_string(), "file-issues");
+        assert_eq!(PipelineStage::FileIssues.to_string(), "file_issues");
         assert_eq!(PipelineStage::Fix.to_string(), "fix");
-        assert_eq!(PipelineStage::AwaitFix.to_string(), "await-fix");
+        assert_eq!(PipelineStage::AwaitFix.to_string(), "await_fix");
         assert_eq!(PipelineStage::Merge.to_string(), "merge");
-        assert_eq!(PipelineStage::PullRequest.to_string(), "pull-request");
+        assert_eq!(PipelineStage::PullRequest.to_string(), "pull_request");
         assert_eq!(PipelineStage::Done.to_string(), "done");
         assert_eq!(PipelineStage::Failed.to_string(), "failed");
+
+        // Verify Display matches serde roundtrip
+        for stage in [
+            PipelineStage::Partition,
+            PipelineStage::AwaitReview,
+            PipelineStage::HumanCheckpoint,
+            PipelineStage::FileIssues,
+            PipelineStage::AwaitFix,
+            PipelineStage::PullRequest,
+        ] {
+            let json = serde_json::to_string(&stage).unwrap();
+            let serde_name = json.trim_matches('"');
+            assert_eq!(
+                stage.to_string(),
+                serde_name,
+                "Display and serde mismatch for {:?}",
+                stage
+            );
+        }
     }
 
     #[test]
@@ -583,7 +621,7 @@ mod tests {
         let t = StageTransition {
             from: PipelineStage::Review,
             to: PipelineStage::AwaitReview,
-            timestamp: "2026-03-12T00:00:00Z".to_string(),
+            timestamp: Utc::now(),
             notes: Some("test note".to_string()),
         };
         let json = serde_json::to_string(&t).unwrap();
@@ -874,13 +912,15 @@ mod tests {
     }
 
     #[test]
-    fn test_pipeline_created_at_is_rfc3339() {
+    fn test_pipeline_created_at_is_datetime() {
         let p = Pipeline::new(test_config());
-        let parsed = chrono::DateTime::parse_from_rfc3339(&p.created_at);
+        // created_at is now DateTime<Utc>; verify it serializes to valid RFC3339
+        let json = serde_json::to_string(&p.created_at).unwrap();
+        let parsed = chrono::DateTime::parse_from_rfc3339(json.trim_matches('"'));
         assert!(
             parsed.is_ok(),
-            "created_at should be valid RFC3339: {}",
-            p.created_at
+            "created_at should serialize to valid RFC3339: {}",
+            json
         );
     }
 
@@ -1147,19 +1187,21 @@ mod tests {
     }
 
     #[test]
-    fn test_history_timestamps_are_rfc3339() {
+    fn test_history_timestamps_are_datetime() {
         let mut p = Pipeline::new(test_config());
         p.advance().unwrap();
         p.advance().unwrap();
         p.fail("done");
 
         for (i, t) in p.history.iter().enumerate() {
-            let parsed = chrono::DateTime::parse_from_rfc3339(&t.timestamp);
+            // timestamp is now DateTime<Utc>; verify it serializes to valid RFC3339
+            let json = serde_json::to_string(&t.timestamp).unwrap();
+            let parsed = chrono::DateTime::parse_from_rfc3339(json.trim_matches('"'));
             assert!(
                 parsed.is_ok(),
-                "history[{}] timestamp should be valid RFC3339: {}",
+                "history[{}] timestamp should serialize to valid RFC3339: {}",
                 i,
-                t.timestamp
+                json
             );
         }
     }
@@ -1181,7 +1223,7 @@ mod tests {
         let t = StageTransition {
             from: PipelineStage::Partition,
             to: PipelineStage::Review,
-            timestamp: "2026-03-13T12:00:00Z".to_string(),
+            timestamp: Utc::now(),
             notes: None,
         };
         let json = serde_json::to_string(&t).unwrap();
@@ -1249,9 +1291,12 @@ mod tests {
             summary.contains("Created:"),
             "Summary should include Created: field"
         );
+        // DateTime<Utc> Display produces RFC3339 format
+        let created_str = p.created_at.to_rfc3339();
         assert!(
-            summary.contains(&p.created_at),
-            "Summary should include the actual created_at value"
+            summary.contains(&created_str),
+            "Summary should include the actual created_at value: {}",
+            summary
         );
     }
 

--- a/crosslink/src/server/types.rs
+++ b/crosslink/src/server/types.rs
@@ -519,54 +519,12 @@ pub struct TokenUsageSummaryResponse {
 }
 
 // ---------------------------------------------------------------------------
-// Orchestrator
+// Orchestrator — re-exported from canonical definitions in orchestrator::models (#480)
 // ---------------------------------------------------------------------------
 
-/// An atomic work item within an orchestration stage.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct OrchestratorTask {
-    pub id: String,
-    pub title: String,
-    pub description: String,
-    /// Estimated complexity in agent-hours.
-    pub complexity_hours: f64,
-}
-
-/// A work unit within a phase — may have parallel agents.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct OrchestratorStage {
-    pub id: String,
-    pub title: String,
-    pub description: String,
-    pub tasks: Vec<OrchestratorTask>,
-    /// IDs of stages that must complete before this one starts.
-    pub depends_on: Vec<String>,
-    /// Suggested number of parallel agents for this stage.
-    pub agent_count: usize,
-    pub complexity_hours: f64,
-}
-
-/// A major sequential milestone in the execution plan.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct OrchestratorPhase {
-    pub id: String,
-    pub title: String,
-    pub description: String,
-    pub stages: Vec<OrchestratorStage>,
-    /// Criteria for declaring this phase complete (e.g. test pass, merge gate).
-    pub gate_criteria: Vec<String>,
-}
-
-/// The full LLM-decomposed execution plan.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct OrchestratorPlan {
-    pub id: String,
-    pub document_slug: String,
-    pub phases: Vec<OrchestratorPhase>,
-    pub created_at: DateTime<Utc>,
-    pub total_stages: usize,
-    pub estimated_hours: f64,
-}
+pub use crate::orchestrator::models::{
+    OrchestratorPhase, OrchestratorPlan, OrchestratorStage, OrchestratorTask,
+};
 
 /// Request body for `POST /api/v1/orchestrator/decompose`.
 #[derive(Debug, Clone, Deserialize)]
@@ -587,6 +545,9 @@ pub enum StageStatus {
     Done,
     Failed,
     Skipped,
+    /// Reserved for dashboard display. The orchestrator engine uses `Pending`
+    /// combined with DAG dependency checking instead of an explicit Blocked
+    /// state, but the frontend uses this variant for visualization (#488).
     Blocked,
 }
 


### PR DESCRIPTION
## Summary

- **#480**: Move OrchestratorPlan/Phase/Stage/Task canonical definitions from `server::types` to `orchestrator::models`, re-export for backward compatibility
- **#481**: Extract `build_progress_event()` to decouple executor from WebSocket event construction
- **#483**: Deduplicate unblocking logic via shared `Dag::find_newly_unblocked()` used by both `mark_done` and `mark_skipped_and_unblock`
- **#485**: Cache topological sort in DAG at construction time to avoid recomputation per `stages_by_phase()` call
- **#486**: Add `require_running_state()` guard to `mark_stage_running/done/failed` — prevents mutations when execution is idle/paused/done
- **#487**: Warn when `run_pipeline` config parameter is silently ignored on resume
- **#488**: Document `StageStatus::Blocked` as reserved for frontend dashboard display
- **#489**: Align `PipelineStage::Display` with serde `snake_case` naming (e.g. `await_review` not `await-review`)
- **#490**: Use `DateTime<Utc>` instead of `String` for pipeline timestamps (`created_at`, `StageTransition::timestamp`)
- **#491**: Consolidate `ORCHESTRATOR_DIR` constant into `models.rs` (was duplicated in `decompose.rs` and `executor.rs`)
- **#493/#494**: Scope `tokio::sync::broadcast` import to `broadcast_event` method body
- **#521**: Add `BudgetConfig::default()` to eliminate hardcoded fallbacks
- Fix median calculation for even-length arrays in `recompute_model_estimates`
- Extract `DEFAULT_AGENT_IMAGE` constant to eliminate duplicated string literals
- Replace `git add -A` with explicit `git add --all -- swarm/` in lifecycle
- Fix hardcoded `develop` base ref in `extract_diff_ranges` to try multiple refs

## Test plan

- [x] All 1665 lib tests pass (`cargo test --lib`)
- [ ] Verify orchestrator execution lifecycle still works end-to-end
- [ ] Verify pipeline serde backward compatibility with existing `pipeline.json` files
- [ ] Verify swarm budget estimates work correctly with even observation counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)