### PR TITLE
feat: add first-class Shell/Bash language support

### DIFF
--- a/crosslink/resources/claude/hooks/post-edit-check.py
+++ b/crosslink/resources/claude/hooks/post-edit-check.py
@@ -162,6 +162,23 @@ def run_linter(file_path, max_errors=10):
                             if len(errors) >= max_errors:
                                 break
 
+        elif ext in ('.sh', '.bash'):
+            # Shell: run shellcheck
+            try:
+                result = subprocess.run(
+                    ['shellcheck', '-f', 'gcc', file_path],
+                    capture_output=True,
+                    text=True,
+                    timeout=10
+                )
+                for line in result.stdout.split('\n'):
+                    if line.strip():
+                        errors.append(line.strip()[:100])
+                        if len(errors) >= max_errors:
+                            break
+            except FileNotFoundError:
+                pass  # shellcheck not installed
+
         elif ext in ('.ex', '.exs', '.heex'):
             # Elixir: run mix format --check-formatted, then mix credo --strict if available
             project_root = find_project_root(file_path, ['mix.exs'])
@@ -274,6 +291,13 @@ def find_test_files(file_path, project_root):
         test_patterns = [
             os.path.join(os.path.dirname(file_path), f'{name_without_ext}_test.go'),
         ]
+    elif ext in ('.sh', '.bash'):
+        test_patterns = [
+            os.path.join(project_root, 'test', '**', f'{name_without_ext}.bats'),
+            os.path.join(project_root, 'tests', '**', f'{name_without_ext}.bats'),
+            os.path.join(project_root, 'test', '**', f'test_{name_without_ext}.sh'),
+            os.path.join(project_root, 'tests', '**', f'test_{name_without_ext}.sh'),
+        ]
     elif ext in ('.ex', '.exs'):
         test_patterns = [
             os.path.join(project_root, 'test', '**', f'{name_without_ext}_test.exs'),
@@ -293,7 +317,7 @@ def get_test_reminder(file_path, project_root):
         return None  # Editing a test file, no reminder needed
 
     ext = os.path.splitext(file_path)[1]
-    code_extensions = ('.rs', '.py', '.js', '.ts', '.tsx', '.jsx', '.go', '.ex', '.exs', '.heex')
+    code_extensions = ('.rs', '.py', '.js', '.ts', '.tsx', '.jsx', '.go', '.sh', '.bash', '.ex', '.exs', '.heex')
 
     if ext not in code_extensions:
         return None
@@ -336,6 +360,11 @@ def get_test_reminder(file_path, project_root):
             test_cmd = 'npm test'
     elif ext == '.go' and project_root:
         test_cmd = 'go test ./...'
+    elif ext in ('.sh', '.bash') and project_root:
+        # Check for bats test framework
+        bats_dir = os.path.join(project_root, 'test')
+        if os.path.isdir(bats_dir) and any(f.endswith('.bats') for f in os.listdir(bats_dir)):
+            test_cmd = 'bats test/'
     elif ext in ('.ex', '.exs', '.heex') and project_root:
         if os.path.exists(os.path.join(project_root, 'mix.exs')):
             test_cmd = 'mix test'
@@ -368,7 +397,7 @@ def main():
     code_extensions = (
         '.rs', '.py', '.js', '.ts', '.tsx', '.jsx', '.go', '.java',
         '.c', '.cpp', '.h', '.hpp', '.cs', '.rb', '.php', '.swift',
-        '.kt', '.scala', '.zig', '.odin', '.ex', '.exs', '.heex'
+        '.kt', '.scala', '.zig', '.odin', '.sh', '.bash', '.ex', '.exs', '.heex'
     )
 
     if not any(file_path.endswith(ext) for ext in code_extensions):

--- a/crosslink/resources/claude/hooks/prompt-guard.py
+++ b/crosslink/resources/claude/hooks/prompt-guard.py
@@ -90,6 +90,7 @@ def load_all_rules(crosslink_dir):
         'swift.md': 'Swift', 'kotlin.md': 'Kotlin', 'scala.md': 'Scala',
         'zig.md': 'Zig', 'odin.md': 'Odin',
         'elixir.md': 'Elixir', 'elixir-phoenix.md': 'Elixir/Phoenix',
+        'shell.md': 'Shell',
         'web.md': 'Web',
     }
 
@@ -160,6 +161,8 @@ def detect_languages():
         '.ex': 'Elixir',
         '.exs': 'Elixir',
         '.heex': 'Elixir/Phoenix',
+        '.sh': 'Shell',
+        '.bash': 'Shell',
     }
 
     found = set()
@@ -179,6 +182,7 @@ def detect_languages():
         'composer.json': 'PHP',
         'Package.swift': 'Swift',
         'mix.exs': 'Elixir',
+        '.shellcheckrc': 'Shell',
     }
 
     # Check cwd and immediate subdirs for config files

--- a/crosslink/resources/crosslink/rules/shell.md
+++ b/crosslink/resources/crosslink/rules/shell.md
@@ -1,0 +1,50 @@
+### Shell/Bash Best Practices
+
+#### Script Header
+Every script MUST start with a strict preamble:
+```bash
+#!/usr/bin/env bash
+set -o errexit   # -e: Abort on nonzero exitstatus
+set -o nounset   # -u: Abort on unbound variable
+set -o pipefail  # Don't hide errors within pipes
+IFS=$'\n\t'      # Safe word splitting
+```
+
+#### Scoping & Immutability
+- Global constants: always `readonly`, use `UPPER_CASE`
+- Every variable inside functions MUST be `local`
+- Use `return` for status codes, `echo` to "return" data via command substitution
+- Use guard clauses (early returns) to flatten control flow — max 3 levels of indentation
+
+#### Syntax & Safety
+```bash
+# GOOD: Double brackets, quoted vars, $() subshells
+if [[ -n "${my_var}" ]]; then
+    result="$(some_command)"
+fi
+
+# BAD: Single brackets, unquoted vars, backticks
+if [ -n $my_var ]; then
+    result=`some_command`
+fi
+```
+- Always use `[[ ... ]]` for conditionals, not `[ ... ]`
+- Use `(( ... ))` for arithmetic
+- Use `$(...)` for subshells, never backticks
+- Quote EVERYTHING: `"${var}"`, not `$var`
+- Check tool dependencies with `command -v`, not `which`
+
+#### Logging & Error Handling
+- Use a `die()` function for fatal errors
+- All logging (info, warn, error) goes to `stderr` (`>&2`); `stdout` is for data/results only
+- Respect XDG: `"${XDG_CONFIG_HOME:-$HOME/.config}"`
+- Temp files: use `mktemp -t` or `mktemp -d`, clean up with `trap`
+
+#### Portability
+- Avoid `sed -i` (differs on macOS vs Linux) — use a temp file and `mv`
+- Use `printf` instead of `echo -e` or `echo -n`
+- Test on both bash 3.2 (macOS default) and 5.x (modern Linux)
+
+#### Verification
+- All scripts MUST pass `shellcheck` with zero warnings
+- Run `shellcheck -x script.sh` before committing

--- a/crosslink/src/commands/context.rs
+++ b/crosslink/src/commands/context.rs
@@ -21,6 +21,7 @@ const LANGUAGE_MANIFESTS: &[(&str, &str, &str)] = &[
     ("CMakeLists.txt", "C/C++", "cpp.md"),
     ("Makefile", "C/C++", "c.md"),
     ("mix.exs", "Elixir", "elixir.md"),
+    (".shellcheckrc", "Shell", "shell.md"),
 ];
 
 /// Expected hook files that should exist in .claude/hooks/.
@@ -370,6 +371,27 @@ fn detect_active_languages(project_root: &Path) -> Vec<String> {
         for &(manifest, lang, _rule_file) in LANGUAGE_MANIFESTS {
             if dir.join(manifest).exists() && seen.insert(lang.to_string()) {
                 found.push(lang.to_string());
+            }
+        }
+    }
+
+    // Shell detection: scan for .sh files in root, scripts/, and bin/
+    if !seen.contains("Shell") {
+        let shell_dirs = [
+            project_root.to_path_buf(),
+            project_root.join("scripts"),
+            project_root.join("bin"),
+        ];
+        'shell_scan: for dir in &shell_dirs {
+            if let Ok(entries) = fs::read_dir(dir) {
+                for entry in entries.filter_map(|e| e.ok()) {
+                    let name = entry.file_name().to_string_lossy().to_string();
+                    if name.ends_with(".sh") || name.ends_with(".bash") {
+                        seen.insert("Shell".to_string());
+                        found.push("Shell".to_string());
+                        break 'shell_scan;
+                    }
+                }
             }
         }
     }

--- a/crosslink/src/commands/kickoff/helpers.rs
+++ b/crosslink/src/commands/kickoff/helpers.rs
@@ -174,6 +174,32 @@ pub(crate) fn detect_conventions(repo_root: &Path) -> ProjectConventions {
         conv.allowed_tools.push("Bash(make *)".to_string());
     }
 
+    // Shell: detect via .shellcheckrc or .sh files in root/scripts/bin
+    let has_shell = repo_root.join(".shellcheckrc").is_file()
+        || ["", "scripts", "bin"].iter().any(|sub| {
+            let dir = if sub.is_empty() {
+                repo_root.to_path_buf()
+            } else {
+                repo_root.join(sub)
+            };
+            dir.is_dir()
+                && std::fs::read_dir(&dir)
+                    .ok()
+                    .map(|entries| {
+                        entries.filter_map(|e| e.ok()).any(|e| {
+                            let n = e.file_name().to_string_lossy().to_string();
+                            n.ends_with(".sh") || n.ends_with(".bash")
+                        })
+                    })
+                    .unwrap_or(false)
+        });
+    if has_shell {
+        conv.lint_commands.push("shellcheck **/*.sh".to_string());
+        conv.allowed_tools.push("Bash(shellcheck *)".to_string());
+        conv.allowed_tools.push("Bash(bash *)".to_string());
+        conv.allowed_tools.push("Bash(bats *)".to_string());
+    }
+
     // Elixir
     if repo_root.join("mix.exs").is_file() {
         if conv.test_command.is_none() {

--- a/docs_src/reference/rules.qmd
+++ b/docs_src/reference/rules.qmd
@@ -107,6 +107,7 @@ Available language rules:
 | `zig.md` | Zig |
 | `odin.md` | Odin |
 | `elixir.md` | Elixir |
+| `shell.md` | Shell/Bash |
 
 You can edit these files to add project-specific language conventions, or remove files for languages not used in your project to reduce noise.
 


### PR DESCRIPTION
## Summary
- Add `shell.md` rule file with opinionated Shell/Bash best practices (strict mode preamble, shellcheck, quoting, scoping, portability)
- Add shell language detection via `.shellcheckrc` config file and `.sh`/`.bash` file scanning in root, `scripts/`, and `bin/` directories
- Integrate `shellcheck` linter in post-edit hooks with `.sh`/`.bash` extension support
- Add bats test framework discovery and test command suggestions
- Add shell convention detection to kickoff helpers (shellcheck lint, bash/bats/shellcheck tool permissions)

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo check` compiles clean
- [x] All 1682 tests pass (0 failures)
- [ ] Verify shell detection triggers on a project with `.sh` files in root
- [ ] Verify shellcheck runs on `.sh` file edits when installed
- [ ] Verify `context measure` shows shell.md as active in a shell-heavy project

🤖 Generated with [Claude Code](https://claude.com/claude-code)