### PR TITLE
fix: add gh to allowed bash prefixes and cache session status in hook

### DIFF
--- a/crosslink/resources/claude/hooks/work-check.py
+++ b/crosslink/resources/claude/hooks/work-check.py
@@ -57,6 +57,14 @@ DEFAULT_ALLOWED_BASH = [
     "npm test", "npm run", "npx ",
     "tsc", "node ", "python ",
     "ls", "dir", "pwd", "echo",
+    # GitHub CLI and common read-only / infrastructure commands (#522)
+    "gh ",
+    "cat ", "head ", "tail ", "wc ",
+    "grep ", "rg ", "find ", "sort ", "uniq ",
+    "which ", "command ",
+    "mktemp", "sleep ",
+    "date", "env", "uname", "id ",
+    "basename ", "dirname ", "realpath ", "stat ", "file ",
 ]
 
 
@@ -380,7 +388,19 @@ def main():
     if not crosslink_dir:
         sys.exit(0)
 
-    # Check session status
+    # Fast path: check sentinel file written by `crosslink session work` / `quick` (#522).
+    # Avoids spawning a subprocess (~100ms) on every non-allowlisted Bash call.
+    sentinel = os.path.join(crosslink_dir, ".active-issue")
+    if os.path.isfile(sentinel):
+        try:
+            with open(sentinel) as f:
+                content = f.read().strip()
+            if content:
+                sys.exit(0)
+        except OSError:
+            pass  # Fall through to subprocess check
+
+    # Slow path: sentinel missing or empty — fall back to session status subprocess
     status = run_crosslink(["session", "status"], crosslink_dir)
     if not status:
         # crosslink not available — don't block

--- a/crosslink/src/commands/create.rs
+++ b/crosslink/src/commands/create.rs
@@ -124,6 +124,10 @@ fn auto_claim_and_set_work(
             }
             return Err(e);
         }
+        // Write sentinel file for fast hook checks (#522)
+        if let Some(dir) = crosslink_dir {
+            crate::commands::session::write_active_issue_sentinel(dir, id);
+        }
         if !quiet {
             println!("Now working on: {} {}", format_issue_id(id), title);
         }

--- a/crosslink/src/commands/init/merge.rs
+++ b/crosslink/src/commands/init/merge.rs
@@ -19,6 +19,7 @@ const GITIGNORE_MANAGED_SECTION: &str = "\
 .crosslink/daemon.pid
 .crosslink/daemon.log
 .crosslink/last_test_run
+.crosslink/.active-issue
 .crosslink/keys/
 .crosslink/.hub-cache/
 .crosslink/.knowledge-cache/

--- a/crosslink/src/commands/session.rs
+++ b/crosslink/src/commands/session.rs
@@ -24,6 +24,23 @@ pub fn run(
 }
 
 /// Load the current `agent_id` from `.crosslink/agent.json` (best-effort).
+const ACTIVE_ISSUE_SENTINEL: &str = ".active-issue";
+
+/// Write a sentinel file recording the active issue ID for fast hook checks.
+///
+/// The `work-check.py` hook reads this file instead of spawning
+/// `crosslink session status`, reducing hook latency from ~100ms to ~1ms.
+pub fn write_active_issue_sentinel(crosslink_dir: &Path, issue_id: i64) {
+    let path = crosslink_dir.join(ACTIVE_ISSUE_SENTINEL);
+    let _ = std::fs::write(&path, issue_id.to_string());
+}
+
+/// Remove the active-issue sentinel file (session ended or issue closed).
+pub fn clear_active_issue_sentinel(crosslink_dir: &Path) {
+    let path = crosslink_dir.join(ACTIVE_ISSUE_SENTINEL);
+    let _ = std::fs::remove_file(&path);
+}
+
 fn load_agent_id(crosslink_dir: &std::path::Path) -> Option<String> {
     crate::identity::AgentConfig::load(crosslink_dir)
         .ok()
@@ -109,6 +126,10 @@ pub fn end(db: &Database, notes: Option<&str>, crosslink_dir: &std::path::Path) 
     // attempts to find the active issue for comment attachment. Moving
     // end_session above the comment block would silently lose handoff notes (#441).
     db.end_session(session.id, notes)?;
+
+    // Clear sentinel file so hooks know no issue is active (#522).
+    clear_active_issue_sentinel(crosslink_dir);
+
     println!("Session #{} ended.", session.id);
     if notes.is_some() {
         println!("Handoff notes saved.");
@@ -251,6 +272,10 @@ pub fn work(db: &Database, issue_id: i64, crosslink_dir: &std::path::Path) -> Re
         }
         return Err(e);
     }
+    // Write sentinel file for fast hook checks (#522).
+    // The work-check hook reads this instead of spawning `crosslink session status`.
+    write_active_issue_sentinel(crosslink_dir, issue.id);
+
     println!(
         "Now working on: {} {}",
         format_issue_id(issue.id),


### PR DESCRIPTION
## Summary
- Expands `DEFAULT_ALLOWED_BASH` with `gh` and 20+ common CLI tools (`cat`, `head`, `tail`, `wc`, `grep`, `rg`, `find`, `sort`, `which`, `mktemp`, `sleep`, `date`, `env`, `stat`, `file`, etc.)
- Adds `.crosslink/.active-issue` sentinel file written by `session work` and `quick`, cleared by `session end`
- Hook reads sentinel file first (~1ms filesystem check) before falling back to `crosslink session status` subprocess (~100ms)
- Adds `.active-issue` to the gitignore managed section

Closes #522

## Test plan
- [x] `cargo build` passes
- [x] `cargo clippy -- -D warnings -W clippy::unwrap_used -W clippy::expect_used` clean (1.94.0)
- [x] 1682 lib tests + 186 CLI integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)