### PR TITLE
docs: document team and solo configuration presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,28 @@ Research done by one agent is available to all.
 - **Auto-injection** — Relevant knowledge pages injected into agent context via MCP server
 - **Conflict resolution** — Accept-both merge strategy for concurrent knowledge edits
 
+### Configuration Presets
+
+Get the right defaults for your workflow without reading docs.
+
+- **Team mode** — Strict tracking, required comments, CI verification, enforced commit signing. For shared repos with multiple contributors or agents.
+- **Solo mode** — Relaxed tracking, encouraged comments, local-only verification, signing disabled. For personal projects and solo development.
+- **Custom** — Configure each setting individually via the interactive walkthrough.
+
+```bash
+# Choose during first-time setup (interactive TUI)
+crosslink init
+
+# Or apply a preset directly
+crosslink config --preset team
+crosslink config --preset solo
+
+# Skip the TUI and use team defaults
+crosslink init --defaults
+```
+
+The presets configure tracking strictness, comment discipline, lock stealing policy, kickoff verification level, and signing enforcement. Run `crosslink config show` to see current settings, or `crosslink config --reconfigure` to re-run the walkthrough.
+
 ### Behavioral Hooks & Rules
 
 Your agents follow the rules without being told.

--- a/crosslink/src/main.rs
+++ b/crosslink/src/main.rs
@@ -104,7 +104,11 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Initialize crosslink in the current directory
+    /// Initialize crosslink in the current directory.
+    ///
+    /// On first run, launches an interactive walkthrough to choose a preset
+    /// (Team, Solo, or Custom) and configure behavioral hooks. Use --defaults
+    /// to skip the walkthrough and apply team-mode defaults non-interactively.
     Init {
         /// Force update hooks even if already initialized
         #[arg(short, long, conflicts_with = "update")]
@@ -133,7 +137,7 @@ enum Commands {
         /// Re-run TUI walkthrough even if config exists
         #[arg(long, conflicts_with = "update")]
         reconfigure: bool,
-        /// Skip TUI and use opinionated defaults
+        /// Skip TUI and use opinionated team-mode defaults
         #[arg(long)]
         defaults: bool,
     },
@@ -227,12 +231,18 @@ enum Commands {
         action: MigrateCommands,
     },
 
-    /// View and modify repo-level configuration
+    /// View and modify repo-level configuration.
+    ///
+    /// Without a subcommand, opens the interactive walkthrough to choose a
+    /// preset (Team, Solo, or Custom) and adjust settings. Use --preset to
+    /// apply a preset directly without the TUI.
     Config {
         #[command(subcommand)]
         command: Option<ConfigCommands>,
 
-        /// Apply a preset configuration (team, solo)
+        /// Apply a preset without the TUI: "team" (strict tracking, CI
+        /// verification, enforced signing) or "solo" (relaxed tracking,
+        /// local verification, signing disabled)
         #[arg(long)]
         preset: Option<String>,
     },


### PR DESCRIPTION
## Summary
- Adds a "Configuration Presets" section to README explaining team mode, solo mode, and custom configuration
- Improves CLI help text for `init` and `config` commands to describe what presets do and how to apply them
- Shows usage examples: `crosslink config --preset team`, interactive TUI, and `--defaults`

Closes #533

## Test plan
- [x] `cargo build` passes
- [x] `cargo clippy -- -D warnings -W clippy::unwrap_used -W clippy::expect_used` clean
- [x] 1682 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)