### PR TITLE
feat: sentinel — autonomous maintenance daemon (V0–V3, GH#504)

### DIFF
--- a/crosslink/Cargo.lock
+++ b/crosslink/Cargo.lock
@@ -393,6 +393,8 @@ dependencies = [
  "chrono",
  "clap",
  "crossterm",
+ "hex",
+ "hmac",
  "notify",
  "proptest",
  "ratatui",
@@ -543,6 +545,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -804,6 +807,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -2061,6 +2073,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"

--- a/crosslink/Cargo.toml
+++ b/crosslink/Cargo.toml
@@ -47,6 +47,8 @@ toml = "0.8"
 sha2 = "0.10"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+hmac = "0.12"
+hex = "0.4.3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crosslink/resources/crosslink/hook-config.json
+++ b/crosslink/resources/crosslink/hook-config.json
@@ -44,7 +44,7 @@
     "sources": {
       "github_labels": {
         "enabled": true,
-        "labels": ["agent-todo: replicate"]
+        "labels": ["agent-todo: replicate", "agent-todo: fix"]
       }
     },
     "default_agent": {

--- a/crosslink/resources/crosslink/hook-config.json
+++ b/crosslink/resources/crosslink/hook-config.json
@@ -36,5 +36,28 @@
     "gated_git_commands": [],
     "agent_lint_commands": [],
     "agent_test_commands": []
+  },
+  "sentinel": {
+    "enabled": false,
+    "interval_minutes": 10,
+    "max_concurrent_agents": 3,
+    "sources": {
+      "github_labels": {
+        "enabled": true,
+        "labels": ["agent-todo: replicate"]
+      }
+    },
+    "default_agent": {
+      "model": "claude-sonnet-4-6",
+      "timeout_minutes": 30,
+      "verify": "local"
+    },
+    "escalation": {
+      "enabled": true,
+      "model": "claude-opus-4-6",
+      "cooldown_minutes": 30,
+      "max_attempts": 2,
+      "timeout_multiplier_pct": 150
+    }
   }
 }

--- a/crosslink/src/clock_skew.rs
+++ b/crosslink/src/clock_skew.rs
@@ -329,8 +329,7 @@ mod tests {
         let violations = detect_git_skew_violations(cache_dir).unwrap();
         assert!(
             violations.is_empty(),
-            "Expected no violations for events within threshold, got: {:?}",
-            violations
+            "Expected no violations for events within threshold, got: {violations:?}"
         );
     }
 
@@ -492,7 +491,7 @@ mod tests {
                     parent_uuid: None,
                     created_by: "agent-1".to_string(),
                 },
-                format!("IssueCreated({}, Test)", uuid),
+                format!("IssueCreated({uuid}, Test)"),
             ),
             (
                 Event::LockClaimed {
@@ -506,7 +505,7 @@ mod tests {
                     issue_uuid: uuid,
                     label: "bug".to_string(),
                 },
-                format!("LabelAdded({}, bug)", uuid),
+                format!("LabelAdded({uuid}, bug)"),
             ),
         ];
 
@@ -656,9 +655,7 @@ mod tests {
             let desc = describe_event(&event);
             assert!(
                 desc.contains(expected_prefix),
-                "describe_event should contain '{}', got '{}'",
-                expected_prefix,
-                desc
+                "describe_event should contain '{expected_prefix}', got '{desc}'"
             );
         }
     }
@@ -672,7 +669,7 @@ mod tests {
             description: None,
             priority: None,
         });
-        assert_eq!(desc, format!("IssueUpdated({})", uuid));
+        assert_eq!(desc, format!("IssueUpdated({uuid})"));
     }
 
     #[test]
@@ -683,7 +680,7 @@ mod tests {
             new_status: "open".to_string(),
             closed_at: None,
         });
-        assert_eq!(desc, format!("StatusChanged({}, open)", uuid));
+        assert_eq!(desc, format!("StatusChanged({uuid}, open)"));
     }
 
     #[test]
@@ -702,7 +699,7 @@ mod tests {
             blocked_uuid: a,
             blocker_uuid: b,
         });
-        assert_eq!(desc, format!("DependencyAdded({} blocked by {})", a, b));
+        assert_eq!(desc, format!("DependencyAdded({a} blocked by {b})"));
     }
 
     #[test]
@@ -713,10 +710,7 @@ mod tests {
             blocked_uuid: a,
             blocker_uuid: b,
         });
-        assert_eq!(
-            desc,
-            format!("DependencyRemoved({} unblocked from {})", a, b)
-        );
+        assert_eq!(desc, format!("DependencyRemoved({a} unblocked from {b})"));
     }
 
     #[test]
@@ -727,7 +721,7 @@ mod tests {
             uuid_a: a,
             uuid_b: b,
         });
-        assert_eq!(desc, format!("RelationAdded({}, {})", a, b));
+        assert_eq!(desc, format!("RelationAdded({a}, {b})"));
     }
 
     #[test]
@@ -738,7 +732,7 @@ mod tests {
             uuid_a: a,
             uuid_b: b,
         });
-        assert_eq!(desc, format!("RelationRemoved({}, {})", a, b));
+        assert_eq!(desc, format!("RelationRemoved({a}, {b})"));
     }
 
     #[test]
@@ -748,7 +742,7 @@ mod tests {
             issue_uuid: uuid,
             milestone_uuid: None,
         });
-        assert_eq!(desc, format!("MilestoneAssigned({})", uuid));
+        assert_eq!(desc, format!("MilestoneAssigned({uuid})"));
     }
 
     #[test]
@@ -758,7 +752,7 @@ mod tests {
             issue_uuid: uuid,
             label: "wontfix".to_string(),
         });
-        assert_eq!(desc, format!("LabelRemoved({}, wontfix)", uuid));
+        assert_eq!(desc, format!("LabelRemoved({uuid}, wontfix)"));
     }
 
     #[test]
@@ -768,7 +762,7 @@ mod tests {
             issue_uuid: uuid,
             new_parent_uuid: Some(Uuid::new_v4()),
         });
-        assert_eq!(desc, format!("ParentChanged({})", uuid));
+        assert_eq!(desc, format!("ParentChanged({uuid})"));
     }
 
     #[test]

--- a/crosslink/src/commands/agent.rs
+++ b/crosslink/src/commands/agent.rs
@@ -539,8 +539,7 @@ mod tests {
         let err_msg = result.unwrap_err().to_string();
         assert!(
             err_msg.contains("at least 3 characters"),
-            "Unexpected error: {}",
-            err_msg
+            "Unexpected error: {err_msg}"
         );
     }
 
@@ -639,8 +638,7 @@ mod tests {
         let err_msg = result.unwrap_err().to_string();
         assert!(
             err_msg.contains("Remote mismatch"),
-            "Unexpected error: {}",
-            err_msg
+            "Unexpected error: {err_msg}"
         );
     }
 

--- a/crosslink/src/commands/comment.rs
+++ b/crosslink/src/commands/comment.rs
@@ -109,12 +109,12 @@ mod tests {
         let (db, _dir) = setup_test_db();
         let issue_id = db.create_issue("Test issue", None, "medium").unwrap();
 
-        let long_content = "a".repeat(100000);
+        let long_content = "a".repeat(100_000);
         let result = run(&db, None, issue_id, &long_content, "note");
         assert!(result.is_ok());
 
         let comments = db.get_comments(issue_id).unwrap();
-        assert_eq!(comments[0].content.len(), 100000);
+        assert_eq!(comments[0].content.len(), 100_000);
     }
 
     #[test]
@@ -218,14 +218,14 @@ mod tests {
             let issue_id = db.create_issue("Test", None, "medium").unwrap();
 
             for i in 0..count {
-                run(&db, None, issue_id, &format!("Comment {}", i), "note").unwrap();
+                run(&db, None, issue_id, &format!("Comment {i}"), "note").unwrap();
             }
 
             let comments = db.get_comments(issue_id).unwrap();
             prop_assert_eq!(comments.len(), count);
 
             for (i, comment) in comments.iter().enumerate() {
-                prop_assert_eq!(&comment.content, &format!("Comment {}", i));
+                prop_assert_eq!(&comment.content, &format!("Comment {i}"));
             }
         }
 
@@ -238,7 +238,7 @@ mod tests {
             let (db, _dir) = setup_test_db();
             let issue_id = db.create_issue("Test", None, "medium").unwrap();
 
-            let content = format!("{}{}{}", prefix, emoji, suffix);
+            let content = format!("{prefix}{emoji}{suffix}");
             run(&db, None, issue_id, &content, "note").unwrap();
 
             let comments = db.get_comments(issue_id).unwrap();

--- a/crosslink/src/commands/config_registry.rs
+++ b/crosslink/src/commands/config_registry.rs
@@ -27,6 +27,7 @@ pub enum ConfigGroup {
     Security,
     Infrastructure,
     Agents,
+    Sentinel,
 }
 
 impl ConfigGroup {
@@ -36,6 +37,7 @@ impl ConfigGroup {
             ConfigGroup::Security => "Security",
             ConfigGroup::Infrastructure => "Infrastructure",
             ConfigGroup::Agents => "Agents",
+            ConfigGroup::Sentinel => "Sentinel",
         }
     }
 
@@ -45,6 +47,7 @@ impl ConfigGroup {
             ConfigGroup::Security,
             ConfigGroup::Infrastructure,
             ConfigGroup::Agents,
+            ConfigGroup::Sentinel,
         ]
     }
 }
@@ -162,6 +165,98 @@ pub static REGISTRY: &[ConfigKey] = &[
         description: "Named aliases for external repositories (e.g. repo-alias.upstream)",
         group: ConfigGroup::Infrastructure,
         hot_swappable: false,
+    },
+    // --- Sentinel config keys ---
+    ConfigKey {
+        key: "sentinel.enabled",
+        config_type: ConfigType::Bool,
+        description: "Enable the autonomous sentinel daemon",
+        group: ConfigGroup::Sentinel,
+        hot_swappable: true,
+    },
+    ConfigKey {
+        key: "sentinel.interval_minutes",
+        config_type: ConfigType::Integer,
+        description: "Minutes between sentinel poll cycles (1-1440)",
+        group: ConfigGroup::Sentinel,
+        hot_swappable: true,
+    },
+    ConfigKey {
+        key: "sentinel.max_concurrent_agents",
+        config_type: ConfigType::Integer,
+        description: "Maximum agents sentinel may run simultaneously (1-10)",
+        group: ConfigGroup::Sentinel,
+        hot_swappable: true,
+    },
+    ConfigKey {
+        key: "sentinel.sources.github_labels.enabled",
+        config_type: ConfigType::Bool,
+        description: "Enable GitHub label polling source",
+        group: ConfigGroup::Sentinel,
+        hot_swappable: true,
+    },
+    ConfigKey {
+        key: "sentinel.sources.github_labels.labels",
+        config_type: ConfigType::StringArray,
+        description: "GitHub labels that trigger sentinel dispatch (e.g. agent-todo: replicate)",
+        group: ConfigGroup::Sentinel,
+        hot_swappable: true,
+    },
+    ConfigKey {
+        key: "sentinel.default_agent.model",
+        config_type: ConfigType::String,
+        description: "Default model for sentinel-dispatched agents",
+        group: ConfigGroup::Sentinel,
+        hot_swappable: true,
+    },
+    ConfigKey {
+        key: "sentinel.default_agent.timeout_minutes",
+        config_type: ConfigType::Integer,
+        description: "Default timeout in minutes for sentinel agents (5-480)",
+        group: ConfigGroup::Sentinel,
+        hot_swappable: true,
+    },
+    ConfigKey {
+        key: "sentinel.default_agent.verify",
+        config_type: ConfigType::Enum(&["local", "ci", "thorough"]),
+        description: "Default verification level for sentinel agents",
+        group: ConfigGroup::Sentinel,
+        hot_swappable: true,
+    },
+    ConfigKey {
+        key: "sentinel.escalation.enabled",
+        config_type: ConfigType::Bool,
+        description: "Enable automatic Sonnet->Opus escalation on failure",
+        group: ConfigGroup::Sentinel,
+        hot_swappable: true,
+    },
+    ConfigKey {
+        key: "sentinel.escalation.model",
+        config_type: ConfigType::String,
+        description: "Model to escalate to on first-attempt failure",
+        group: ConfigGroup::Sentinel,
+        hot_swappable: true,
+    },
+    ConfigKey {
+        key: "sentinel.escalation.cooldown_minutes",
+        config_type: ConfigType::Integer,
+        description: "Minutes to wait before retrying with escalated model (5-1440)",
+        group: ConfigGroup::Sentinel,
+        hot_swappable: true,
+    },
+    ConfigKey {
+        key: "sentinel.escalation.max_attempts",
+        config_type: ConfigType::Integer,
+        description: "Maximum dispatch attempts per signal (1-5)",
+        group: ConfigGroup::Sentinel,
+        hot_swappable: true,
+    },
+    ConfigKey {
+        key: "sentinel.escalation.timeout_multiplier_pct",
+        config_type: ConfigType::Integer,
+        description: "Timeout multiplier for escalation attempt as percentage (150 = 1.5x)",
+        group: ConfigGroup::Sentinel,
+        hot_swappable: true,
     },
 ];
 

--- a/crosslink/src/commands/delete.rs
+++ b/crosslink/src/commands/delete.rs
@@ -274,7 +274,7 @@ mod tests {
             let issue_id = db.create_issue("Test", None, "medium").unwrap();
 
             for i in 0..count {
-                db.add_comment(issue_id, &format!("Comment {}", i), "note").unwrap();
+                db.add_comment(issue_id, &format!("Comment {i}"), "note").unwrap();
             }
 
             run_force(&db, issue_id).unwrap();

--- a/crosslink/src/commands/init/mod.rs
+++ b/crosslink/src/commands/init/mod.rs
@@ -1174,7 +1174,7 @@ mod tests {
         assert!(content.contains("python") || content.contains("def") || content.len() > 20);
     }
 
-    /// Keys that the embedded MCP_JSON is expected to manage.
+    /// Keys that the embedded `MCP_JSON` is expected to manage.
     fn embedded_mcp_keys() -> Vec<String> {
         let embedded: serde_json::Value = serde_json::from_str(MCP_JSON).unwrap();
         embedded["mcpServers"]
@@ -1211,8 +1211,7 @@ mod tests {
         for key in embedded_mcp_keys() {
             assert!(
                 servers.contains_key(&key),
-                "embedded key \"{}\" should exist",
-                key
+                "embedded key \"{key}\" should exist"
             );
         }
         assert!(
@@ -1244,8 +1243,7 @@ mod tests {
         for key in &expected_keys {
             assert!(
                 warnings.iter().any(|w| w.contains(key)),
-                "should warn about overwriting \"{}\"",
-                key
+                "should warn about overwriting \"{key}\""
             );
         }
     }
@@ -1274,8 +1272,7 @@ mod tests {
         for key in &expected_keys {
             assert!(
                 servers.contains_key(key),
-                "fresh file should contain \"{}\"",
-                key
+                "fresh file should contain \"{key}\""
             );
         }
     }
@@ -1295,8 +1292,7 @@ mod tests {
         let err = format!("{:#}", result.unwrap_err());
         assert!(
             err.contains("invalid JSON"),
-            "Error should mention invalid JSON, got: {}",
-            err
+            "Error should mention invalid JSON, got: {err}"
         );
 
         // Original (broken) content should be untouched
@@ -1319,8 +1315,7 @@ mod tests {
         let err = format!("{:#}", result.unwrap_err());
         assert!(
             err.contains("not a JSON object"),
-            "Error should mention not a JSON object, got: {}",
-            err
+            "Error should mention not a JSON object, got: {err}"
         );
 
         // Original content should be untouched
@@ -1343,8 +1338,7 @@ mod tests {
         let err = format!("{:#}", result.unwrap_err());
         assert!(
             err.contains("invalid JSON"),
-            "Error should mention invalid JSON, got: {}",
-            err
+            "Error should mention invalid JSON, got: {err}"
         );
     }
 
@@ -1363,8 +1357,7 @@ mod tests {
         let err = format!("{:#}", result.unwrap_err());
         assert!(
             err.contains("non-object mcpServers"),
-            "Error should mention non-object mcpServers, got: {}",
-            err
+            "Error should mention non-object mcpServers, got: {err}"
         );
 
         // Original content should be untouched
@@ -1500,7 +1493,7 @@ mod tests {
             COMMAND_FILES.len()
         );
         for (filename, content) in COMMAND_FILES {
-            assert!(!content.is_empty(), "Command file {} is empty", filename);
+            assert!(!content.is_empty(), "Command file {filename} is empty");
         }
         assert!(!RULE_SANITIZE_PATTERNS.is_empty());
         assert!(!HOOK_CONFIG_JSON.is_empty());
@@ -1519,11 +1512,7 @@ mod tests {
         // All should have content
         for (name, content) in RULE_FILES {
             assert!(!name.is_empty(), "Rule file name should not be empty");
-            assert!(
-                !content.is_empty(),
-                "Rule file {} should not be empty",
-                name
-            );
+            assert!(!content.is_empty(), "Rule file {name} should not be empty");
         }
     }
 
@@ -1758,8 +1747,7 @@ mod tests {
         for expected in embedded_allowed_tools() {
             assert!(
                 tools.iter().any(|v| v.as_str() == Some(&expected)),
-                "allowedTools should contain \"{}\"",
-                expected
+                "allowedTools should contain \"{expected}\""
             );
         }
     }
@@ -1823,8 +1811,7 @@ mod tests {
         for expected in embedded_allowed_tools() {
             assert!(
                 tools.contains(&expected.as_str()),
-                "embedded tool \"{}\" should be preserved after force re-init",
-                expected
+                "embedded tool \"{expected}\" should be preserved after force re-init"
             );
         }
         assert!(
@@ -1857,8 +1844,7 @@ mod tests {
             let count = tools.iter().filter(|&&t| t == expected.as_str()).count();
             assert_eq!(
                 count, 1,
-                "\"{}\" should appear exactly once, found {}",
-                expected, count
+                "\"{expected}\" should appear exactly once, found {count}"
             );
         }
     }
@@ -1878,8 +1864,7 @@ mod tests {
         let err = format!("{:#}", result.unwrap_err());
         assert!(
             err.contains("invalid JSON"),
-            "Error should mention invalid JSON, got: {}",
-            err
+            "Error should mention invalid JSON, got: {err}"
         );
 
         // Original (broken) content should be untouched
@@ -1902,8 +1887,7 @@ mod tests {
         let err = format!("{:#}", result.unwrap_err());
         assert!(
             err.contains("not a JSON object"),
-            "Error should mention not a JSON object, got: {}",
-            err
+            "Error should mention not a JSON object, got: {err}"
         );
     }
 
@@ -1930,8 +1914,7 @@ mod tests {
         for expected in embedded_allowed_tools() {
             assert!(
                 tools.contains(&expected.as_str()),
-                "fresh file should contain \"{}\"",
-                expected
+                "fresh file should contain \"{expected}\""
             );
         }
     }
@@ -2006,10 +1989,8 @@ mod tests {
 
         // Add user content before and after the managed section
         let content = fs::read_to_string(dir.path().join(".gitignore")).unwrap();
-        let new_content = format!(
-            "# My custom rules\n/build/\n\n{}\n# Trailing rules\n*.tmp\n",
-            content
-        );
+        let new_content =
+            format!("# My custom rules\n/build/\n\n{content}\n# Trailing rules\n*.tmp\n");
         fs::write(dir.path().join(".gitignore"), new_content).unwrap();
 
         // Force re-init
@@ -2261,8 +2242,7 @@ mod tests {
         let err = format!("{:#}", result.unwrap_err());
         assert!(
             err.contains("not initialized"),
-            "Should mention not initialized, got: {}",
-            err
+            "Should mention not initialized, got: {err}"
         );
     }
 
@@ -2398,14 +2378,14 @@ mod tests {
         // Custom tool should still be present
         let result: serde_json::Value =
             serde_json::from_str(&fs::read_to_string(&settings_path).unwrap()).unwrap();
-        let tools: Vec<&str> = result["allowedTools"]
+        let has_custom_tool = result["allowedTools"]
             .as_array()
             .unwrap()
             .iter()
             .filter_map(|v| v.as_str())
-            .collect();
+            .any(|t| t == "Bash(my-tool *)");
         assert!(
-            tools.contains(&"Bash(my-tool *)"),
+            has_custom_tool,
             "Custom allowedTools entry should survive --update"
         );
     }
@@ -2457,7 +2437,7 @@ mod tests {
         ];
         for hook in &hook_files {
             let key = format!(".claude/hooks/{hook}");
-            assert!(files.contains_key(&key), "Manifest should track {}", key);
+            assert!(files.contains_key(&key), "Manifest should track {key}");
         }
 
         // Should track MCP servers

--- a/crosslink/src/commands/intervene.rs
+++ b/crosslink/src/commands/intervene.rs
@@ -193,7 +193,7 @@ mod tests {
                 &db,
                 None,
                 id,
-                &format!("Test {}", trigger),
+                &format!("Test {trigger}"),
                 trigger,
                 None,
                 dir.path(),

--- a/crosslink/src/commands/knowledge/operations.rs
+++ b/crosslink/src/commands/knowledge/operations.rs
@@ -856,7 +856,7 @@ mod tests {
     use crate::knowledge::{PageFrontmatter, Source, KNOWLEDGE_CACHE_DIR};
     use tempfile::tempdir;
 
-    /// Create a KnowledgeManager with a pre-created cache directory (no git needed).
+    /// Create a `KnowledgeManager` with a pre-created cache directory (no git needed).
     fn setup_km() -> (KnowledgeManager, tempfile::TempDir) {
         let dir = tempdir().unwrap();
         let crosslink_dir = dir.path().join(".crosslink");
@@ -920,7 +920,7 @@ mod tests {
         let now = Utc::now().format("%Y-%m-%d").to_string();
         let fm = PageFrontmatter {
             title: "Rust Testing Patterns".to_string(),
-            tags: tags.clone(),
+            tags,
             sources: sources
                 .iter()
                 .map(|url| Source {
@@ -1150,11 +1150,8 @@ mod tests {
             .iter()
             .filter(|p| p.slug != "target-page")
             .filter(|p| {
-                if let Ok(content) = km.read_page(&p.slug) {
-                    content.contains("target-page")
-                } else {
-                    false
-                }
+                km.read_page(&p.slug)
+                    .is_ok_and(|content| content.contains("target-page"))
             })
             .collect();
         assert_eq!(referencing_pages.len(), 1);
@@ -1231,7 +1228,7 @@ mod tests {
     fn test_add_from_doc_auto_tags() {
         // Verify that design-doc tag is added
         let tags: Vec<String> = vec!["existing-tag".to_string()];
-        let mut all_tags = tags.clone();
+        let mut all_tags = tags;
         if !all_tags.iter().any(|t| t == "design-doc") {
             all_tags.push("design-doc".to_string());
         }
@@ -1249,7 +1246,7 @@ mod tests {
         } else if doc.title.is_empty() {
             "fallback-slug".to_string()
         } else {
-            doc.title.clone()
+            doc.title
         };
         assert_eq!(display_title, "My Great Feature");
     }
@@ -1263,7 +1260,7 @@ mod tests {
         } else if doc.title.is_empty() {
             "fallback".to_string()
         } else {
-            doc.title.clone()
+            doc.title
         };
         assert_eq!(display_title, "Explicit Title");
     }
@@ -1374,7 +1371,7 @@ mod tests {
 
     #[test]
     fn test_import_preserves_existing_frontmatter() {
-        let (km, _dir) = setup_km();
+        let (km, dir) = setup_km();
 
         let raw = "---\ntitle: Existing Title\ntags: [original]\nsources: []\ncontributors: [alice]\ncreated: 2026-01-01\nupdated: 2026-01-15\n---\n\nBody content.\n";
 
@@ -1382,7 +1379,7 @@ mod tests {
             &km,
             // We need to write a temp file to import from
             &{
-                let p = _dir.path().join("test.md");
+                let p = dir.path().join("test.md");
                 std::fs::write(&p, raw).unwrap();
                 p
             },
@@ -1407,14 +1404,14 @@ mod tests {
 
     #[test]
     fn test_import_generates_frontmatter() {
-        let (km, _dir) = setup_km();
+        let (km, dir) = setup_km();
 
         let raw = "# Just a heading\n\nSome body text.\n";
 
         import_single_file(
             &km,
             &{
-                let p = _dir.path().join("my-doc.md");
+                let p = dir.path().join("my-doc.md");
                 std::fs::write(&p, raw).unwrap();
                 p
             },

--- a/crosslink/src/commands/label.rs
+++ b/crosslink/src/commands/label.rs
@@ -134,7 +134,7 @@ mod tests {
         assert!(result.is_ok());
 
         let labels = db.get_labels(issue_id).unwrap();
-        assert!(labels.contains(&"".to_string()));
+        assert!(labels.contains(&String::new()));
     }
 
     #[test]

--- a/crosslink/src/commands/lifecycle.rs
+++ b/crosslink/src/commands/lifecycle.rs
@@ -278,8 +278,8 @@ mod tests {
 
     #[test]
     fn test_close_existing_issue() {
-        let (db, _dir) = setup_test_db();
-        let crosslink_dir = _dir.path().join(".crosslink");
+        let (db, dir) = setup_test_db();
+        let crosslink_dir = dir.path().join(".crosslink");
         std::fs::create_dir_all(&crosslink_dir).unwrap();
 
         let issue_id = db.create_issue("Test issue", None, "medium").unwrap();
@@ -294,8 +294,8 @@ mod tests {
 
     #[test]
     fn test_close_nonexistent_issue() {
-        let (db, _dir) = setup_test_db();
-        let crosslink_dir = _dir.path().join(".crosslink");
+        let (db, dir) = setup_test_db();
+        let crosslink_dir = dir.path().join(".crosslink");
         std::fs::create_dir_all(&crosslink_dir).unwrap();
 
         let result = close(&db, None, 99999, false, &crosslink_dir);
@@ -305,8 +305,8 @@ mod tests {
 
     #[test]
     fn test_close_already_closed_issue() {
-        let (db, _dir) = setup_test_db();
-        let crosslink_dir = _dir.path().join(".crosslink");
+        let (db, dir) = setup_test_db();
+        let crosslink_dir = dir.path().join(".crosslink");
         std::fs::create_dir_all(&crosslink_dir).unwrap();
 
         let issue_id = db.create_issue("Test issue", None, "medium").unwrap();
@@ -440,8 +440,8 @@ mod tests {
 
     #[test]
     fn test_close_reopen_cycle() {
-        let (db, _dir) = setup_test_db();
-        let crosslink_dir = _dir.path().join(".crosslink");
+        let (db, dir) = setup_test_db();
+        let crosslink_dir = dir.path().join(".crosslink");
         std::fs::create_dir_all(&crosslink_dir).unwrap();
 
         let issue_id = db.create_issue("Test issue", None, "medium").unwrap();
@@ -467,8 +467,8 @@ mod tests {
     proptest! {
         #[test]
         fn prop_close_sets_status_to_closed(title in "[a-zA-Z0-9 ]{1,50}") {
-            let (db, _dir) = setup_test_db();
-            let crosslink_dir = _dir.path().join(".crosslink");
+            let (db, dir) = setup_test_db();
+            let crosslink_dir = dir.path().join(".crosslink");
             std::fs::create_dir_all(&crosslink_dir).unwrap();
 
             let issue_id = db.create_issue(&title, None, "medium").unwrap();
@@ -493,8 +493,8 @@ mod tests {
 
         #[test]
         fn prop_nonexistent_issue_close_fails(issue_id in 1000i64..10000) {
-            let (db, _dir) = setup_test_db();
-            let crosslink_dir = _dir.path().join(".crosslink");
+            let (db, dir) = setup_test_db();
+            let crosslink_dir = dir.path().join(".crosslink");
             std::fs::create_dir_all(&crosslink_dir).unwrap();
 
             let result = close(&db, None, issue_id, false, &crosslink_dir);

--- a/crosslink/src/commands/migrate.rs
+++ b/crosslink/src/commands/migrate.rs
@@ -458,7 +458,7 @@ mod tests {
             time_entries: vec![],
         };
 
-        let path = issues_dir.join(format!("{}.json", uuid));
+        let path = issues_dir.join(format!("{uuid}.json"));
         write_issue_file(&path, &issue).unwrap();
 
         // Verify file exists and is valid
@@ -556,23 +556,23 @@ mod tests {
         assert_eq!(related.len(), 2);
 
         // Only store relations where related_id > issue_id
-        let related_uuids: Vec<Uuid> = related
+        let related_uuid_count = related
             .iter()
             .filter(|r| r.id > id1)
             .filter_map(|r| id_to_uuid.get(&r.id).copied())
-            .collect();
-        assert_eq!(related_uuids.len(), 2);
+            .count();
+        assert_eq!(related_uuid_count, 2);
 
         // For issue 2, related issue is 1 (but 1 < 2 so we skip it)
         let related2 = db.get_related_issues(id2).unwrap();
-        let related2_uuids: Vec<Uuid> = related2
+        let related2_uuid_count = related2
             .iter()
             .filter(|r| r.id > id2)
             .filter_map(|r| id_to_uuid.get(&r.id).copied())
-            .collect();
+            .count();
         // id1 < id2, so no stored relations from id2's perspective
         // id3 > id2, but id2 isn't directly related to id3
-        assert_eq!(related2_uuids.len(), 0);
+        assert_eq!(related2_uuid_count, 0);
     }
 
     #[test]

--- a/crosslink/src/commands/milestone.rs
+++ b/crosslink/src/commands/milestone.rs
@@ -381,7 +381,7 @@ mod tests {
         fn prop_list_returns_correct_count(count in 0usize..5) {
             let (db, _dir) = setup_test_db();
             for i in 0..count {
-                db.create_milestone(&format!("v{}.0", i), None).unwrap();
+                db.create_milestone(&format!("v{i}.0"), None).unwrap();
             }
             list(&db, None).unwrap();
             let milestones = db.list_milestones(None).unwrap();

--- a/crosslink/src/commands/mod.rs
+++ b/crosslink/src/commands/mod.rs
@@ -34,6 +34,7 @@ pub mod next;
 pub mod prune;
 pub mod relate;
 pub mod search;
+pub mod sentinel;
 pub mod session;
 pub mod show;
 pub mod style;

--- a/crosslink/src/commands/next.rs
+++ b/crosslink/src/commands/next.rs
@@ -322,7 +322,7 @@ mod tests {
         fn prop_run_never_panics(count in 0usize..5) {
             let (db, dir) = setup_test_db();
             for i in 0..count {
-                db.create_issue(&format!("Issue {}", i), None, "medium").unwrap();
+                db.create_issue(&format!("Issue {i}"), None, "medium").unwrap();
             }
             let result = run(&db, dir.path());
             prop_assert!(result.is_ok());

--- a/crosslink/src/commands/relate.rs
+++ b/crosslink/src/commands/relate.rs
@@ -221,7 +221,7 @@ mod tests {
         fn prop_add_remove_roundtrip(a in 0i64..3, b in 0i64..3) {
             if a != b {
                 let (db, _dir) = setup_test_db();
-                let ids: Vec<i64> = (0..5).map(|i| db.create_issue(&format!("Issue {}", i), None, "medium").unwrap()).collect();
+                let ids: Vec<i64> = (0..5).map(|i| db.create_issue(&format!("Issue {i}"), None, "medium").unwrap()).collect();
 
                 let id1 = ids[a as usize % ids.len()];
                 let id2 = ids[b as usize % ids.len()];

--- a/crosslink/src/commands/sentinel/collect.rs
+++ b/crosslink/src/commands/sentinel/collect.rs
@@ -14,6 +14,14 @@ pub struct CollectStats {
     pub still_running: u32,
 }
 
+/// Worktree artifacts extracted for template rendering.
+struct WorktreeArtifacts {
+    test_file: Option<String>,
+    test_output: Option<String>,
+    pr_number: Option<String>,
+    files_changed: Option<String>,
+}
+
 /// Poll completed agents, read findings, post results to GitHub, update records.
 ///
 /// Runs every sentinel cycle (after dispatch phase in oneshot, every cycle in watch).
@@ -46,7 +54,6 @@ pub fn collect_completed(db: &Database, crosslink_dir: &Path) -> Result<CollectS
         let outcome = if status_content.trim().starts_with("DONE") {
             "success"
         } else if dispatch.attempt_number >= 2 {
-            // Both Sonnet and Opus failed — mark as exhausted so we don't retry
             "exhausted"
         } else {
             "failure"
@@ -59,8 +66,10 @@ pub fn collect_completed(db: &Database, crosslink_dir: &Path) -> Result<CollectS
             String::new()
         };
 
-        // Compute duration
         let duration = format_elapsed(&dispatch.created_at);
+
+        // Extract worktree artifacts for template rendering
+        let artifacts = extract_worktree_artifacts(&wt_path, dispatch.label.contains("fix"));
 
         // Build structured comment (template varies by dispatch type)
         let comment_body = if dispatch.label.contains("fix") {
@@ -71,6 +80,7 @@ pub fn collect_completed(db: &Database, crosslink_dir: &Path) -> Result<CollectS
                 dispatch.attempt_number,
                 &duration,
                 &findings,
+                &artifacts,
                 dispatch.id,
             )
         } else {
@@ -81,6 +91,7 @@ pub fn collect_completed(db: &Database, crosslink_dir: &Path) -> Result<CollectS
                 dispatch.attempt_number,
                 &duration,
                 &findings,
+                &artifacts,
                 dispatch.id,
             )
         };
@@ -106,11 +117,126 @@ pub fn collect_completed(db: &Database, crosslink_dir: &Path) -> Result<CollectS
     Ok(stats)
 }
 
+/// Extract test file, test output, PR number, and diff stats from a worktree.
+fn extract_worktree_artifacts(wt_path: &Path, is_fix: bool) -> WorktreeArtifacts {
+    let test_file = find_test_file(wt_path);
+    let test_output = read_test_output(wt_path);
+    let pr_number = if is_fix {
+        find_pr_number(wt_path)
+    } else {
+        None
+    };
+    let files_changed = if is_fix { git_diff_stat(wt_path) } else { None };
+
+    WorktreeArtifacts {
+        test_file,
+        test_output,
+        pr_number,
+        files_changed,
+    }
+}
+
+/// Find new/modified test files in the worktree via `git diff --name-only`.
+fn find_test_file(wt_path: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .args(["diff", "--name-only", "HEAD~1..HEAD", "--", "tests/"])
+        .current_dir(wt_path)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let first_test = stdout.lines().find(|l| l.contains("test"))?;
+    Some(first_test.to_string())
+}
+
+/// Read test output from `.kickoff-report.json` if it exists.
+fn read_test_output(wt_path: &Path) -> Option<String> {
+    let report_path = wt_path.join(".kickoff-report.json");
+    let content = std::fs::read_to_string(&report_path).ok()?;
+    let report: serde_json::Value = serde_json::from_str(&content).ok()?;
+
+    // Try to extract test output from the report's criteria or phases
+    if let Some(phases) = report.get("phases") {
+        if let Some(testing) = phases.get("testing") {
+            let tests_run = testing.get("tests_run").and_then(|v| v.as_u64());
+            let tests_passed = testing.get("tests_passed").and_then(|v| v.as_u64());
+            let tests_failed = testing.get("tests_failed").and_then(|v| v.as_u64());
+            if let (Some(run), Some(passed), Some(failed)) = (tests_run, tests_passed, tests_failed)
+            {
+                return Some(format!(
+                    "test result: {run} run, {passed} passed, {failed} failed"
+                ));
+            }
+        }
+    }
+    None
+}
+
+/// Find the PR number for a fix dispatch by looking up the branch.
+fn find_pr_number(wt_path: &Path) -> Option<String> {
+    // Get the branch name
+    let branch_output = Command::new("git")
+        .args(["branch", "--show-current"])
+        .current_dir(wt_path)
+        .output()
+        .ok()?;
+    if !branch_output.status.success() {
+        return None;
+    }
+    let branch = String::from_utf8_lossy(&branch_output.stdout)
+        .trim()
+        .to_string();
+    if branch.is_empty() {
+        return None;
+    }
+
+    // Look up PR by head branch
+    let pr_output = Command::new("gh")
+        .args([
+            "pr",
+            "list",
+            "--head",
+            &branch,
+            "--json",
+            "number",
+            "--jq",
+            ".[0].number",
+        ])
+        .current_dir(wt_path)
+        .output()
+        .ok()?;
+    if !pr_output.status.success() {
+        return None;
+    }
+    let num = String::from_utf8_lossy(&pr_output.stdout)
+        .trim()
+        .to_string();
+    if num.is_empty() || num == "null" {
+        None
+    } else {
+        Some(num)
+    }
+}
+
+/// Get `git diff --stat` summary for fix dispatches.
+fn git_diff_stat(wt_path: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .args(["diff", "--stat", "HEAD~1..HEAD"])
+        .current_dir(wt_path)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    // Return only the summary line (last line)
+    stdout.lines().last().map(String::from)
+}
+
 /// Resolve the main repo root from a crosslink directory.
 fn repo_root(crosslink_dir: &Path) -> Result<std::path::PathBuf> {
-    // .crosslink lives at <repo>/.crosslink, so parent is repo root.
-    // But in a worktree, crosslink_dir may be <repo>/.worktrees/<slug>/.crosslink.
-    // Use git to resolve reliably.
     let output = std::process::Command::new("git")
         .args(["rev-parse", "--show-toplevel"])
         .current_dir(crosslink_dir)
@@ -162,6 +288,7 @@ fn build_replicate_template(
     attempt: i32,
     duration: &str,
     findings: &str,
+    artifacts: &WorktreeArtifacts,
     dispatch_id: i64,
 ) -> String {
     let status_display = match status {
@@ -171,11 +298,27 @@ fn build_replicate_template(
         _ => status,
     };
 
+    let test_file_row = artifacts
+        .test_file
+        .as_ref()
+        .map(|f| format!("| Test file | `{f}` |\n"))
+        .unwrap_or_default();
+
     let findings_section = if findings.is_empty() {
         "No findings recorded.".to_string()
     } else {
         findings.to_string()
     };
+
+    let test_output_section = artifacts
+        .test_output
+        .as_ref()
+        .map(|output| {
+            // Truncate to 50 lines
+            let truncated: String = output.lines().take(50).collect::<Vec<_>>().join("\n");
+            format!("### Test output\n\n```\n{truncated}\n```\n")
+        })
+        .unwrap_or_default();
 
     format!(
         r#"## Sentinel: Reproduction Report
@@ -187,11 +330,12 @@ fn build_replicate_template(
 | Model | {model} |
 | Attempt | {attempt} of 2 |
 | Duration | {duration} |
-
+{test_file_row}
 ### Findings
 
 {findings_section}
 
+{test_output_section}
 ### Next steps
 
 - [ ] Review the agent's findings
@@ -210,6 +354,7 @@ fn build_fix_template(
     attempt: i32,
     duration: &str,
     findings: &str,
+    artifacts: &WorktreeArtifacts,
     dispatch_id: i64,
 ) -> String {
     let status_display = match status {
@@ -219,11 +364,32 @@ fn build_fix_template(
         _ => status,
     };
 
+    let pr_row = artifacts
+        .pr_number
+        .as_ref()
+        .map(|n| format!("| PR | #{n} (draft) |\n"))
+        .unwrap_or_default();
+
+    let diff_row = artifacts
+        .files_changed
+        .as_ref()
+        .map(|s| format!("| Changes | {s} |\n"))
+        .unwrap_or_default();
+
     let findings_section = if findings.is_empty() {
         "No findings recorded.".to_string()
     } else {
         findings.to_string()
     };
+
+    let test_output_section = artifacts
+        .test_output
+        .as_ref()
+        .map(|output| {
+            let truncated: String = output.lines().take(50).collect::<Vec<_>>().join("\n");
+            format!("### Test results\n\n```\n{truncated}\n```\n")
+        })
+        .unwrap_or_default();
 
     format!(
         r#"## Sentinel: Fix Report
@@ -235,11 +401,12 @@ fn build_fix_template(
 | Model | {model} |
 | Attempt | {attempt} of 2 |
 | Duration | {duration} |
-
+{pr_row}{diff_row}
 ### Findings
 
 {findings_section}
 
+{test_output_section}
 ### Next steps
 
 - [ ] Review the draft PR

--- a/crosslink/src/commands/sentinel/collect.rs
+++ b/crosslink/src/commands/sentinel/collect.rs
@@ -45,6 +45,9 @@ pub fn collect_completed(db: &Database, crosslink_dir: &Path) -> Result<CollectS
 
         let outcome = if status_content.trim().starts_with("DONE") {
             "success"
+        } else if dispatch.attempt_number >= 2 {
+            // Both Sonnet and Opus failed — mark as exhausted so we don't retry
+            "exhausted"
         } else {
             "failure"
         };
@@ -152,6 +155,7 @@ fn build_replicate_template(
     let status_display = match status {
         "success" => "Reproduced",
         "failure" => "Could not reproduce",
+        "exhausted" => "Could not reproduce (all attempts exhausted)",
         _ => status,
     };
 

--- a/crosslink/src/commands/sentinel/collect.rs
+++ b/crosslink/src/commands/sentinel/collect.rs
@@ -23,6 +23,18 @@ struct WorktreeArtifacts {
     files_changed: Option<String>,
 }
 
+/// Inputs for rendering a result template.
+struct TemplateContext<'a> {
+    status: &'a str,
+    agent_id: &'a str,
+    model: &'a str,
+    attempt: i32,
+    duration: &'a str,
+    findings: &'a str,
+    artifacts: &'a WorktreeArtifacts,
+    dispatch_id: i64,
+}
+
 /// Poll completed agents, read findings, post results to GitHub, update records.
 ///
 /// Runs every sentinel cycle (after dispatch phase in oneshot, every cycle in watch).
@@ -65,11 +77,9 @@ pub fn collect_completed(
         };
 
         // Read agent findings from crosslink comments on the linked issue
-        let findings = if let Some(issue_id) = dispatch.crosslink_issue_id {
-            read_agent_findings(db, issue_id)
-        } else {
-            String::new()
-        };
+        let findings = dispatch
+            .crosslink_issue_id
+            .map_or_else(String::new, |issue_id| read_agent_findings(db, issue_id));
 
         let duration = format_elapsed(&dispatch.created_at);
 
@@ -77,41 +87,28 @@ pub fn collect_completed(
         let artifacts = extract_worktree_artifacts(&wt_path, dispatch.label.contains("fix"));
 
         // Build structured comment (template varies by dispatch type)
+        let ctx = TemplateContext {
+            status: outcome,
+            agent_id,
+            model: dispatch.model_used.as_deref().unwrap_or("unknown"),
+            attempt: dispatch.attempt_number,
+            duration: &duration,
+            findings: &findings,
+            artifacts: &artifacts,
+            dispatch_id: dispatch.id,
+        };
         let comment_body = if dispatch.label.contains("fix") {
-            build_fix_template(
-                outcome,
-                agent_id,
-                dispatch.model_used.as_deref().unwrap_or("unknown"),
-                dispatch.attempt_number,
-                &duration,
-                &findings,
-                &artifacts,
-                dispatch.id,
-            )
+            build_fix_template(&ctx)
         } else {
-            build_replicate_template(
-                outcome,
-                agent_id,
-                dispatch.model_used.as_deref().unwrap_or("unknown"),
-                dispatch.attempt_number,
-                &duration,
-                &findings,
-                &artifacts,
-                dispatch.id,
-            )
+            build_replicate_template(&ctx)
         };
 
         // Post to GH issue (with Layer 4 dedup check)
         if let Some(gh_num) = dispatch.gh_issue_number {
-            match gh_comment_already_posted(gh_num, dispatch.id) {
-                Ok(true) => {
-                    tracing::debug!("sentinel #{} already posted to GH#{}", dispatch.id, gh_num);
-                }
-                _ => {
-                    if let Err(e) = post_gh_comment(gh_num, &comment_body) {
-                        tracing::warn!("failed to post results to GH#{gh_num}: {e}");
-                    }
-                }
+            if gh_comment_already_posted(gh_num, dispatch.id) {
+                tracing::debug!("sentinel #{} already posted to GH#{}", dispatch.id, gh_num);
+            } else if let Err(e) = post_gh_comment(gh_num, &comment_body) {
+                tracing::warn!("failed to post results to GH#{gh_num}: {e}");
             }
         }
 
@@ -119,14 +116,12 @@ pub fn collect_completed(
 
         // Send outbound notification if configured
         if let Some(cfg) = config {
-            if let Err(e) = super::notify::notify_dispatch_completed(
+            super::notify::notify_dispatch_completed(
                 &cfg.notifications,
                 dispatch,
                 outcome,
                 &findings,
-            ) {
-                tracing::warn!("notification failed for dispatch #{}: {e}", dispatch.id);
-            }
+            );
         }
 
         stats.collected += 1;
@@ -165,34 +160,37 @@ fn find_test_file(wt_path: &Path) -> Option<String> {
         .output()
         .ok();
 
-    let diff_args = if let Some(ref base) = base_output {
-        if base.status.success() {
-            let base_sha = String::from_utf8_lossy(&base.stdout).trim().to_string();
-            vec![
-                "diff".to_string(),
-                "--name-only".to_string(),
-                "--diff-filter=AM".to_string(),
-                format!("{base_sha}..HEAD"),
-                "--".to_string(),
-                "tests/".to_string(),
-            ]
-        } else {
-            // Fallback: list all tracked test files
+    let diff_args = base_output.as_ref().map_or_else(
+        || {
             vec![
                 "ls-files".to_string(),
                 "--".to_string(),
                 "tests/".to_string(),
             ]
-        }
-    } else {
-        vec![
-            "ls-files".to_string(),
-            "--".to_string(),
-            "tests/".to_string(),
-        ]
-    };
+        },
+        |base| {
+            if base.status.success() {
+                let base_sha = String::from_utf8_lossy(&base.stdout).trim().to_string();
+                vec![
+                    "diff".to_string(),
+                    "--name-only".to_string(),
+                    "--diff-filter=AM".to_string(),
+                    format!("{base_sha}..HEAD"),
+                    "--".to_string(),
+                    "tests/".to_string(),
+                ]
+            } else {
+                // Fallback: list all tracked test files
+                vec![
+                    "ls-files".to_string(),
+                    "--".to_string(),
+                    "tests/".to_string(),
+                ]
+            }
+        },
+    );
 
-    let args_refs: Vec<&str> = diff_args.iter().map(|s| s.as_str()).collect();
+    let args_refs: Vec<&str> = diff_args.iter().map(String::as_str).collect();
     let output = Command::new("git")
         .args(&args_refs)
         .current_dir(wt_path)
@@ -215,9 +213,13 @@ fn read_test_output(wt_path: &Path) -> Option<String> {
     // Try to extract test output from the report's criteria or phases
     if let Some(phases) = report.get("phases") {
         if let Some(testing) = phases.get("testing") {
-            let tests_run = testing.get("tests_run").and_then(|v| v.as_u64());
-            let tests_passed = testing.get("tests_passed").and_then(|v| v.as_u64());
-            let tests_failed = testing.get("tests_failed").and_then(|v| v.as_u64());
+            let tests_run = testing.get("tests_run").and_then(serde_json::Value::as_u64);
+            let tests_passed = testing
+                .get("tests_passed")
+                .and_then(serde_json::Value::as_u64);
+            let tests_failed = testing
+                .get("tests_failed")
+                .and_then(serde_json::Value::as_u64);
             if let (Some(run), Some(passed), Some(failed)) = (tests_run, tests_passed, tests_failed)
             {
                 return Some(format!(
@@ -311,9 +313,8 @@ fn repo_root(crosslink_dir: &Path) -> Result<std::path::PathBuf> {
 
 /// Read observation and resolution comments from a crosslink issue.
 fn read_agent_findings(db: &Database, issue_id: i64) -> String {
-    let comments = match db.get_comments(issue_id) {
-        Ok(c) => c,
-        Err(_) => return String::new(),
+    let Ok(comments) = db.get_comments(issue_id) else {
+        return String::new();
     };
 
     comments
@@ -341,47 +342,45 @@ pub fn format_elapsed(started_at: &str) -> String {
 }
 
 /// Build the structured reproduction result template for GitHub.
-fn build_replicate_template(
-    status: &str,
-    agent_id: &str,
-    model: &str,
-    attempt: i32,
-    duration: &str,
-    findings: &str,
-    artifacts: &WorktreeArtifacts,
-    dispatch_id: i64,
-) -> String {
-    let status_display = match status {
+fn build_replicate_template(ctx: &TemplateContext<'_>) -> String {
+    let status_display = match ctx.status {
         "success" => "Reproduced",
         "failure" => "Could not reproduce",
         "exhausted" => "Could not reproduce (all attempts exhausted)",
-        _ => status,
+        _ => ctx.status,
     };
 
-    let test_file_row = artifacts
+    let test_file_row = ctx
+        .artifacts
         .test_file
         .as_ref()
         .map(|f| format!("| Test file | `{f}` |\n"))
         .unwrap_or_default();
 
-    let findings_section = if findings.is_empty() {
+    let findings_section = if ctx.findings.is_empty() {
         "No findings recorded.".to_string()
     } else {
-        findings.to_string()
+        ctx.findings.to_string()
     };
 
-    let test_output_section = artifacts
+    let test_output_section = ctx
+        .artifacts
         .test_output
         .as_ref()
         .map(|output| {
-            // Truncate to 50 lines
             let truncated: String = output.lines().take(50).collect::<Vec<_>>().join("\n");
             format!("### Test output\n\n```\n{truncated}\n```\n")
         })
         .unwrap_or_default();
 
+    let agent_id = ctx.agent_id;
+    let model = ctx.model;
+    let attempt = ctx.attempt;
+    let duration = ctx.duration;
+    let dispatch_id = ctx.dispatch_id;
+
     format!(
-        r#"## Sentinel: Reproduction Report
+        "## Sentinel: Reproduction Report
 
 | Field | Value |
 |-------|-------|
@@ -402,47 +401,41 @@ fn build_replicate_template(
 - [ ] Label `agent-todo: fix` to trigger an automated fix attempt
 
 ---
-*Posted by crosslink sentinel | sentinel #{dispatch_id}*"#
+*Posted by crosslink sentinel | sentinel #{dispatch_id}*"
     )
 }
 
 /// Build the structured fix result template for GitHub.
-fn build_fix_template(
-    status: &str,
-    agent_id: &str,
-    model: &str,
-    attempt: i32,
-    duration: &str,
-    findings: &str,
-    artifacts: &WorktreeArtifacts,
-    dispatch_id: i64,
-) -> String {
-    let status_display = match status {
+fn build_fix_template(ctx: &TemplateContext<'_>) -> String {
+    let status_display = match ctx.status {
         "success" => "Fixed",
         "failure" => "Could not fix",
         "exhausted" => "Could not fix (all attempts exhausted)",
-        _ => status,
+        _ => ctx.status,
     };
 
-    let pr_row = artifacts
+    let pr_row = ctx
+        .artifacts
         .pr_number
         .as_ref()
         .map(|n| format!("| PR | #{n} (draft) |\n"))
         .unwrap_or_default();
 
-    let diff_row = artifacts
+    let diff_row = ctx
+        .artifacts
         .files_changed
         .as_ref()
         .map(|s| format!("| Changes | {s} |\n"))
         .unwrap_or_default();
 
-    let findings_section = if findings.is_empty() {
+    let findings_section = if ctx.findings.is_empty() {
         "No findings recorded.".to_string()
     } else {
-        findings.to_string()
+        ctx.findings.to_string()
     };
 
-    let test_output_section = artifacts
+    let test_output_section = ctx
+        .artifacts
         .test_output
         .as_ref()
         .map(|output| {
@@ -451,8 +444,14 @@ fn build_fix_template(
         })
         .unwrap_or_default();
 
+    let agent_id = ctx.agent_id;
+    let model = ctx.model;
+    let attempt = ctx.attempt;
+    let duration = ctx.duration;
+    let dispatch_id = ctx.dispatch_id;
+
     format!(
-        r#"## Sentinel: Fix Report
+        "## Sentinel: Fix Report
 
 | Field | Value |
 |-------|-------|
@@ -473,7 +472,7 @@ fn build_fix_template(
 - [ ] Run CI and verify the fix
 
 ---
-*Posted by crosslink sentinel | sentinel #{dispatch_id}*"#
+*Posted by crosslink sentinel | sentinel #{dispatch_id}*"
     )
 }
 

--- a/crosslink/src/commands/sentinel/collect.rs
+++ b/crosslink/src/commands/sentinel/collect.rs
@@ -62,16 +62,28 @@ pub fn collect_completed(db: &Database, crosslink_dir: &Path) -> Result<CollectS
         // Compute duration
         let duration = format_elapsed(&dispatch.created_at);
 
-        // Build structured comment
-        let comment_body = build_replicate_template(
-            outcome,
-            agent_id,
-            dispatch.model_used.as_deref().unwrap_or("unknown"),
-            dispatch.attempt_number,
-            &duration,
-            &findings,
-            dispatch.id,
-        );
+        // Build structured comment (template varies by dispatch type)
+        let comment_body = if dispatch.label.contains("fix") {
+            build_fix_template(
+                outcome,
+                agent_id,
+                dispatch.model_used.as_deref().unwrap_or("unknown"),
+                dispatch.attempt_number,
+                &duration,
+                &findings,
+                dispatch.id,
+            )
+        } else {
+            build_replicate_template(
+                outcome,
+                agent_id,
+                dispatch.model_used.as_deref().unwrap_or("unknown"),
+                dispatch.attempt_number,
+                &duration,
+                &findings,
+                dispatch.id,
+            )
+        };
 
         // Post to GH issue (with Layer 4 dedup check)
         if let Some(gh_num) = dispatch.gh_issue_number {
@@ -184,6 +196,54 @@ fn build_replicate_template(
 
 - [ ] Review the agent's findings
 - [ ] Label `agent-todo: fix` to trigger an automated fix attempt
+
+---
+*Posted by crosslink sentinel | sentinel #{dispatch_id}*"#
+    )
+}
+
+/// Build the structured fix result template for GitHub.
+fn build_fix_template(
+    status: &str,
+    agent_id: &str,
+    model: &str,
+    attempt: i32,
+    duration: &str,
+    findings: &str,
+    dispatch_id: i64,
+) -> String {
+    let status_display = match status {
+        "success" => "Fixed",
+        "failure" => "Could not fix",
+        "exhausted" => "Could not fix (all attempts exhausted)",
+        _ => status,
+    };
+
+    let findings_section = if findings.is_empty() {
+        "No findings recorded.".to_string()
+    } else {
+        findings.to_string()
+    };
+
+    format!(
+        r#"## Sentinel: Fix Report
+
+| Field | Value |
+|-------|-------|
+| Status | {status_display} |
+| Agent | `{agent_id}` |
+| Model | {model} |
+| Attempt | {attempt} of 2 |
+| Duration | {duration} |
+
+### Findings
+
+{findings_section}
+
+### Next steps
+
+- [ ] Review the draft PR
+- [ ] Run CI and verify the fix
 
 ---
 *Posted by crosslink sentinel | sentinel #{dispatch_id}*"#

--- a/crosslink/src/commands/sentinel/collect.rs
+++ b/crosslink/src/commands/sentinel/collect.rs
@@ -1,0 +1,22 @@
+use anyhow::Result;
+use std::path::Path;
+
+use crate::db::Database;
+
+/// Statistics from a result collection pass.
+#[derive(Debug, Default)]
+#[allow(dead_code)]
+pub struct CollectStats {
+    pub collected: u32,
+    pub orphaned: u32,
+    pub still_running: u32,
+}
+
+/// Poll completed agents, read findings, post results to GitHub, update records.
+///
+/// Runs every sentinel cycle (after dispatch phase in oneshot, every cycle in watch).
+#[allow(dead_code)]
+pub fn collect_completed(_db: &Database, _crosslink_dir: &Path) -> Result<CollectStats> {
+    // Will be implemented in #655
+    Ok(CollectStats::default())
+}

--- a/crosslink/src/commands/sentinel/collect.rs
+++ b/crosslink/src/commands/sentinel/collect.rs
@@ -4,6 +4,7 @@ use std::process::Command;
 
 use crate::db::Database;
 
+use super::config::SentinelConfig;
 use super::seen_set::gh_comment_already_posted;
 
 /// Statistics from a result collection pass.
@@ -25,7 +26,11 @@ struct WorktreeArtifacts {
 /// Poll completed agents, read findings, post results to GitHub, update records.
 ///
 /// Runs every sentinel cycle (after dispatch phase in oneshot, every cycle in watch).
-pub fn collect_completed(db: &Database, crosslink_dir: &Path) -> Result<CollectStats> {
+pub fn collect_completed(
+    db: &Database,
+    crosslink_dir: &Path,
+    config: Option<&SentinelConfig>,
+) -> Result<CollectStats> {
     let pending = db.get_pending_dispatches()?;
     let mut stats = CollectStats::default();
 
@@ -111,6 +116,19 @@ pub fn collect_completed(db: &Database, crosslink_dir: &Path) -> Result<CollectS
         }
 
         db.update_dispatch_outcome(dispatch.id, outcome, &findings)?;
+
+        // Send outbound notification if configured
+        if let Some(cfg) = config {
+            if let Err(e) = super::notify::notify_dispatch_completed(
+                &cfg.notifications,
+                dispatch,
+                outcome,
+                &findings,
+            ) {
+                tracing::warn!("notification failed for dispatch #{}: {e}", dispatch.id);
+            }
+        }
+
         stats.collected += 1;
     }
 

--- a/crosslink/src/commands/sentinel/collect.rs
+++ b/crosslink/src/commands/sentinel/collect.rs
@@ -60,7 +60,7 @@ pub fn collect_completed(db: &Database, crosslink_dir: &Path) -> Result<CollectS
         };
 
         // Compute duration
-        let duration = compute_duration(&dispatch.created_at);
+        let duration = format_elapsed(&dispatch.created_at);
 
         // Build structured comment
         let comment_body = build_replicate_template(
@@ -127,7 +127,7 @@ fn read_agent_findings(db: &Database, issue_id: i64) -> String {
 }
 
 /// Compute human-readable duration from an RFC3339 start time to now.
-fn compute_duration(started_at: &str) -> String {
+pub fn format_elapsed(started_at: &str) -> String {
     let Ok(start) = chrono::DateTime::parse_from_rfc3339(started_at) else {
         return "unknown".to_string();
     };

--- a/crosslink/src/commands/sentinel/collect.rs
+++ b/crosslink/src/commands/sentinel/collect.rs
@@ -154,10 +154,47 @@ fn extract_worktree_artifacts(wt_path: &Path, is_fix: bool) -> WorktreeArtifacts
     }
 }
 
-/// Find new/modified test files in the worktree via `git diff --name-only`.
+/// Find new/modified test files in the worktree via `git diff`.
+/// Uses `--diff-filter=AM` (added or modified) against the merge base
+/// to handle repos with any number of commits.
 fn find_test_file(wt_path: &Path) -> Option<String> {
+    // Find the merge base with the default branch
+    let base_output = Command::new("git")
+        .args(["merge-base", "HEAD", "HEAD~1"])
+        .current_dir(wt_path)
+        .output()
+        .ok();
+
+    let diff_args = if let Some(ref base) = base_output {
+        if base.status.success() {
+            let base_sha = String::from_utf8_lossy(&base.stdout).trim().to_string();
+            vec![
+                "diff".to_string(),
+                "--name-only".to_string(),
+                "--diff-filter=AM".to_string(),
+                format!("{base_sha}..HEAD"),
+                "--".to_string(),
+                "tests/".to_string(),
+            ]
+        } else {
+            // Fallback: list all tracked test files
+            vec![
+                "ls-files".to_string(),
+                "--".to_string(),
+                "tests/".to_string(),
+            ]
+        }
+    } else {
+        vec![
+            "ls-files".to_string(),
+            "--".to_string(),
+            "tests/".to_string(),
+        ]
+    };
+
+    let args_refs: Vec<&str> = diff_args.iter().map(|s| s.as_str()).collect();
     let output = Command::new("git")
-        .args(["diff", "--name-only", "HEAD~1..HEAD", "--", "tests/"])
+        .args(&args_refs)
         .current_dir(wt_path)
         .output()
         .ok()?;
@@ -239,9 +276,11 @@ fn find_pr_number(wt_path: &Path) -> Option<String> {
 }
 
 /// Get `git diff --stat` summary for fix dispatches.
+/// Uses `--stat` against the worktree's uncommitted + committed changes.
 fn git_diff_stat(wt_path: &Path) -> Option<String> {
+    // Try diffing against merge-base first; fall back to just `git diff --stat`
     let output = Command::new("git")
-        .args(["diff", "--stat", "HEAD~1..HEAD"])
+        .args(["diff", "--stat", "HEAD"])
         .current_dir(wt_path)
         .output()
         .ok()?;
@@ -249,6 +288,9 @@ fn git_diff_stat(wt_path: &Path) -> Option<String> {
         return None;
     }
     let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if stdout.is_empty() {
+        return None;
+    }
     // Return only the summary line (last line)
     stdout.lines().last().map(String::from)
 }

--- a/crosslink/src/commands/sentinel/collect.rs
+++ b/crosslink/src/commands/sentinel/collect.rs
@@ -1,11 +1,13 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use std::path::Path;
+use std::process::Command;
 
 use crate::db::Database;
 
+use super::seen_set::gh_comment_already_posted;
+
 /// Statistics from a result collection pass.
 #[derive(Debug, Default)]
-#[allow(dead_code)]
 pub struct CollectStats {
     pub collected: u32,
     pub orphaned: u32,
@@ -15,8 +17,192 @@ pub struct CollectStats {
 /// Poll completed agents, read findings, post results to GitHub, update records.
 ///
 /// Runs every sentinel cycle (after dispatch phase in oneshot, every cycle in watch).
-#[allow(dead_code)]
-pub fn collect_completed(_db: &Database, _crosslink_dir: &Path) -> Result<CollectStats> {
-    // Will be implemented in #655
-    Ok(CollectStats::default())
+pub fn collect_completed(db: &Database, crosslink_dir: &Path) -> Result<CollectStats> {
+    let pending = db.get_pending_dispatches()?;
+    let mut stats = CollectStats::default();
+
+    let root = repo_root(crosslink_dir)?;
+
+    for dispatch in &pending {
+        let Some(agent_id) = &dispatch.agent_id else {
+            continue;
+        };
+
+        // Check if worktree still exists
+        let wt_path = root.join(".worktrees").join(agent_id);
+        if !wt_path.exists() {
+            db.update_dispatch_outcome(dispatch.id, "orphaned", "worktree removed")?;
+            stats.orphaned += 1;
+            continue;
+        }
+
+        // Check sentinel file for completion
+        let status_path = wt_path.join(".kickoff-status");
+        let Ok(status_content) = std::fs::read_to_string(&status_path) else {
+            stats.still_running += 1;
+            continue;
+        };
+
+        let outcome = if status_content.trim().starts_with("DONE") {
+            "success"
+        } else {
+            "failure"
+        };
+
+        // Read agent findings from crosslink comments on the linked issue
+        let findings = if let Some(issue_id) = dispatch.crosslink_issue_id {
+            read_agent_findings(db, issue_id)
+        } else {
+            String::new()
+        };
+
+        // Compute duration
+        let duration = compute_duration(&dispatch.created_at);
+
+        // Build structured comment
+        let comment_body = build_replicate_template(
+            outcome,
+            agent_id,
+            dispatch.model_used.as_deref().unwrap_or("unknown"),
+            dispatch.attempt_number,
+            &duration,
+            &findings,
+            dispatch.id,
+        );
+
+        // Post to GH issue (with Layer 4 dedup check)
+        if let Some(gh_num) = dispatch.gh_issue_number {
+            match gh_comment_already_posted(gh_num, dispatch.id) {
+                Ok(true) => {
+                    tracing::debug!("sentinel #{} already posted to GH#{}", dispatch.id, gh_num);
+                }
+                _ => {
+                    if let Err(e) = post_gh_comment(gh_num, &comment_body) {
+                        tracing::warn!("failed to post results to GH#{gh_num}: {e}");
+                    }
+                }
+            }
+        }
+
+        db.update_dispatch_outcome(dispatch.id, outcome, &findings)?;
+        stats.collected += 1;
+    }
+
+    Ok(stats)
+}
+
+/// Resolve the main repo root from a crosslink directory.
+fn repo_root(crosslink_dir: &Path) -> Result<std::path::PathBuf> {
+    // .crosslink lives at <repo>/.crosslink, so parent is repo root.
+    // But in a worktree, crosslink_dir may be <repo>/.worktrees/<slug>/.crosslink.
+    // Use git to resolve reliably.
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .current_dir(crosslink_dir)
+        .output()
+        .context("Failed to run git rev-parse")?;
+    if !output.status.success() {
+        anyhow::bail!("Not in a git repository");
+    }
+    let root = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    Ok(std::path::PathBuf::from(root))
+}
+
+/// Read observation and resolution comments from a crosslink issue.
+fn read_agent_findings(db: &Database, issue_id: i64) -> String {
+    let comments = match db.get_comments(issue_id) {
+        Ok(c) => c,
+        Err(_) => return String::new(),
+    };
+
+    comments
+        .iter()
+        .filter(|c| c.kind == "observation" || c.kind == "resolution")
+        .map(|c| c.content.as_str())
+        .collect::<Vec<_>>()
+        .join("\n\n---\n\n")
+}
+
+/// Compute human-readable duration from an RFC3339 start time to now.
+fn compute_duration(started_at: &str) -> String {
+    let Ok(start) = chrono::DateTime::parse_from_rfc3339(started_at) else {
+        return "unknown".to_string();
+    };
+    let elapsed = chrono::Utc::now().signed_duration_since(start.with_timezone(&chrono::Utc));
+    let total_secs = elapsed.num_seconds();
+    if total_secs < 60 {
+        format!("{total_secs}s")
+    } else if total_secs < 3600 {
+        format!("{}m {}s", total_secs / 60, total_secs % 60)
+    } else {
+        format!("{}h {}m", total_secs / 3600, (total_secs % 3600) / 60)
+    }
+}
+
+/// Build the structured reproduction result template for GitHub.
+fn build_replicate_template(
+    status: &str,
+    agent_id: &str,
+    model: &str,
+    attempt: i32,
+    duration: &str,
+    findings: &str,
+    dispatch_id: i64,
+) -> String {
+    let status_display = match status {
+        "success" => "Reproduced",
+        "failure" => "Could not reproduce",
+        _ => status,
+    };
+
+    let findings_section = if findings.is_empty() {
+        "No findings recorded.".to_string()
+    } else {
+        findings.to_string()
+    };
+
+    format!(
+        r#"## Sentinel: Reproduction Report
+
+| Field | Value |
+|-------|-------|
+| Status | {status_display} |
+| Agent | `{agent_id}` |
+| Model | {model} |
+| Attempt | {attempt} of 2 |
+| Duration | {duration} |
+
+### Findings
+
+{findings_section}
+
+### Next steps
+
+- [ ] Review the agent's findings
+- [ ] Label `agent-todo: fix` to trigger an automated fix attempt
+
+---
+*Posted by crosslink sentinel | sentinel #{dispatch_id}*"#
+    )
+}
+
+/// Post a comment to a GitHub issue via `gh`.
+fn post_gh_comment(gh_issue_number: i64, body: &str) -> Result<()> {
+    let output = Command::new("gh")
+        .args([
+            "issue",
+            "comment",
+            &gh_issue_number.to_string(),
+            "--body",
+            body,
+        ])
+        .output()
+        .context("Failed to run `gh issue comment`")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("gh issue comment failed: {}", stderr.trim());
+    }
+
+    Ok(())
 }

--- a/crosslink/src/commands/sentinel/config.rs
+++ b/crosslink/src/commands/sentinel/config.rs
@@ -33,6 +33,7 @@ impl Default for SentinelConfig {
 pub struct SourcesConfig {
     pub github_labels: GitHubLabelsConfig,
     pub internal_hygiene: InternalHygieneConfig,
+    pub github_ci: GitHubCIConfig,
 }
 
 impl Default for SourcesConfig {
@@ -40,6 +41,7 @@ impl Default for SourcesConfig {
         Self {
             github_labels: GitHubLabelsConfig::default(),
             internal_hygiene: InternalHygieneConfig::default(),
+            github_ci: GitHubCIConfig::default(),
         }
     }
 }
@@ -78,6 +80,19 @@ impl Default for InternalHygieneConfig {
             enabled: true,
             stale_threshold_days: 30,
         }
+    }
+}
+
+/// GitHub CI failure source configuration.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct GitHubCIConfig {
+    pub enabled: bool,
+}
+
+impl Default for GitHubCIConfig {
+    fn default() -> Self {
+        Self { enabled: false }
     }
 }
 

--- a/crosslink/src/commands/sentinel/config.rs
+++ b/crosslink/src/commands/sentinel/config.rs
@@ -34,6 +34,7 @@ pub struct SourcesConfig {
     pub github_labels: GitHubLabelsConfig,
     pub internal_hygiene: InternalHygieneConfig,
     pub github_ci: GitHubCIConfig,
+    pub maintenance_sweep: MaintenanceSweepSourceConfig,
 }
 
 impl Default for SourcesConfig {
@@ -42,6 +43,7 @@ impl Default for SourcesConfig {
             github_labels: GitHubLabelsConfig::default(),
             internal_hygiene: InternalHygieneConfig::default(),
             github_ci: GitHubCIConfig::default(),
+            maintenance_sweep: MaintenanceSweepSourceConfig::default(),
         }
     }
 }
@@ -79,6 +81,27 @@ impl Default for InternalHygieneConfig {
         Self {
             enabled: true,
             stale_threshold_days: 30,
+        }
+    }
+}
+
+/// Maintenance sweep source configuration.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct MaintenanceSweepSourceConfig {
+    pub enabled: bool,
+    pub lint_enabled: bool,
+    pub test_coverage_enabled: bool,
+    pub lint_warning_threshold: u64,
+}
+
+impl Default for MaintenanceSweepSourceConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            lint_enabled: true,
+            test_coverage_enabled: false,
+            lint_warning_threshold: 10,
         }
     }
 }

--- a/crosslink/src/commands/sentinel/config.rs
+++ b/crosslink/src/commands/sentinel/config.rs
@@ -32,24 +32,13 @@ impl Default for SentinelConfig {
 }
 
 /// Source adapter configuration.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default)]
 pub struct SourcesConfig {
     pub github_labels: GitHubLabelsConfig,
     pub internal_hygiene: InternalHygieneConfig,
     pub github_ci: GitHubCIConfig,
     pub maintenance_sweep: MaintenanceSweepSourceConfig,
-}
-
-impl Default for SourcesConfig {
-    fn default() -> Self {
-        Self {
-            github_labels: GitHubLabelsConfig::default(),
-            internal_hygiene: InternalHygieneConfig::default(),
-            github_ci: GitHubCIConfig::default(),
-            maintenance_sweep: MaintenanceSweepSourceConfig::default(),
-        }
-    }
 }
 
 /// GitHub label polling configuration.
@@ -111,16 +100,10 @@ impl Default for MaintenanceSweepSourceConfig {
 }
 
 /// GitHub CI failure source configuration.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default)]
 pub struct GitHubCIConfig {
     pub enabled: bool,
-}
-
-impl Default for GitHubCIConfig {
-    fn default() -> Self {
-        Self { enabled: false }
-    }
 }
 
 /// Default agent settings for dispatched agents.
@@ -173,7 +156,7 @@ impl Default for WebhookServerConfig {
 }
 
 /// Outbound notification configuration.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default)]
 pub struct NotificationConfig {
     pub enabled: bool,
@@ -182,18 +165,9 @@ pub struct NotificationConfig {
     pub webhook_urls: Vec<String>,
 }
 
-impl Default for NotificationConfig {
-    fn default() -> Self {
-        Self {
-            enabled: false,
-            webhook_urls: Vec::new(),
-        }
-    }
-}
-
 impl NotificationConfig {
     /// Check if a URL looks like a Slack incoming webhook.
-    pub fn is_slack_url(&self, url: &str) -> bool {
+    pub fn is_slack_url(url: &str) -> bool {
         url.contains("hooks.slack.com")
     }
 }

--- a/crosslink/src/commands/sentinel/config.rs
+++ b/crosslink/src/commands/sentinel/config.rs
@@ -54,7 +54,10 @@ impl Default for GitHubLabelsConfig {
     fn default() -> Self {
         Self {
             enabled: true,
-            labels: vec!["agent-todo: replicate".to_string()],
+            labels: vec![
+                "agent-todo: replicate".to_string(),
+                "agent-todo: fix".to_string(),
+            ],
         }
     }
 }

--- a/crosslink/src/commands/sentinel/config.rs
+++ b/crosslink/src/commands/sentinel/config.rs
@@ -13,6 +13,7 @@ pub struct SentinelConfig {
     pub default_agent: DefaultAgentConfig,
     pub escalation: EscalationConfig,
     pub webhook: WebhookServerConfig,
+    pub notifications: NotificationConfig,
 }
 
 impl Default for SentinelConfig {
@@ -25,6 +26,7 @@ impl Default for SentinelConfig {
             default_agent: DefaultAgentConfig::default(),
             escalation: EscalationConfig::default(),
             webhook: WebhookServerConfig::default(),
+            notifications: NotificationConfig::default(),
         }
     }
 }
@@ -168,6 +170,32 @@ impl Default for WebhookServerConfig {
             port: 9876,
             secret: None,
         }
+    }
+}
+
+/// Outbound notification configuration.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct NotificationConfig {
+    pub enabled: bool,
+    /// Webhook URLs to POST dispatch results to. Supports Slack incoming
+    /// webhooks (auto-detected by URL pattern) and generic JSON endpoints.
+    pub webhook_urls: Vec<String>,
+}
+
+impl Default for NotificationConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            webhook_urls: Vec::new(),
+        }
+    }
+}
+
+impl NotificationConfig {
+    /// Check if a URL looks like a Slack incoming webhook.
+    pub fn is_slack_url(&self, url: &str) -> bool {
+        url.contains("hooks.slack.com")
     }
 }
 

--- a/crosslink/src/commands/sentinel/config.rs
+++ b/crosslink/src/commands/sentinel/config.rs
@@ -129,10 +129,16 @@ impl Default for GitHubCIConfig {
 pub struct DefaultAgentConfig {
     pub model: String,
     pub timeout_minutes: u64,
-    /// Reserved for future per-rule verify level override. Currently each rule
-    /// hardcodes its verify level (Local for replicate, Ci for fix).
-    #[serde(default)]
-    _verify: String,
+    /// Verify level as a string ("local", "ci", "thorough"). Parse via `verify_level()`.
+    pub verify: String,
+}
+
+impl DefaultAgentConfig {
+    /// Parse the verify string into a `VerifyLevel`, falling back to `Local` on invalid input.
+    pub fn verify_level(&self) -> crate::commands::kickoff::VerifyLevel {
+        crate::commands::kickoff::parse_verify_level(&self.verify)
+            .unwrap_or(crate::commands::kickoff::VerifyLevel::Local)
+    }
 }
 
 impl Default for DefaultAgentConfig {
@@ -140,7 +146,7 @@ impl Default for DefaultAgentConfig {
         Self {
             model: "claude-sonnet-4-6".to_string(),
             timeout_minutes: 30,
-            _verify: "local".to_string(),
+            verify: "local".to_string(),
         }
     }
 }

--- a/crosslink/src/commands/sentinel/config.rs
+++ b/crosslink/src/commands/sentinel/config.rs
@@ -1,0 +1,136 @@
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use std::path::Path;
+
+/// Top-level sentinel configuration from `.crosslink/hook-config.json`.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct SentinelConfig {
+    pub enabled: bool,
+    pub interval_minutes: u64,
+    pub max_concurrent_agents: u32,
+    pub sources: SourcesConfig,
+    pub default_agent: DefaultAgentConfig,
+    pub escalation: EscalationConfig,
+}
+
+impl Default for SentinelConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            interval_minutes: 10,
+            max_concurrent_agents: 3,
+            sources: SourcesConfig::default(),
+            default_agent: DefaultAgentConfig::default(),
+            escalation: EscalationConfig::default(),
+        }
+    }
+}
+
+/// Source adapter configuration.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct SourcesConfig {
+    pub github_labels: GitHubLabelsConfig,
+}
+
+impl Default for SourcesConfig {
+    fn default() -> Self {
+        Self {
+            github_labels: GitHubLabelsConfig::default(),
+        }
+    }
+}
+
+/// GitHub label polling configuration.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct GitHubLabelsConfig {
+    pub enabled: bool,
+    pub labels: Vec<String>,
+}
+
+impl Default for GitHubLabelsConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            labels: vec!["agent-todo: replicate".to_string()],
+        }
+    }
+}
+
+/// Default agent settings for dispatched agents.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct DefaultAgentConfig {
+    pub model: String,
+    pub timeout_minutes: u64,
+    /// Deserialized as a string, validated at load time via `validated_verify()`.
+    verify: String,
+}
+
+impl DefaultAgentConfig {
+    /// Parse the verify string into a `VerifyLevel`, falling back to `Local` on invalid input.
+    #[allow(dead_code)]
+    pub fn verify_level(&self) -> crate::commands::kickoff::VerifyLevel {
+        crate::commands::kickoff::parse_verify_level(&self.verify)
+            .unwrap_or(crate::commands::kickoff::VerifyLevel::Local)
+    }
+}
+
+impl Default for DefaultAgentConfig {
+    fn default() -> Self {
+        Self {
+            model: "claude-sonnet-4-6".to_string(),
+            timeout_minutes: 30,
+            verify: "local".to_string(),
+        }
+    }
+}
+
+/// Automatic model escalation configuration.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct EscalationConfig {
+    pub enabled: bool,
+    pub model: String,
+    pub cooldown_minutes: u64,
+    pub max_attempts: u32,
+    /// Stored as integer percentage (150 = 1.5x) to avoid float in config.
+    pub timeout_multiplier_pct: u32,
+}
+
+impl Default for EscalationConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            model: "claude-opus-4-6".to_string(),
+            cooldown_minutes: 30,
+            max_attempts: 2,
+            timeout_multiplier_pct: 150,
+        }
+    }
+}
+
+impl SentinelConfig {
+    /// Load sentinel config from hook-config.json.
+    /// Returns default config if the sentinel key is absent.
+    pub fn load(crosslink_dir: &Path) -> Result<Self> {
+        let config_path = crosslink_dir.join("hook-config.json");
+        if !config_path.exists() {
+            return Ok(Self::default());
+        }
+        let content = std::fs::read_to_string(&config_path)
+            .with_context(|| format!("Failed to read {}", config_path.display()))?;
+        let root: serde_json::Value = serde_json::from_str(&content)
+            .with_context(|| format!("Failed to parse {}", config_path.display()))?;
+        match root.get("sentinel") {
+            Some(sentinel_val) => {
+                let config: SentinelConfig = serde_json::from_value(sentinel_val.clone())
+                    .context("Failed to parse sentinel config")?;
+                Ok(config)
+            }
+            None => Ok(Self::default()),
+        }
+    }
+}

--- a/crosslink/src/commands/sentinel/config.rs
+++ b/crosslink/src/commands/sentinel/config.rs
@@ -12,6 +12,7 @@ pub struct SentinelConfig {
     pub sources: SourcesConfig,
     pub default_agent: DefaultAgentConfig,
     pub escalation: EscalationConfig,
+    pub webhook: WebhookServerConfig,
 }
 
 impl Default for SentinelConfig {
@@ -23,6 +24,7 @@ impl Default for SentinelConfig {
             sources: SourcesConfig::default(),
             default_agent: DefaultAgentConfig::default(),
             escalation: EscalationConfig::default(),
+            webhook: WebhookServerConfig::default(),
         }
     }
 }
@@ -144,6 +146,27 @@ impl Default for DefaultAgentConfig {
             model: "claude-sonnet-4-6".to_string(),
             timeout_minutes: 30,
             verify: "local".to_string(),
+        }
+    }
+}
+
+/// Webhook server configuration.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct WebhookServerConfig {
+    pub enabled: bool,
+    pub port: u16,
+    /// GitHub webhook secret for HMAC-SHA256 signature verification.
+    /// If None, signatures are not verified (not recommended for production).
+    pub secret: Option<String>,
+}
+
+impl Default for WebhookServerConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            port: 9876,
+            secret: None,
         }
     }
 }

--- a/crosslink/src/commands/sentinel/config.rs
+++ b/crosslink/src/commands/sentinel/config.rs
@@ -32,12 +32,14 @@ impl Default for SentinelConfig {
 #[serde(default)]
 pub struct SourcesConfig {
     pub github_labels: GitHubLabelsConfig,
+    pub internal_hygiene: InternalHygieneConfig,
 }
 
 impl Default for SourcesConfig {
     fn default() -> Self {
         Self {
             github_labels: GitHubLabelsConfig::default(),
+            internal_hygiene: InternalHygieneConfig::default(),
         }
     }
 }
@@ -58,6 +60,23 @@ impl Default for GitHubLabelsConfig {
                 "agent-todo: replicate".to_string(),
                 "agent-todo: fix".to_string(),
             ],
+        }
+    }
+}
+
+/// Internal hygiene source configuration.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct InternalHygieneConfig {
+    pub enabled: bool,
+    pub stale_threshold_days: i64,
+}
+
+impl Default for InternalHygieneConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            stale_threshold_days: 30,
         }
     }
 }

--- a/crosslink/src/commands/sentinel/config.rs
+++ b/crosslink/src/commands/sentinel/config.rs
@@ -129,17 +129,10 @@ impl Default for GitHubCIConfig {
 pub struct DefaultAgentConfig {
     pub model: String,
     pub timeout_minutes: u64,
-    /// Deserialized as a string, validated at load time via `validated_verify()`.
-    verify: String,
-}
-
-impl DefaultAgentConfig {
-    /// Parse the verify string into a `VerifyLevel`, falling back to `Local` on invalid input.
-    #[allow(dead_code)]
-    pub fn verify_level(&self) -> crate::commands::kickoff::VerifyLevel {
-        crate::commands::kickoff::parse_verify_level(&self.verify)
-            .unwrap_or(crate::commands::kickoff::VerifyLevel::Local)
-    }
+    /// Reserved for future per-rule verify level override. Currently each rule
+    /// hardcodes its verify level (Local for replicate, Ci for fix).
+    #[serde(default)]
+    _verify: String,
 }
 
 impl Default for DefaultAgentConfig {
@@ -147,7 +140,7 @@ impl Default for DefaultAgentConfig {
         Self {
             model: "claude-sonnet-4-6".to_string(),
             timeout_minutes: 30,
-            verify: "local".to_string(),
+            _verify: "local".to_string(),
         }
     }
 }

--- a/crosslink/src/commands/sentinel/dispatch.rs
+++ b/crosslink/src/commands/sentinel/dispatch.rs
@@ -178,7 +178,7 @@ Your task:
 6. Record your findings as a crosslink comment (--kind resolution)
 7. Push your branch and open a draft PR linking GH#{gh_issue_number}
 
-Draft PR title: fix: {title} (sentinel)
+Draft PR title: fix: {title} (sentinel GH#{gh_issue_number})
 
 Constraints:
 - You may modify files in src/ and tests/

--- a/crosslink/src/commands/sentinel/dispatch.rs
+++ b/crosslink/src/commands/sentinel/dispatch.rs
@@ -38,9 +38,30 @@ pub struct AgentScope {
 }
 
 /// Run a signal through the triage engine to determine its disposition.
-pub fn triage(signal: &Signal, decision: &SignalDecision, config: &SentinelConfig) -> Disposition {
+///
+/// If `tuning` is provided, it may override the default model for signals
+/// where historical data shows poor Sonnet performance.
+pub fn triage(
+    signal: &Signal,
+    decision: &SignalDecision,
+    config: &SentinelConfig,
+    tuning: Option<&super::tuning::TuningOverride>,
+) -> Disposition {
+    let label = signal
+        .metadata
+        .get("label")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
     let (model, attempt) = match decision {
-        SignalDecision::New => (config.default_agent.model.clone(), 1u32),
+        SignalDecision::New => {
+            // Check if self-tuning recommends a different model for this label
+            let model = tuning
+                .and_then(|t| t.model_for_label(label))
+                .map(String::from)
+                .unwrap_or_else(|| config.default_agent.model.clone());
+            (model, 1u32)
+        }
         SignalDecision::Escalate => (config.escalation.model.clone(), 2u32),
         SignalDecision::Skip(reason) => {
             return Disposition::Skip {
@@ -57,67 +78,59 @@ pub fn triage(signal: &Signal, decision: &SignalDecision, config: &SentinelConfi
     };
 
     match &signal.source {
-        SourceKind::GitHub => {
-            let label = signal
-                .metadata
-                .get("label")
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
+        SourceKind::GitHub => match label {
+            "agent-todo: replicate" => {
+                let gh_num = signal
+                    .metadata
+                    .get("number")
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(0);
 
-            match label {
-                "agent-todo: replicate" => {
-                    let gh_num = signal
-                        .metadata
-                        .get("number")
-                        .and_then(|v| v.as_i64())
-                        .unwrap_or(0);
+                let description = build_replicate_prompt(gh_num, &signal.title, &signal.body);
 
-                    let description = build_replicate_prompt(gh_num, &signal.title, &signal.body);
-
-                    Disposition::Dispatch {
-                        description,
-                        scope: AgentScope {
-                            allowed_paths: vec!["tests/".into()],
-                            verify: VerifyLevel::Local,
-                            timeout: Duration::from_secs(timeout_secs),
-                            model,
-                        },
-                        attempt,
-                    }
+                Disposition::Dispatch {
+                    description,
+                    scope: AgentScope {
+                        allowed_paths: vec!["tests/".into()],
+                        verify: VerifyLevel::Local,
+                        timeout: Duration::from_secs(timeout_secs),
+                        model,
+                    },
+                    attempt,
                 }
-                "agent-todo: fix" => {
-                    let gh_num = signal
-                        .metadata
-                        .get("number")
-                        .and_then(|v| v.as_i64())
-                        .unwrap_or(0);
-
-                    // Fix agents get more time: 60min base (vs 30min for replicate)
-                    let fix_timeout_secs = (config.default_agent.timeout_minutes * 60) * 2;
-                    let fix_timeout = if attempt > 1 {
-                        fix_timeout_secs * u64::from(config.escalation.timeout_multiplier_pct) / 100
-                    } else {
-                        fix_timeout_secs
-                    };
-
-                    let description = build_fix_prompt(gh_num, &signal.title, &signal.body);
-
-                    Disposition::Dispatch {
-                        description,
-                        scope: AgentScope {
-                            allowed_paths: vec!["src/".into(), "tests/".into()],
-                            verify: VerifyLevel::Ci,
-                            timeout: Duration::from_secs(fix_timeout),
-                            model,
-                        },
-                        attempt,
-                    }
-                }
-                other => Disposition::Skip {
-                    reason: format!("unrecognized agent-todo label: {other}"),
-                },
             }
-        }
+            "agent-todo: fix" => {
+                let gh_num = signal
+                    .metadata
+                    .get("number")
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(0);
+
+                // Fix agents get more time: 60min base (vs 30min for replicate)
+                let fix_timeout_secs = (config.default_agent.timeout_minutes * 60) * 2;
+                let fix_timeout = if attempt > 1 {
+                    fix_timeout_secs * u64::from(config.escalation.timeout_multiplier_pct) / 100
+                } else {
+                    fix_timeout_secs
+                };
+
+                let description = build_fix_prompt(gh_num, &signal.title, &signal.body);
+
+                Disposition::Dispatch {
+                    description,
+                    scope: AgentScope {
+                        allowed_paths: vec!["src/".into(), "tests/".into()],
+                        verify: VerifyLevel::Ci,
+                        timeout: Duration::from_secs(fix_timeout),
+                        model,
+                    },
+                    attempt,
+                }
+            }
+            other => Disposition::Skip {
+                reason: format!("unrecognized agent-todo label: {other}"),
+            },
+        },
         SourceKind::Internal => {
             // Internal hygiene signals are triaged for human review, not auto-dispatched
             Disposition::Triage {

--- a/crosslink/src/commands/sentinel/dispatch.rs
+++ b/crosslink/src/commands/sentinel/dispatch.rs
@@ -85,6 +85,34 @@ pub fn triage(signal: &Signal, decision: &SignalDecision, config: &SentinelConfi
                         attempt,
                     }
                 }
+                "agent-todo: fix" => {
+                    let gh_num = signal
+                        .metadata
+                        .get("number")
+                        .and_then(|v| v.as_i64())
+                        .unwrap_or(0);
+
+                    // Fix agents get more time: 60min base (vs 30min for replicate)
+                    let fix_timeout_secs = (config.default_agent.timeout_minutes * 60) * 2;
+                    let fix_timeout = if attempt > 1 {
+                        fix_timeout_secs * u64::from(config.escalation.timeout_multiplier_pct) / 100
+                    } else {
+                        fix_timeout_secs
+                    };
+
+                    let description = build_fix_prompt(gh_num, &signal.title, &signal.body);
+
+                    Disposition::Dispatch {
+                        description,
+                        scope: AgentScope {
+                            allowed_paths: vec!["src/".into(), "tests/".into()],
+                            verify: VerifyLevel::Ci,
+                            timeout: Duration::from_secs(fix_timeout),
+                            model,
+                        },
+                        attempt,
+                    }
+                }
                 other => Disposition::Skip {
                     reason: format!("unrecognized agent-todo label: {other}"),
                 },
@@ -124,5 +152,38 @@ Constraints:
 - Do NOT fix the bug — only reproduce it
 - Do NOT push code or create PRs
 - Time limit: 30 minutes"#
+    )
+}
+
+fn build_fix_prompt(gh_issue_number: i64, title: &str, body: &str) -> String {
+    let body_truncated = if body.len() > 4000 {
+        format!("{}...\n\n(truncated)", &body[..4000])
+    } else {
+        body.to_string()
+    };
+
+    format!(
+        r#"Fix the bug described in GitHub issue #{gh_issue_number}.
+
+Title: {title}
+Body:
+{body_truncated}
+
+Your task:
+1. Read the issue carefully and understand the expected vs actual behavior
+2. Explore the codebase to find the root cause
+3. Write a failing test that demonstrates the bug
+4. Implement the fix
+5. Run the full test suite to confirm the fix works and nothing else breaks
+6. Record your findings as a crosslink comment (--kind resolution)
+7. Push your branch and open a draft PR linking GH#{gh_issue_number}
+
+Draft PR title: fix: {title} (sentinel)
+
+Constraints:
+- You may modify files in src/ and tests/
+- Push your branch when tests pass
+- Open a DRAFT PR (not ready for review) — a human will review it
+- Time limit: 60 minutes"#
     )
 }

--- a/crosslink/src/commands/sentinel/dispatch.rs
+++ b/crosslink/src/commands/sentinel/dispatch.rs
@@ -1,0 +1,34 @@
+use std::time::Duration;
+
+use crate::commands::kickoff::VerifyLevel;
+
+/// What the triage engine decides to do with a signal.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub enum Disposition {
+    /// Spawn a kickoff agent with this scope.
+    Dispatch {
+        description: String,
+        scope: AgentScope,
+        attempt: u32,
+    },
+    /// Create a crosslink issue for human review.
+    Triage {
+        priority: String,
+        labels: Vec<String>,
+    },
+    /// Already handled or no matching rule — skip.
+    Skip { reason: String },
+    /// Eligible but cannot dispatch right now.
+    Defer { reason: String },
+}
+
+/// Constrains what a dispatched agent can do.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct AgentScope {
+    pub allowed_paths: Vec<String>,
+    pub verify: VerifyLevel,
+    pub timeout: Duration,
+    pub model: String,
+}

--- a/crosslink/src/commands/sentinel/dispatch.rs
+++ b/crosslink/src/commands/sentinel/dispatch.rs
@@ -21,11 +21,17 @@ pub enum Disposition {
     },
     /// Already handled or no matching rule — skip.
     Skip { reason: String },
+    /// Eligible but cannot dispatch right now (e.g. at concurrent agent capacity).
+    /// Will be retried on the next cycle.
+    Defer { reason: String },
 }
 
 /// Constrains what a dispatched agent can do.
 #[derive(Debug, Clone)]
 pub struct AgentScope {
+    /// Path prefixes the agent is allowed to write to (e.g. ["tests/", "src/"]).
+    /// Enforced via the kickoff prompt + allowed-tools whitelist.
+    pub allowed_paths: Vec<String>,
     pub verify: VerifyLevel,
     pub timeout: Duration,
     pub model: String,
@@ -85,7 +91,9 @@ pub fn triage(
                 Disposition::Dispatch {
                     description,
                     scope: AgentScope {
-                        verify: VerifyLevel::Local,
+                        allowed_paths: vec!["tests/".into()],
+                        // Replicate uses the config default verify level (typically Local)
+                        verify: config.default_agent.verify_level(),
                         timeout: Duration::from_secs(timeout_secs),
                         model,
                     },
@@ -112,6 +120,8 @@ pub fn triage(
                 Disposition::Dispatch {
                     description,
                     scope: AgentScope {
+                        allowed_paths: vec!["src/".into(), "tests/".into()],
+                        // Fix dispatches always use Ci to push branch + open draft PR
                         verify: VerifyLevel::Ci,
                         timeout: Duration::from_secs(fix_timeout),
                         model,

--- a/crosslink/src/commands/sentinel/dispatch.rs
+++ b/crosslink/src/commands/sentinel/dispatch.rs
@@ -125,9 +125,13 @@ pub fn triage(signal: &Signal, decision: &SignalDecision, config: &SentinelConfi
                 labels: vec!["hygiene".into()],
             }
         }
-        _ => Disposition::Skip {
-            reason: "no matching rule for source".into(),
-        },
+        SourceKind::CI => {
+            // CI failures are triaged for human review with high priority
+            Disposition::Triage {
+                priority: "high".into(),
+                labels: vec!["ci-failure".into()],
+            }
+        }
     }
 }
 

--- a/crosslink/src/commands/sentinel/dispatch.rs
+++ b/crosslink/src/commands/sentinel/dispatch.rs
@@ -29,7 +29,7 @@ pub enum Disposition {
 /// Constrains what a dispatched agent can do.
 #[derive(Debug, Clone)]
 pub struct AgentScope {
-    /// Path prefixes the agent is allowed to write to (e.g. ["tests/", "src/"]).
+    /// Path prefixes the agent is allowed to write to (e.g. `["tests/", "src/"]`).
     /// Enforced via the kickoff prompt + allowed-tools whitelist.
     pub allowed_paths: Vec<String>,
     pub verify: VerifyLevel,
@@ -58,8 +58,7 @@ pub fn triage(
             // Check if self-tuning recommends a different model for this label
             let model = tuning
                 .and_then(|t| t.model_for_label(label))
-                .map(String::from)
-                .unwrap_or_else(|| config.default_agent.model.clone());
+                .map_or_else(|| config.default_agent.model.clone(), String::from);
             (model, 1u32)
         }
         SignalDecision::Escalate => (config.escalation.model.clone(), 2u32),
@@ -83,7 +82,7 @@ pub fn triage(
                 let gh_num = signal
                     .metadata
                     .get("number")
-                    .and_then(|v| v.as_i64())
+                    .and_then(serde_json::Value::as_i64)
                     .unwrap_or(0);
 
                 let description = build_replicate_prompt(gh_num, &signal.title, &signal.body);
@@ -104,7 +103,7 @@ pub fn triage(
                 let gh_num = signal
                     .metadata
                     .get("number")
-                    .and_then(|v| v.as_i64())
+                    .and_then(serde_json::Value::as_i64)
                     .unwrap_or(0);
 
                 // Fix agents get more time: 60min base (vs 30min for replicate)
@@ -162,7 +161,7 @@ fn build_replicate_prompt(gh_issue_number: i64, title: &str, body: &str) -> Stri
     let body_truncated = truncate_body(body, 4000);
 
     format!(
-        r#"Reproduce the bug described in GitHub issue #{gh_issue_number}.
+        "Reproduce the bug described in GitHub issue #{gh_issue_number}.
 
 Title: {title}
 Body:
@@ -180,7 +179,7 @@ Constraints:
 - You may ONLY create or modify files in tests/ directories
 - Do NOT fix the bug — only reproduce it
 - Do NOT push code or create PRs
-- Time limit: 30 minutes"#
+- Time limit: 30 minutes"
     )
 }
 
@@ -188,7 +187,7 @@ fn build_fix_prompt(gh_issue_number: i64, title: &str, body: &str) -> String {
     let body_truncated = truncate_body(body, 4000);
 
     format!(
-        r#"Fix the bug described in GitHub issue #{gh_issue_number}.
+        "Fix the bug described in GitHub issue #{gh_issue_number}.
 
 Title: {title}
 Body:
@@ -209,6 +208,6 @@ Constraints:
 - You may modify files in src/ and tests/
 - Push your branch when tests pass
 - Open a DRAFT PR (not ready for review) — a human will review it
-- Time limit: 60 minutes"#
+- Time limit: 60 minutes"
     )
 }

--- a/crosslink/src/commands/sentinel/dispatch.rs
+++ b/crosslink/src/commands/sentinel/dispatch.rs
@@ -2,9 +2,11 @@ use std::time::Duration;
 
 use crate::commands::kickoff::VerifyLevel;
 
+use super::config::SentinelConfig;
+use super::sources::{Signal, SignalDecision, SourceKind};
+
 /// What the triage engine decides to do with a signal.
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub enum Disposition {
     /// Spawn a kickoff agent with this scope.
     Dispatch {
@@ -13,6 +15,7 @@ pub enum Disposition {
         attempt: u32,
     },
     /// Create a crosslink issue for human review.
+    #[allow(dead_code)]
     Triage {
         priority: String,
         labels: Vec<String>,
@@ -20,15 +23,106 @@ pub enum Disposition {
     /// Already handled or no matching rule — skip.
     Skip { reason: String },
     /// Eligible but cannot dispatch right now.
+    #[allow(dead_code)]
     Defer { reason: String },
 }
 
 /// Constrains what a dispatched agent can do.
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct AgentScope {
+    #[allow(dead_code)]
     pub allowed_paths: Vec<String>,
     pub verify: VerifyLevel,
     pub timeout: Duration,
     pub model: String,
+}
+
+/// Run a signal through the triage engine to determine its disposition.
+pub fn triage(signal: &Signal, decision: &SignalDecision, config: &SentinelConfig) -> Disposition {
+    let (model, attempt) = match decision {
+        SignalDecision::New => (config.default_agent.model.clone(), 1u32),
+        SignalDecision::Escalate => (config.escalation.model.clone(), 2u32),
+        SignalDecision::Skip(reason) => {
+            return Disposition::Skip {
+                reason: reason.to_string(),
+            };
+        }
+    };
+
+    let base_timeout_secs = config.default_agent.timeout_minutes * 60;
+    let timeout_secs = if attempt > 1 {
+        base_timeout_secs * u64::from(config.escalation.timeout_multiplier_pct) / 100
+    } else {
+        base_timeout_secs
+    };
+
+    match &signal.source {
+        SourceKind::GitHub => {
+            let label = signal
+                .metadata
+                .get("label")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+
+            match label {
+                "agent-todo: replicate" => {
+                    let gh_num = signal
+                        .metadata
+                        .get("number")
+                        .and_then(|v| v.as_i64())
+                        .unwrap_or(0);
+
+                    let description = build_replicate_prompt(gh_num, &signal.title, &signal.body);
+
+                    Disposition::Dispatch {
+                        description,
+                        scope: AgentScope {
+                            allowed_paths: vec!["tests/".into()],
+                            verify: VerifyLevel::Local,
+                            timeout: Duration::from_secs(timeout_secs),
+                            model,
+                        },
+                        attempt,
+                    }
+                }
+                other => Disposition::Skip {
+                    reason: format!("unrecognized agent-todo label: {other}"),
+                },
+            }
+        }
+        _ => Disposition::Skip {
+            reason: "no matching rule for source".into(),
+        },
+    }
+}
+
+fn build_replicate_prompt(gh_issue_number: i64, title: &str, body: &str) -> String {
+    // Truncate body to avoid blowing up the prompt
+    let body_truncated = if body.len() > 4000 {
+        format!("{}...\n\n(truncated)", &body[..4000])
+    } else {
+        body.to_string()
+    };
+
+    format!(
+        r#"Reproduce the bug described in GitHub issue #{gh_issue_number}.
+
+Title: {title}
+Body:
+{body_truncated}
+
+Your task:
+1. Read the issue carefully and understand the expected vs actual behavior
+2. Explore the codebase to find the relevant code paths
+3. Write a failing test that demonstrates the bug
+4. Run the test suite to confirm your test fails for the right reason
+5. Record your findings as a crosslink comment (--kind observation)
+6. If you cannot reproduce, explain why (--kind resolution)
+
+Constraints:
+- You may ONLY create or modify files in tests/ directories
+- Do NOT fix the bug — only reproduce it
+- Do NOT push code or create PRs
+- Time limit: 30 minutes"#
+    )
 }

--- a/crosslink/src/commands/sentinel/dispatch.rs
+++ b/crosslink/src/commands/sentinel/dispatch.rs
@@ -118,6 +118,13 @@ pub fn triage(signal: &Signal, decision: &SignalDecision, config: &SentinelConfi
                 },
             }
         }
+        SourceKind::Internal => {
+            // Internal hygiene signals are triaged for human review, not auto-dispatched
+            Disposition::Triage {
+                priority: "low".into(),
+                labels: vec!["hygiene".into()],
+            }
+        }
         _ => Disposition::Skip {
             reason: "no matching rule for source".into(),
         },

--- a/crosslink/src/commands/sentinel/dispatch.rs
+++ b/crosslink/src/commands/sentinel/dispatch.rs
@@ -15,23 +15,17 @@ pub enum Disposition {
         attempt: u32,
     },
     /// Create a crosslink issue for human review.
-    #[allow(dead_code)]
     Triage {
         priority: String,
         labels: Vec<String>,
     },
     /// Already handled or no matching rule — skip.
     Skip { reason: String },
-    /// Eligible but cannot dispatch right now.
-    #[allow(dead_code)]
-    Defer { reason: String },
 }
 
 /// Constrains what a dispatched agent can do.
 #[derive(Debug, Clone)]
 pub struct AgentScope {
-    #[allow(dead_code)]
-    pub allowed_paths: Vec<String>,
     pub verify: VerifyLevel,
     pub timeout: Duration,
     pub model: String,
@@ -91,7 +85,6 @@ pub fn triage(
                 Disposition::Dispatch {
                     description,
                     scope: AgentScope {
-                        allowed_paths: vec!["tests/".into()],
                         verify: VerifyLevel::Local,
                         timeout: Duration::from_secs(timeout_secs),
                         model,
@@ -119,7 +112,6 @@ pub fn triage(
                 Disposition::Dispatch {
                     description,
                     scope: AgentScope {
-                        allowed_paths: vec!["src/".into(), "tests/".into()],
                         verify: VerifyLevel::Ci,
                         timeout: Duration::from_secs(fix_timeout),
                         model,
@@ -148,13 +140,16 @@ pub fn triage(
     }
 }
 
-fn build_replicate_prompt(gh_issue_number: i64, title: &str, body: &str) -> String {
-    // Truncate body to avoid blowing up the prompt
-    let body_truncated = if body.len() > 4000 {
-        format!("{}...\n\n(truncated)", &body[..4000])
+fn truncate_body(body: &str, max_len: usize) -> String {
+    if body.len() > max_len {
+        format!("{}...\n\n(truncated)", &body[..max_len])
     } else {
         body.to_string()
-    };
+    }
+}
+
+fn build_replicate_prompt(gh_issue_number: i64, title: &str, body: &str) -> String {
+    let body_truncated = truncate_body(body, 4000);
 
     format!(
         r#"Reproduce the bug described in GitHub issue #{gh_issue_number}.
@@ -180,11 +175,7 @@ Constraints:
 }
 
 fn build_fix_prompt(gh_issue_number: i64, title: &str, body: &str) -> String {
-    let body_truncated = if body.len() > 4000 {
-        format!("{}...\n\n(truncated)", &body[..4000])
-    } else {
-        body.to_string()
-    };
+    let body_truncated = truncate_body(body, 4000);
 
     format!(
         r#"Fix the bug described in GitHub issue #{gh_issue_number}.

--- a/crosslink/src/commands/sentinel/engine.rs
+++ b/crosslink/src/commands/sentinel/engine.rs
@@ -287,6 +287,9 @@ fn create_sentinel_issue(
 }
 
 /// Spawn a kickoff agent for a sentinel dispatch.
+///
+/// For fix dispatches (VerifyLevel::Ci), propagates GH_TOKEN so the agent
+/// can push branches and create draft PRs.
 fn spawn_agent(
     crosslink_dir: &Path,
     db: &Database,
@@ -295,7 +298,23 @@ fn spawn_agent(
     issue_id: i64,
     scope: &super::dispatch::AgentScope,
 ) -> Result<String> {
-    use crate::commands::kickoff::{run, ContainerMode, KickoffOpts};
+    use crate::commands::kickoff::{run, ContainerMode, KickoffOpts, VerifyLevel};
+
+    // For Ci verify level, ensure GH_TOKEN is available so the agent can push + create PRs.
+    // Read it from `gh auth token` and inject into the process environment.
+    if scope.verify == VerifyLevel::Ci && std::env::var("GH_TOKEN").is_err() {
+        if let Ok(output) = std::process::Command::new("gh")
+            .args(["auth", "token"])
+            .output()
+        {
+            if output.status.success() {
+                let token = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                if !token.is_empty() {
+                    std::env::set_var("GH_TOKEN", &token);
+                }
+            }
+        }
+    }
 
     let opts = KickoffOpts {
         description,

--- a/crosslink/src/commands/sentinel/engine.rs
+++ b/crosslink/src/commands/sentinel/engine.rs
@@ -40,7 +40,7 @@ pub fn run_oneshot(
     }
 
     if dry_run {
-        return run_dry(config, quiet);
+        return Ok(run_dry(config, quiet));
     }
 
     // Poll all configured sources to gather signals
@@ -51,7 +51,7 @@ pub fn run_oneshot(
         db,
         writer,
         config,
-        all_signals,
+        &all_signals,
         "oneshot",
         quiet,
     )
@@ -66,10 +66,7 @@ fn poll_all_sources(
 ) -> Vec<Signal> {
     let mut sources: Vec<Box<dyn Source>> = Vec::new();
     if config.sources.github_labels.enabled {
-        match GitHubLabelSource::new(config) {
-            Ok(src) => sources.push(Box::new(src)),
-            Err(e) => tracing::warn!("failed to initialize github-labels source: {e}"),
-        }
+        sources.push(Box::new(GitHubLabelSource::new(config)));
     }
     if config.sources.github_ci.enabled {
         sources.push(Box::new(super::sources::ci::GitHubCISource::new()));
@@ -124,7 +121,7 @@ pub fn process_signal_batch(
     db: &Database,
     writer: Option<&SharedWriter>,
     config: &SentinelConfig,
-    all_signals: Vec<Signal>,
+    all_signals: &[Signal],
     mode: &str,
     quiet: bool,
 ) -> Result<CycleStats> {
@@ -153,7 +150,7 @@ pub fn process_signal_batch(
     };
 
     // 4. Triage and dispatch each signal
-    for signal in &all_signals {
+    for signal in all_signals {
         // Layer 2: in-memory dedup
         let decision = seen.evaluate(&signal.reference, config);
         if let SignalDecision::Skip(reason) = &decision {
@@ -311,12 +308,14 @@ pub fn process_signal_batch(
     // 8. Record run stats
     db.complete_sentinel_run(
         &run_id,
-        stats.signals_found as i64,
-        stats.dispatched as i64,
-        stats.collected as i64,
-        0, // triaged
-        stats.skipped as i64,
-        stats.deferred as i64,
+        &crate::db::sentinel::RunCounters {
+            signals_found: i64::from(stats.signals_found),
+            dispatched: i64::from(stats.dispatched),
+            collected: i64::from(stats.collected),
+            triaged: 0,
+            skipped: i64::from(stats.skipped),
+            deferred: i64::from(stats.deferred),
+        },
     )?;
 
     if !quiet {
@@ -329,7 +328,7 @@ pub fn process_signal_batch(
     Ok(stats)
 }
 
-fn run_dry(config: &SentinelConfig, quiet: bool) -> Result<CycleStats> {
+fn run_dry(config: &SentinelConfig, quiet: bool) -> CycleStats {
     if !quiet {
         println!("sentinel dry-run: would poll sources and dispatch agents");
         println!(
@@ -345,7 +344,7 @@ fn run_dry(config: &SentinelConfig, quiet: bool) -> Result<CycleStats> {
             );
         }
     }
-    Ok(CycleStats::default())
+    CycleStats::default()
 }
 
 /// Create a crosslink issue for a sentinel signal.
@@ -380,7 +379,7 @@ fn create_sentinel_issue(
 
 /// Spawn a kickoff agent for a sentinel dispatch.
 ///
-/// For fix dispatches (VerifyLevel::Ci), propagates GH_TOKEN so the agent
+/// For fix dispatches (`VerifyLevel::Ci`), propagates `GH_TOKEN` so the agent
 /// can push branches and create draft PRs.
 fn spawn_agent(
     crosslink_dir: &Path,

--- a/crosslink/src/commands/sentinel/engine.rs
+++ b/crosslink/src/commands/sentinel/engine.rs
@@ -1,0 +1,61 @@
+use anyhow::Result;
+use std::path::Path;
+
+use crate::db::Database;
+use crate::shared_writer::SharedWriter;
+
+use super::config::SentinelConfig;
+
+/// Statistics from a single sentinel cycle.
+#[derive(Debug, Default)]
+#[allow(dead_code)]
+pub struct CycleStats {
+    pub signals_found: u32,
+    pub dispatched: u32,
+    pub collected: u32,
+    pub skipped: u32,
+    pub deferred: u32,
+}
+
+/// Run a single sentinel cycle: poll sources, triage, dispatch, collect.
+pub fn run_oneshot(
+    _crosslink_dir: &Path,
+    _db: &Database,
+    _writer: Option<&SharedWriter>,
+    config: &SentinelConfig,
+    dry_run: bool,
+    _label_filter: Option<&str>,
+    quiet: bool,
+) -> Result<CycleStats> {
+    if !config.enabled {
+        if !quiet {
+            println!("sentinel is disabled");
+        }
+        return Ok(CycleStats::default());
+    }
+
+    if dry_run {
+        if !quiet {
+            println!("sentinel dry-run: would poll sources and dispatch agents");
+            println!(
+                "  sources: github-labels (labels: {:?})",
+                config.sources.github_labels.labels
+            );
+            println!("  max concurrent agents: {}", config.max_concurrent_agents);
+            println!("  default model: {}", config.default_agent.model);
+            if config.escalation.enabled {
+                println!(
+                    "  escalation: {} after {}m cooldown",
+                    config.escalation.model, config.escalation.cooldown_minutes
+                );
+            }
+        }
+        return Ok(CycleStats::default());
+    }
+
+    // Full implementation in #654
+    if !quiet {
+        println!("0 signals found");
+    }
+    Ok(CycleStats::default())
+}

--- a/crosslink/src/commands/sentinel/engine.rs
+++ b/crosslink/src/commands/sentinel/engine.rs
@@ -148,21 +148,23 @@ pub fn run_oneshot(
             // This can happen if SeenSet was loaded before a previous cycle's dispatch was recorded
         }
 
-        // 5. Check capacity
-        let in_flight = db.count_pending_dispatches()?;
-        if in_flight >= config.max_concurrent_agents as i64 {
-            if !quiet {
-                println!(
-                    "  defer: {} (at capacity: {}/{})",
-                    signal.reference, in_flight, config.max_concurrent_agents
-                );
+        // 5. Triage
+        let mut disposition = triage(signal, &decision, config, Some(&tuning));
+
+        // 6. Capacity check: if triage decided to dispatch but we're at capacity,
+        //    override to Defer so the signal is retried on the next cycle.
+        if matches!(disposition, super::dispatch::Disposition::Dispatch { .. }) {
+            let in_flight = db.count_pending_dispatches()?;
+            if in_flight >= config.max_concurrent_agents as i64 {
+                disposition = super::dispatch::Disposition::Defer {
+                    reason: format!(
+                        "at capacity: {}/{}",
+                        in_flight, config.max_concurrent_agents
+                    ),
+                };
             }
-            stats.deferred += 1;
-            continue;
         }
 
-        // 6. Triage
-        let disposition = triage(signal, &decision, config, Some(&tuning));
         match disposition {
             super::dispatch::Disposition::Dispatch {
                 description,
@@ -237,7 +239,12 @@ pub fn run_oneshot(
                 }
                 stats.skipped += 1;
             }
-            // Defer is handled by the pre-triage capacity check above (continue)
+            super::dispatch::Disposition::Defer { reason } => {
+                if !quiet {
+                    println!("  defer: {} ({})", signal.reference, reason);
+                }
+                stats.deferred += 1;
+            }
             super::dispatch::Disposition::Triage { priority, labels } => {
                 // Triage-only signals get a crosslink issue with priority + labels
                 let issue_id = create_sentinel_issue(db, writer, signal)?;
@@ -375,8 +382,22 @@ fn spawn_agent(
         }
     }
 
+    // Append a strict path-enforcement section so the agent honors AgentScope.allowed_paths
+    // even if the prompt template's natural language is ambiguous.
+    let scoped_description = format!(
+        "{description}\n\n## Path Enforcement (sentinel scope)\n\
+         You may ONLY create or modify files under these path prefixes:\n{}\n\
+         Modifying files outside these prefixes is a contract violation.",
+        scope
+            .allowed_paths
+            .iter()
+            .map(|p| format!("- `{p}`"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+
     let opts = KickoffOpts {
-        description,
+        description: &scoped_description,
         issue: Some(issue_id),
         container: ContainerMode::None,
         verify: scope.verify.clone(),

--- a/crosslink/src/commands/sentinel/engine.rs
+++ b/crosslink/src/commands/sentinel/engine.rs
@@ -82,6 +82,19 @@ pub fn run_oneshot(
     // 2. Load SeenSet
     let seen = SeenSet::load(db)?;
 
+    // 2b. Load self-tuning overrides from historical success rates
+    let tuning = if config.escalation.enabled {
+        super::tuning::TuningOverride::from_history(db, config).unwrap_or_else(|e| {
+            tracing::warn!("self-tuning load failed: {e}");
+            super::tuning::TuningOverride::none()
+        })
+    } else {
+        super::tuning::TuningOverride::none()
+    };
+    if tuning.has_overrides() && !quiet {
+        println!("  self-tuning: model overrides active based on historical data");
+    }
+
     // 3. Poll all sources
     let mut all_signals: Vec<Signal> = Vec::new();
     for source in &mut sources {
@@ -149,7 +162,7 @@ pub fn run_oneshot(
         }
 
         // 6. Triage
-        let disposition = triage(signal, &decision, config);
+        let disposition = triage(signal, &decision, config, Some(&tuning));
         match disposition {
             super::dispatch::Disposition::Dispatch {
                 description,

--- a/crosslink/src/commands/sentinel/engine.rs
+++ b/crosslink/src/commands/sentinel/engine.rs
@@ -235,7 +235,7 @@ pub fn run_oneshot(
     }
 
     // 7. Collect results from previously completed agents
-    match collect::collect_completed(db, crosslink_dir) {
+    match collect::collect_completed(db, crosslink_dir, Some(config)) {
         Ok(collect_stats) => stats.collected = collect_stats.collected,
         Err(e) => tracing::warn!("result collection failed: {e}"),
     }

--- a/crosslink/src/commands/sentinel/engine.rs
+++ b/crosslink/src/commands/sentinel/engine.rs
@@ -65,6 +65,19 @@ pub fn run_oneshot(
             super::sources::internal::InternalHygieneSource::new(crosslink_dir, hygiene_config),
         ));
     }
+    if config.sources.maintenance_sweep.enabled {
+        let sweep_config = super::sources::maintenance::MaintenanceSweepConfig {
+            lint_enabled: config.sources.maintenance_sweep.lint_enabled,
+            test_coverage_enabled: config.sources.maintenance_sweep.test_coverage_enabled,
+            lint_warning_threshold: config.sources.maintenance_sweep.lint_warning_threshold,
+        };
+        // Resolve repo root for running commands
+        if let Ok(root) = resolve_repo_root(crosslink_dir) {
+            sources.push(Box::new(
+                super::sources::maintenance::MaintenanceSweepSource::new(&root, sweep_config),
+            ));
+        }
+    }
 
     // 2. Load SeenSet
     let seen = SeenSet::load(db)?;
@@ -344,4 +357,18 @@ fn spawn_agent(
     };
 
     run(crosslink_dir, db, writer, &opts)
+}
+
+/// Resolve the repo root from a crosslink directory.
+fn resolve_repo_root(crosslink_dir: &Path) -> Result<std::path::PathBuf> {
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .current_dir(crosslink_dir)
+        .output()?;
+    if !output.status.success() {
+        anyhow::bail!("Not in a git repository");
+    }
+    Ok(std::path::PathBuf::from(
+        String::from_utf8_lossy(&output.stdout).trim(),
+    ))
 }

--- a/crosslink/src/commands/sentinel/engine.rs
+++ b/crosslink/src/commands/sentinel/engine.rs
@@ -54,6 +54,9 @@ pub fn run_oneshot(
             Err(e) => tracing::warn!("failed to initialize github-labels source: {e}"),
         }
     }
+    if config.sources.github_ci.enabled {
+        sources.push(Box::new(super::sources::ci::GitHubCISource::new()));
+    }
     if config.sources.internal_hygiene.enabled {
         let hygiene_config = super::sources::internal::InternalHygieneConfig {
             stale_threshold_days: config.sources.internal_hygiene.stale_threshold_days,

--- a/crosslink/src/commands/sentinel/engine.rs
+++ b/crosslink/src/commands/sentinel/engine.rs
@@ -104,13 +104,13 @@ pub fn run_oneshot(
         }
     }
 
-    // Apply label filter if specified
+    // Apply label filter if specified (exact suffix match, not substring)
     if let Some(filter) = label_filter {
         all_signals.retain(|s| {
             s.metadata
                 .get("label")
                 .and_then(|v| v.as_str())
-                .is_some_and(|l| l.contains(filter))
+                .is_some_and(|l| l == filter || l.ends_with(&format!(": {filter}")))
         });
     }
 
@@ -171,54 +171,58 @@ pub fn run_oneshot(
             } => {
                 if !quiet {
                     println!(
-                        "  dispatch: {} (attempt {}, model: {})",
-                        signal.reference, attempt, scope.model
+                        "  dispatch: {} [{:?}] (attempt {}, model: {}, detected: {})",
+                        signal.reference,
+                        signal.kind,
+                        attempt,
+                        scope.model,
+                        signal.detected_at.format("%H:%M:%S")
                     );
                 }
                 // Create crosslink issue for this signal
                 let issue_id = create_sentinel_issue(db, writer, signal)?;
 
                 // Spawn agent via kickoff
+                let source_str = format!("{:?}", signal.source);
+                let label_str = signal
+                    .metadata
+                    .get("label")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown");
+
                 match spawn_agent(crosslink_dir, db, writer, &description, issue_id, &scope) {
                     Ok(agent_id) => {
-                        db.insert_sentinel_dispatch(
-                            &run_id,
-                            &signal.reference,
-                            &signal.title,
-                            &format!("{:?}", signal.source),
-                            "dispatch",
-                            Some(&agent_id),
-                            Some(issue_id),
-                            gh_number,
-                            signal
-                                .metadata
-                                .get("label")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("unknown"),
-                            attempt as i32,
-                            Some(&scope.model),
-                        )?;
+                        db.insert_sentinel_dispatch(&crate::db::sentinel::NewDispatch {
+                            run_id: &run_id,
+                            signal_ref: &signal.reference,
+                            signal_title: &signal.title,
+                            source: &source_str,
+                            disposition: "dispatch",
+                            agent_id: Some(&agent_id),
+                            crosslink_issue_id: Some(issue_id),
+                            gh_issue_number: gh_number,
+                            label: label_str,
+                            attempt_number: attempt as i32,
+                            model_used: Some(&scope.model),
+                        })?;
                         stats.dispatched += 1;
                     }
                     Err(e) => {
                         tracing::error!("agent spawn failed for {}: {e}", signal.reference);
-                        let dispatch_id = db.insert_sentinel_dispatch(
-                            &run_id,
-                            &signal.reference,
-                            &signal.title,
-                            &format!("{:?}", signal.source),
-                            "dispatch",
-                            None,
-                            Some(issue_id),
-                            gh_number,
-                            signal
-                                .metadata
-                                .get("label")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("unknown"),
-                            attempt as i32,
-                            Some(&scope.model),
-                        )?;
+                        let dispatch_id =
+                            db.insert_sentinel_dispatch(&crate::db::sentinel::NewDispatch {
+                                run_id: &run_id,
+                                signal_ref: &signal.reference,
+                                signal_title: &signal.title,
+                                source: &source_str,
+                                disposition: "dispatch",
+                                agent_id: None,
+                                crosslink_issue_id: Some(issue_id),
+                                gh_issue_number: gh_number,
+                                label: label_str,
+                                attempt_number: attempt as i32,
+                                model_used: Some(&scope.model),
+                            })?;
                         db.update_dispatch_outcome(
                             dispatch_id,
                             "failure",
@@ -233,15 +237,26 @@ pub fn run_oneshot(
                 }
                 stats.skipped += 1;
             }
-            super::dispatch::Disposition::Defer { reason } => {
-                if !quiet {
-                    println!("  defer: {} ({})", signal.reference, reason);
+            // Defer is handled by the pre-triage capacity check above (continue)
+            super::dispatch::Disposition::Triage { priority, labels } => {
+                // Triage-only signals get a crosslink issue with priority + labels
+                let issue_id = create_sentinel_issue(db, writer, signal)?;
+                let _ = db.update_issue(issue_id, None, None, Some(&priority));
+                for l in &labels {
+                    if let Some(w) = writer {
+                        let _ = w.add_label(db, issue_id, l);
+                    } else {
+                        let _ = db.add_label(issue_id, l);
+                    }
                 }
-                stats.deferred += 1;
-            }
-            super::dispatch::Disposition::Triage { .. } => {
-                // Triage-only signals just get a crosslink issue, no agent
-                let _issue_id = create_sentinel_issue(db, writer, signal)?;
+                if !quiet {
+                    println!(
+                        "  triage: {} (priority: {}, labels: {})",
+                        signal.reference,
+                        priority,
+                        labels.join(", ")
+                    );
+                }
                 stats.skipped += 1;
             }
         }
@@ -340,15 +355,22 @@ fn spawn_agent(
     // For Ci verify level, ensure GH_TOKEN is available so the agent can push + create PRs.
     // Read it from `gh auth token` and inject into the process environment.
     if scope.verify == VerifyLevel::Ci && std::env::var("GH_TOKEN").is_err() {
-        if let Ok(output) = std::process::Command::new("gh")
+        match std::process::Command::new("gh")
             .args(["auth", "token"])
             .output()
         {
-            if output.status.success() {
+            Ok(output) if output.status.success() => {
                 let token = String::from_utf8_lossy(&output.stdout).trim().to_string();
                 if !token.is_empty() {
                     std::env::set_var("GH_TOKEN", &token);
                 }
+            }
+            Ok(output) => {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                tracing::warn!("gh auth token failed: {}", stderr.trim());
+            }
+            Err(e) => {
+                tracing::warn!("failed to run gh auth token: {e}");
             }
         }
     }

--- a/crosslink/src/commands/sentinel/engine.rs
+++ b/crosslink/src/commands/sentinel/engine.rs
@@ -54,6 +54,14 @@ pub fn run_oneshot(
             Err(e) => tracing::warn!("failed to initialize github-labels source: {e}"),
         }
     }
+    if config.sources.internal_hygiene.enabled {
+        let hygiene_config = super::sources::internal::InternalHygieneConfig {
+            stale_threshold_days: config.sources.internal_hygiene.stale_threshold_days,
+        };
+        sources.push(Box::new(
+            super::sources::internal::InternalHygieneSource::new(crosslink_dir, hygiene_config),
+        ));
+    }
 
     // 2. Load SeenSet
     let seen = SeenSet::load(db)?;

--- a/crosslink/src/commands/sentinel/engine.rs
+++ b/crosslink/src/commands/sentinel/engine.rs
@@ -43,10 +43,27 @@ pub fn run_oneshot(
         return run_dry(config, quiet);
     }
 
-    let run_id = Uuid::new_v4().to_string();
-    db.insert_sentinel_run(&run_id, "oneshot")?;
+    // Poll all configured sources to gather signals
+    let all_signals = poll_all_sources(crosslink_dir, config, label_filter);
 
-    // 1. Initialize sources
+    process_signal_batch(
+        crosslink_dir,
+        db,
+        writer,
+        config,
+        all_signals,
+        "oneshot",
+        quiet,
+    )
+}
+
+/// Poll all configured sources and return their combined signals.
+/// Applies the optional label filter (exact suffix match).
+fn poll_all_sources(
+    crosslink_dir: &Path,
+    config: &SentinelConfig,
+    label_filter: Option<&str>,
+) -> Vec<Signal> {
     let mut sources: Vec<Box<dyn Source>> = Vec::new();
     if config.sources.github_labels.enabled {
         match GitHubLabelSource::new(config) {
@@ -71,7 +88,6 @@ pub fn run_oneshot(
             test_coverage_enabled: config.sources.maintenance_sweep.test_coverage_enabled,
             lint_warning_threshold: config.sources.maintenance_sweep.lint_warning_threshold,
         };
-        // Resolve repo root for running commands
         if let Ok(root) = resolve_repo_root(crosslink_dir) {
             sources.push(Box::new(
                 super::sources::maintenance::MaintenanceSweepSource::new(&root, sweep_config),
@@ -79,10 +95,46 @@ pub fn run_oneshot(
         }
     }
 
-    // 2. Load SeenSet
+    let mut all_signals: Vec<Signal> = Vec::new();
+    for source in &mut sources {
+        match source.poll() {
+            Ok(signals) => all_signals.extend(signals),
+            Err(e) => tracing::warn!("source '{}' poll failed: {e}", source.name()),
+        }
+    }
+
+    if let Some(filter) = label_filter {
+        all_signals.retain(|s| {
+            s.metadata
+                .get("label")
+                .and_then(|v| v.as_str())
+                .is_some_and(|l| l == filter || l.ends_with(&format!(": {filter}")))
+        });
+    }
+
+    all_signals
+}
+
+/// Process a pre-built batch of signals through the dedup/triage/dispatch pipeline.
+///
+/// Used by both `run_oneshot` (after polling sources) and `webhook` (for real-time
+/// events that arrive between polling cycles).
+pub fn process_signal_batch(
+    crosslink_dir: &Path,
+    db: &Database,
+    writer: Option<&SharedWriter>,
+    config: &SentinelConfig,
+    all_signals: Vec<Signal>,
+    mode: &str,
+    quiet: bool,
+) -> Result<CycleStats> {
+    let run_id = Uuid::new_v4().to_string();
+    db.insert_sentinel_run(&run_id, mode)?;
+
+    // Load SeenSet
     let seen = SeenSet::load(db)?;
 
-    // 2b. Load self-tuning overrides from historical success rates
+    // Load self-tuning overrides from historical success rates
     let tuning = if config.escalation.enabled {
         super::tuning::TuningOverride::from_history(db, config).unwrap_or_else(|e| {
             tracing::warn!("self-tuning load failed: {e}");
@@ -93,25 +145,6 @@ pub fn run_oneshot(
     };
     if tuning.has_overrides() && !quiet {
         println!("  self-tuning: model overrides active based on historical data");
-    }
-
-    // 3. Poll all sources
-    let mut all_signals: Vec<Signal> = Vec::new();
-    for source in &mut sources {
-        match source.poll() {
-            Ok(signals) => all_signals.extend(signals),
-            Err(e) => tracing::warn!("source '{}' poll failed: {e}", source.name()),
-        }
-    }
-
-    // Apply label filter if specified (exact suffix match, not substring)
-    if let Some(filter) = label_filter {
-        all_signals.retain(|s| {
-            s.metadata
-                .get("label")
-                .and_then(|v| v.as_str())
-                .is_some_and(|l| l == filter || l.ends_with(&format!(": {filter}")))
-        });
     }
 
     let mut stats = CycleStats {

--- a/crosslink/src/commands/sentinel/engine.rs
+++ b/crosslink/src/commands/sentinel/engine.rs
@@ -1,14 +1,19 @@
 use anyhow::Result;
 use std::path::Path;
+use uuid::Uuid;
 
 use crate::db::Database;
 use crate::shared_writer::SharedWriter;
 
+use super::collect;
 use super::config::SentinelConfig;
+use super::dispatch::triage;
+use super::seen_set::{db_dedup_check, SeenSet};
+use super::sources::github::GitHubLabelSource;
+use super::sources::{Signal, SignalDecision, Source};
 
 /// Statistics from a single sentinel cycle.
 #[derive(Debug, Default)]
-#[allow(dead_code)]
 pub struct CycleStats {
     pub signals_found: u32,
     pub dispatched: u32,
@@ -19,12 +24,12 @@ pub struct CycleStats {
 
 /// Run a single sentinel cycle: poll sources, triage, dispatch, collect.
 pub fn run_oneshot(
-    _crosslink_dir: &Path,
-    _db: &Database,
-    _writer: Option<&SharedWriter>,
+    crosslink_dir: &Path,
+    db: &Database,
+    writer: Option<&SharedWriter>,
     config: &SentinelConfig,
     dry_run: bool,
-    _label_filter: Option<&str>,
+    label_filter: Option<&str>,
     quiet: bool,
 ) -> Result<CycleStats> {
     if !config.enabled {
@@ -35,27 +40,278 @@ pub fn run_oneshot(
     }
 
     if dry_run {
-        if !quiet {
-            println!("sentinel dry-run: would poll sources and dispatch agents");
-            println!(
-                "  sources: github-labels (labels: {:?})",
-                config.sources.github_labels.labels
-            );
-            println!("  max concurrent agents: {}", config.max_concurrent_agents);
-            println!("  default model: {}", config.default_agent.model);
-            if config.escalation.enabled {
-                println!(
-                    "  escalation: {} after {}m cooldown",
-                    config.escalation.model, config.escalation.cooldown_minutes
-                );
-            }
-        }
-        return Ok(CycleStats::default());
+        return run_dry(config, quiet);
     }
 
-    // Full implementation in #654
+    let run_id = Uuid::new_v4().to_string();
+    db.insert_sentinel_run(&run_id, "oneshot")?;
+
+    // 1. Initialize sources
+    let mut sources: Vec<Box<dyn Source>> = Vec::new();
+    if config.sources.github_labels.enabled {
+        match GitHubLabelSource::new(config) {
+            Ok(src) => sources.push(Box::new(src)),
+            Err(e) => tracing::warn!("failed to initialize github-labels source: {e}"),
+        }
+    }
+
+    // 2. Load SeenSet
+    let seen = SeenSet::load(db)?;
+
+    // 3. Poll all sources
+    let mut all_signals: Vec<Signal> = Vec::new();
+    for source in &mut sources {
+        match source.poll() {
+            Ok(signals) => all_signals.extend(signals),
+            Err(e) => tracing::warn!("source '{}' poll failed: {e}", source.name()),
+        }
+    }
+
+    // Apply label filter if specified
+    if let Some(filter) = label_filter {
+        all_signals.retain(|s| {
+            s.metadata
+                .get("label")
+                .and_then(|v| v.as_str())
+                .is_some_and(|l| l.contains(filter))
+        });
+    }
+
+    let mut stats = CycleStats {
+        signals_found: all_signals.len() as u32,
+        ..Default::default()
+    };
+
+    // 4. Triage and dispatch each signal
+    for signal in &all_signals {
+        // Layer 2: in-memory dedup
+        let decision = seen.evaluate(&signal.reference, config);
+        if let SignalDecision::Skip(reason) = &decision {
+            if !quiet {
+                println!("  skip: {} ({})", signal.reference, reason);
+            }
+            stats.skipped += 1;
+            continue;
+        }
+
+        // Layer 3: authoritative DB dedup
+        let gh_number = super::seen_set::parse_gh_issue_number(&signal.reference);
+        let label_suffix = super::seen_set::parse_signal_label_suffix(&signal.reference);
+        if let (Some(num), Some(label)) = (gh_number, label_suffix) {
+            let full_label = format!("agent-todo: {label}");
+            let db_decision = db_dedup_check(db, num, &full_label, config)?;
+            if let SignalDecision::Skip(reason) = &db_decision {
+                if !quiet {
+                    println!("  skip: {} ({})", signal.reference, reason);
+                }
+                stats.skipped += 1;
+                continue;
+            }
+            // If DB says Escalate but SeenSet said New, trust DB (it's authoritative)
+            // This can happen if SeenSet was loaded before a previous cycle's dispatch was recorded
+        }
+
+        // 5. Check capacity
+        let in_flight = db.count_pending_dispatches()?;
+        if in_flight >= config.max_concurrent_agents as i64 {
+            if !quiet {
+                println!(
+                    "  defer: {} (at capacity: {}/{})",
+                    signal.reference, in_flight, config.max_concurrent_agents
+                );
+            }
+            stats.deferred += 1;
+            continue;
+        }
+
+        // 6. Triage
+        let disposition = triage(signal, &decision, config);
+        match disposition {
+            super::dispatch::Disposition::Dispatch {
+                description,
+                scope,
+                attempt,
+            } => {
+                if !quiet {
+                    println!(
+                        "  dispatch: {} (attempt {}, model: {})",
+                        signal.reference, attempt, scope.model
+                    );
+                }
+                // Create crosslink issue for this signal
+                let issue_id = create_sentinel_issue(db, writer, signal)?;
+
+                // Spawn agent via kickoff
+                match spawn_agent(crosslink_dir, db, writer, &description, issue_id, &scope) {
+                    Ok(agent_id) => {
+                        db.insert_sentinel_dispatch(
+                            &run_id,
+                            &signal.reference,
+                            &signal.title,
+                            &format!("{:?}", signal.source),
+                            "dispatch",
+                            Some(&agent_id),
+                            Some(issue_id),
+                            gh_number,
+                            signal
+                                .metadata
+                                .get("label")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("unknown"),
+                            attempt as i32,
+                            Some(&scope.model),
+                        )?;
+                        stats.dispatched += 1;
+                    }
+                    Err(e) => {
+                        tracing::error!("agent spawn failed for {}: {e}", signal.reference);
+                        let dispatch_id = db.insert_sentinel_dispatch(
+                            &run_id,
+                            &signal.reference,
+                            &signal.title,
+                            &format!("{:?}", signal.source),
+                            "dispatch",
+                            None,
+                            Some(issue_id),
+                            gh_number,
+                            signal
+                                .metadata
+                                .get("label")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("unknown"),
+                            attempt as i32,
+                            Some(&scope.model),
+                        )?;
+                        db.update_dispatch_outcome(
+                            dispatch_id,
+                            "failure",
+                            &format!("spawn failed: {e}"),
+                        )?;
+                    }
+                }
+            }
+            super::dispatch::Disposition::Skip { reason } => {
+                if !quiet {
+                    println!("  skip: {} ({})", signal.reference, reason);
+                }
+                stats.skipped += 1;
+            }
+            super::dispatch::Disposition::Defer { reason } => {
+                if !quiet {
+                    println!("  defer: {} ({})", signal.reference, reason);
+                }
+                stats.deferred += 1;
+            }
+            super::dispatch::Disposition::Triage { .. } => {
+                // Triage-only signals just get a crosslink issue, no agent
+                let _issue_id = create_sentinel_issue(db, writer, signal)?;
+                stats.skipped += 1;
+            }
+        }
+    }
+
+    // 7. Collect results from previously completed agents
+    match collect::collect_completed(db, crosslink_dir) {
+        Ok(collect_stats) => stats.collected = collect_stats.collected,
+        Err(e) => tracing::warn!("result collection failed: {e}"),
+    }
+
+    // 8. Record run stats
+    db.complete_sentinel_run(
+        &run_id,
+        stats.signals_found as i64,
+        stats.dispatched as i64,
+        stats.collected as i64,
+        0, // triaged
+        stats.skipped as i64,
+        stats.deferred as i64,
+    )?;
+
     if !quiet {
-        println!("0 signals found");
+        println!(
+            "{} signal(s) found, {} dispatched, {} skipped, {} deferred, {} collected",
+            stats.signals_found, stats.dispatched, stats.skipped, stats.deferred, stats.collected,
+        );
+    }
+
+    Ok(stats)
+}
+
+fn run_dry(config: &SentinelConfig, quiet: bool) -> Result<CycleStats> {
+    if !quiet {
+        println!("sentinel dry-run: would poll sources and dispatch agents");
+        println!(
+            "  sources: github-labels (labels: {:?})",
+            config.sources.github_labels.labels
+        );
+        println!("  max concurrent agents: {}", config.max_concurrent_agents);
+        println!("  default model: {}", config.default_agent.model);
+        if config.escalation.enabled {
+            println!(
+                "  escalation: {} after {}m cooldown",
+                config.escalation.model, config.escalation.cooldown_minutes
+            );
+        }
     }
     Ok(CycleStats::default())
+}
+
+/// Create a crosslink issue for a sentinel signal.
+fn create_sentinel_issue(
+    db: &Database,
+    writer: Option<&SharedWriter>,
+    signal: &Signal,
+) -> Result<i64> {
+    let description = format!(
+        "Sentinel signal: {}\n\n{}",
+        signal.reference,
+        &signal.body[..signal.body.len().min(2000)]
+    );
+    let issue_id = if let Some(w) = writer {
+        w.create_issue(db, &signal.title, Some(&description), "medium")?
+    } else {
+        db.create_issue(&signal.title, Some(&description), "medium")?
+    };
+    // Label the issue
+    let label_fn = |label: &str| -> Result<()> {
+        if let Some(w) = writer {
+            w.add_label(db, issue_id, label)?;
+        } else {
+            db.add_label(issue_id, label)?;
+        }
+        Ok(())
+    };
+    let _ = label_fn("sentinel");
+    let _ = label_fn("bug");
+    Ok(issue_id)
+}
+
+/// Spawn a kickoff agent for a sentinel dispatch.
+fn spawn_agent(
+    crosslink_dir: &Path,
+    db: &Database,
+    writer: Option<&SharedWriter>,
+    description: &str,
+    issue_id: i64,
+    scope: &super::dispatch::AgentScope,
+) -> Result<String> {
+    use crate::commands::kickoff::{run, ContainerMode, KickoffOpts};
+
+    let opts = KickoffOpts {
+        description,
+        issue: Some(issue_id),
+        container: ContainerMode::None,
+        verify: scope.verify.clone(),
+        model: &scope.model,
+        image: crate::commands::kickoff::DEFAULT_AGENT_IMAGE,
+        timeout: scope.timeout,
+        dry_run: false,
+        branch: None,
+        quiet: true,
+        design_doc: None,
+        doc_path: None,
+        skip_permissions: true,
+    };
+
+    run(crosslink_dir, db, writer, &opts)
 }

--- a/crosslink/src/commands/sentinel/history.rs
+++ b/crosslink/src/commands/sentinel/history.rs
@@ -1,9 +1,19 @@
 use anyhow::Result;
+use serde::Serialize;
 
+use crate::db::sentinel::{SentinelDispatch, SentinelRun};
 use crate::db::Database;
 
+/// JSON-serializable view of a run with its dispatches (for --detail --json).
+#[derive(Serialize)]
+struct RunWithDispatches {
+    #[serde(flatten)]
+    run: SentinelRun,
+    dispatches: Vec<SentinelDispatch>,
+}
+
 /// Display past sentinel runs and their dispatch outcomes.
-pub fn show_history(db: &Database, limit: usize, json: bool) -> Result<()> {
+pub fn show_history(db: &Database, limit: usize, detail: bool, json: bool) -> Result<()> {
     let runs = db.list_sentinel_runs(limit)?;
 
     if runs.is_empty() {
@@ -16,8 +26,18 @@ pub fn show_history(db: &Database, limit: usize, json: bool) -> Result<()> {
     }
 
     if json {
-        let json_str = serde_json::to_string_pretty(&runs)?;
-        println!("{json_str}");
+        if detail {
+            let with_details: Vec<RunWithDispatches> = runs
+                .into_iter()
+                .map(|run| {
+                    let dispatches = db.list_dispatches_for_run(&run.run_id).unwrap_or_default();
+                    RunWithDispatches { run, dispatches }
+                })
+                .collect();
+            println!("{}", serde_json::to_string_pretty(&with_details)?);
+        } else {
+            println!("{}", serde_json::to_string_pretty(&runs)?);
+        }
         return Ok(());
     }
 
@@ -45,6 +65,31 @@ pub fn show_history(db: &Database, limit: usize, json: bool) -> Result<()> {
             run.skipped,
             run.deferred,
         );
+
+        if detail {
+            let dispatches = db.list_dispatches_for_run(&run.run_id)?;
+            if dispatches.is_empty() {
+                println!("    (no dispatches)");
+            } else {
+                for d in &dispatches {
+                    let outcome_icon = match d.outcome.as_str() {
+                        "success" => "+",
+                        "failure" => "x",
+                        "exhausted" => "X",
+                        "pending" => ".",
+                        "orphaned" => "?",
+                        _ => "-",
+                    };
+                    let agent = d.agent_id.as_deref().unwrap_or("(none)");
+                    let model = d.model_used.as_deref().unwrap_or("?");
+                    println!(
+                        "    [{}] {} {} attempt={} model={} outcome={}",
+                        outcome_icon, d.signal_ref, agent, d.attempt_number, model, d.outcome
+                    );
+                }
+            }
+            println!();
+        }
     }
 
     Ok(())

--- a/crosslink/src/commands/sentinel/history.rs
+++ b/crosslink/src/commands/sentinel/history.rs
@@ -1,0 +1,10 @@
+use anyhow::Result;
+
+use crate::db::Database;
+
+/// Display past sentinel runs and their dispatch outcomes.
+pub fn show_history(_db: &Database, _limit: usize, _json: bool) -> Result<()> {
+    // Will be implemented in #656 (depends on schema from #651)
+    println!("No sentinel runs recorded yet.");
+    Ok(())
+}

--- a/crosslink/src/commands/sentinel/history.rs
+++ b/crosslink/src/commands/sentinel/history.rs
@@ -3,8 +3,49 @@ use anyhow::Result;
 use crate::db::Database;
 
 /// Display past sentinel runs and their dispatch outcomes.
-pub fn show_history(_db: &Database, _limit: usize, _json: bool) -> Result<()> {
-    // Will be implemented in #656 (depends on schema from #651)
-    println!("No sentinel runs recorded yet.");
+pub fn show_history(db: &Database, limit: usize, json: bool) -> Result<()> {
+    let runs = db.list_sentinel_runs(limit)?;
+
+    if runs.is_empty() {
+        if json {
+            println!("[]");
+        } else {
+            println!("No sentinel runs recorded yet.");
+        }
+        return Ok(());
+    }
+
+    if json {
+        let json_str = serde_json::to_string_pretty(&runs)?;
+        println!("{json_str}");
+        return Ok(());
+    }
+
+    // Table header
+    println!(
+        "{:<36}  {:<20}  {:>7}  {:>10}  {:>9}  {:>7}  {:>7}",
+        "Run", "Started", "Signals", "Dispatched", "Collected", "Skipped", "Deferred"
+    );
+    println!("{}", "-".repeat(105));
+
+    for run in &runs {
+        let started = run
+            .started_at
+            .get(..19)
+            .unwrap_or(&run.started_at)
+            .replace('T', " ");
+        let run_id_short = run.run_id.get(..12).unwrap_or(&run.run_id);
+        println!(
+            "{:<36}  {:<20}  {:>7}  {:>10}  {:>9}  {:>7}  {:>7}",
+            run_id_short,
+            started,
+            run.signals_found,
+            run.dispatched,
+            run.collected,
+            run.skipped,
+            run.deferred,
+        );
+    }
+
     Ok(())
 }

--- a/crosslink/src/commands/sentinel/metrics.rs
+++ b/crosslink/src/commands/sentinel/metrics.rs
@@ -1,0 +1,58 @@
+use anyhow::Result;
+
+use crate::db::Database;
+
+/// Display dispatch success rate metrics grouped by model and label.
+pub fn show_metrics(db: &Database, json: bool) -> Result<()> {
+    let metrics = db.get_dispatch_metrics()?;
+
+    if metrics.is_empty() {
+        if json {
+            println!("[]");
+        } else {
+            println!("No dispatch data recorded yet.");
+        }
+        return Ok(());
+    }
+
+    if json {
+        let json_str = serde_json::to_string_pretty(&metrics)?;
+        println!("{json_str}");
+        return Ok(());
+    }
+
+    println!(
+        "{:<30}  {:<14}  {:>5}  {:>4}  {:>4}  {:>4}  {:>7}  {:>8}",
+        "Label", "Model", "Total", "Pass", "Fail", "Exh.", "Pending", "Rate"
+    );
+    println!("{}", "-".repeat(95));
+
+    for m in &metrics {
+        let rate_str = if m.total - m.pending > 0 {
+            format!("{:.0}%", m.success_rate)
+        } else {
+            "-".to_string()
+        };
+        println!(
+            "{:<30}  {:<14}  {:>5}  {:>4}  {:>4}  {:>4}  {:>7}  {:>8}",
+            truncate(&m.label, 30),
+            truncate(&m.model, 14),
+            m.total,
+            m.successes,
+            m.failures,
+            m.exhausted,
+            m.pending,
+            rate_str,
+        );
+    }
+
+    Ok(())
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}...", &s[..max - 3])
+    }
+}

--- a/crosslink/src/commands/sentinel/mod.rs
+++ b/crosslink/src/commands/sentinel/mod.rs
@@ -3,6 +3,8 @@ pub mod config;
 pub mod dispatch;
 pub mod engine;
 pub mod history;
+#[allow(dead_code)]
+pub mod seen_set;
 pub mod sources;
 
 use anyhow::Result;

--- a/crosslink/src/commands/sentinel/mod.rs
+++ b/crosslink/src/commands/sentinel/mod.rs
@@ -5,6 +5,7 @@ pub mod engine;
 pub mod history;
 pub mod metrics;
 pub mod notify;
+pub mod patterns;
 #[allow(dead_code)]
 pub mod seen_set;
 pub mod sources;
@@ -56,6 +57,10 @@ pub fn dispatch_cmd(
         SentinelCommands::Metrics { json: json_flag } => {
             let use_json = json || json_flag;
             metrics::show_metrics(db, use_json)
+        }
+        SentinelCommands::Patterns { json: json_flag } => {
+            let use_json = json || json_flag;
+            patterns::detect_patterns(db, use_json)
         }
         SentinelCommands::RunDaemon { dir, interval } => watch::run_watch_loop(&dir, interval),
     }

--- a/crosslink/src/commands/sentinel/mod.rs
+++ b/crosslink/src/commands/sentinel/mod.rs
@@ -9,6 +9,7 @@ pub mod patterns;
 #[allow(dead_code)]
 pub mod seen_set;
 pub mod sources;
+pub mod tuning;
 pub mod watch;
 #[allow(dead_code)]
 pub mod webhook;

--- a/crosslink/src/commands/sentinel/mod.rs
+++ b/crosslink/src/commands/sentinel/mod.rs
@@ -4,6 +4,7 @@ pub mod dispatch;
 pub mod engine;
 pub mod history;
 pub mod metrics;
+pub mod notify;
 #[allow(dead_code)]
 pub mod seen_set;
 pub mod sources;

--- a/crosslink/src/commands/sentinel/mod.rs
+++ b/crosslink/src/commands/sentinel/mod.rs
@@ -50,10 +50,11 @@ pub fn dispatch_cmd(
         SentinelCommands::Status => watch::status(crosslink_dir, db),
         SentinelCommands::History {
             limit,
+            detail,
             json: json_flag,
         } => {
             let use_json = json || json_flag;
-            history::show_history(db, limit, use_json)
+            history::show_history(db, limit, detail, use_json)
         }
         SentinelCommands::Stop => watch::stop(crosslink_dir),
         SentinelCommands::Metrics { json: json_flag } => {

--- a/crosslink/src/commands/sentinel/mod.rs
+++ b/crosslink/src/commands/sentinel/mod.rs
@@ -1,0 +1,62 @@
+pub mod collect;
+pub mod config;
+pub mod dispatch;
+pub mod engine;
+pub mod history;
+pub mod sources;
+
+use anyhow::Result;
+use std::path::Path;
+
+use crate::db::Database;
+use crate::shared_writer::SharedWriter;
+use crate::SentinelCommands;
+
+use config::SentinelConfig;
+
+pub fn dispatch_cmd(
+    command: SentinelCommands,
+    crosslink_dir: &Path,
+    db: &Database,
+    writer: Option<&SharedWriter>,
+    quiet: bool,
+    json: bool,
+) -> Result<()> {
+    match command {
+        SentinelCommands::Run { dry_run, label } => {
+            let config = SentinelConfig::load(crosslink_dir)?;
+            engine::run_oneshot(
+                crosslink_dir,
+                db,
+                writer,
+                &config,
+                dry_run,
+                label.as_deref(),
+                quiet,
+            )?;
+            Ok(())
+        }
+        SentinelCommands::Watch { interval: _ } => {
+            // Will be implemented in #659
+            println!("sentinel watch not yet implemented");
+            Ok(())
+        }
+        SentinelCommands::Status => {
+            // Will be implemented in #659
+            println!("sentinel not running");
+            Ok(())
+        }
+        SentinelCommands::History {
+            limit,
+            json: json_flag,
+        } => {
+            let use_json = json || json_flag;
+            history::show_history(db, limit, use_json)
+        }
+        SentinelCommands::Stop => {
+            // Will be implemented in #659
+            println!("sentinel not running");
+            Ok(())
+        }
+    }
+}

--- a/crosslink/src/commands/sentinel/mod.rs
+++ b/crosslink/src/commands/sentinel/mod.rs
@@ -6,11 +6,12 @@ pub mod history;
 pub mod metrics;
 pub mod notify;
 pub mod patterns;
-#[allow(dead_code)]
 pub mod seen_set;
 pub mod sources;
 pub mod tuning;
 pub mod watch;
+// Webhook module is async (axum/tokio) and requires explicit integration
+// with the watch loop's tokio runtime — not yet wired into the sync loop.
 #[allow(dead_code)]
 pub mod webhook;
 

--- a/crosslink/src/commands/sentinel/mod.rs
+++ b/crosslink/src/commands/sentinel/mod.rs
@@ -10,9 +10,6 @@ pub mod seen_set;
 pub mod sources;
 pub mod tuning;
 pub mod watch;
-// Webhook module is async (axum/tokio) and requires explicit integration
-// with the watch loop's tokio runtime — not yet wired into the sync loop.
-#[allow(dead_code)]
 pub mod webhook;
 
 use anyhow::Result;

--- a/crosslink/src/commands/sentinel/mod.rs
+++ b/crosslink/src/commands/sentinel/mod.rs
@@ -6,6 +6,7 @@ pub mod history;
 #[allow(dead_code)]
 pub mod seen_set;
 pub mod sources;
+pub mod watch;
 
 use anyhow::Result;
 use std::path::Path;
@@ -38,16 +39,8 @@ pub fn dispatch_cmd(
             )?;
             Ok(())
         }
-        SentinelCommands::Watch { interval: _ } => {
-            // Will be implemented in #659
-            println!("sentinel watch not yet implemented");
-            Ok(())
-        }
-        SentinelCommands::Status => {
-            // Will be implemented in #659
-            println!("sentinel not running");
-            Ok(())
-        }
+        SentinelCommands::Watch { interval } => watch::start(crosslink_dir, interval),
+        SentinelCommands::Status => watch::status(crosslink_dir, db),
         SentinelCommands::History {
             limit,
             json: json_flag,
@@ -55,10 +48,7 @@ pub fn dispatch_cmd(
             let use_json = json || json_flag;
             history::show_history(db, limit, use_json)
         }
-        SentinelCommands::Stop => {
-            // Will be implemented in #659
-            println!("sentinel not running");
-            Ok(())
-        }
+        SentinelCommands::Stop => watch::stop(crosslink_dir),
+        SentinelCommands::RunDaemon { dir, interval } => watch::run_watch_loop(&dir, interval),
     }
 }

--- a/crosslink/src/commands/sentinel/mod.rs
+++ b/crosslink/src/commands/sentinel/mod.rs
@@ -8,6 +8,8 @@ pub mod metrics;
 pub mod seen_set;
 pub mod sources;
 pub mod watch;
+#[allow(dead_code)]
+pub mod webhook;
 
 use anyhow::Result;
 use std::path::Path;

--- a/crosslink/src/commands/sentinel/mod.rs
+++ b/crosslink/src/commands/sentinel/mod.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod dispatch;
 pub mod engine;
 pub mod history;
+pub mod metrics;
 #[allow(dead_code)]
 pub mod seen_set;
 pub mod sources;
@@ -49,6 +50,10 @@ pub fn dispatch_cmd(
             history::show_history(db, limit, use_json)
         }
         SentinelCommands::Stop => watch::stop(crosslink_dir),
+        SentinelCommands::Metrics { json: json_flag } => {
+            let use_json = json || json_flag;
+            metrics::show_metrics(db, use_json)
+        }
         SentinelCommands::RunDaemon { dir, interval } => watch::run_watch_loop(&dir, interval),
     }
 }

--- a/crosslink/src/commands/sentinel/notify.rs
+++ b/crosslink/src/commands/sentinel/notify.rs
@@ -14,20 +14,18 @@ pub fn notify_dispatch_completed(
     dispatch: &SentinelDispatch,
     outcome: &str,
     findings_summary: &str,
-) -> Result<()> {
+) {
     if !config.enabled {
-        return Ok(());
+        return;
     }
 
     let message = build_notification_message(dispatch, outcome, findings_summary);
 
     for url in &config.webhook_urls {
-        if let Err(e) = send_webhook(url, &message, config.is_slack_url(url)) {
+        if let Err(e) = send_webhook(url, &message, NotificationConfig::is_slack_url(url)) {
             tracing::warn!("notification to {} failed: {e}", mask_url(url));
         }
     }
-
-    Ok(())
 }
 
 /// Build the notification message payload.
@@ -57,8 +55,7 @@ fn build_notification_message(
     let model = dispatch.model_used.as_deref().unwrap_or("unknown");
     let gh_link = dispatch
         .gh_issue_number
-        .map(|n| format!("GH#{n}"))
-        .unwrap_or_else(|| dispatch.signal_ref.clone());
+        .map_or_else(|| dispatch.signal_ref.clone(), |n| format!("GH#{n}"));
 
     let summary = if findings_summary.len() > 300 {
         format!("{}...", &findings_summary[..300])
@@ -177,12 +174,7 @@ fn send_webhook(url: &str, message: &NotificationMessage, is_slack: bool) -> Res
 
 /// Mask a URL for safe logging (hide everything after the host).
 fn mask_url(url: &str) -> String {
-    if let Some(pos) = url
-        .find("//")
+    url.find("//")
         .and_then(|p| url[p + 2..].find('/').map(|q| p + 2 + q))
-    {
-        format!("{}/*****", &url[..pos])
-    } else {
-        "***".to_string()
-    }
+        .map_or_else(|| "***".to_string(), |pos| format!("{}/*****", &url[..pos]))
 }

--- a/crosslink/src/commands/sentinel/notify.rs
+++ b/crosslink/src/commands/sentinel/notify.rs
@@ -1,0 +1,188 @@
+use anyhow::{Context, Result};
+use std::process::Command;
+
+use crate::db::sentinel::SentinelDispatch;
+
+use super::config::NotificationConfig;
+
+/// Send a notification for a completed dispatch.
+///
+/// Supports Slack incoming webhooks and generic HTTP POST endpoints.
+/// Does nothing if notifications are disabled.
+pub fn notify_dispatch_completed(
+    config: &NotificationConfig,
+    dispatch: &SentinelDispatch,
+    outcome: &str,
+    findings_summary: &str,
+) -> Result<()> {
+    if !config.enabled {
+        return Ok(());
+    }
+
+    let message = build_notification_message(dispatch, outcome, findings_summary);
+
+    for url in &config.webhook_urls {
+        if let Err(e) = send_webhook(url, &message, config.is_slack_url(url)) {
+            tracing::warn!("notification to {} failed: {e}", mask_url(url));
+        }
+    }
+
+    Ok(())
+}
+
+/// Build the notification message payload.
+fn build_notification_message(
+    dispatch: &SentinelDispatch,
+    outcome: &str,
+    findings_summary: &str,
+) -> NotificationMessage {
+    let status_emoji = match outcome {
+        "success" => "white_check_mark",
+        "failure" => "x",
+        "exhausted" => "no_entry_sign",
+        "orphaned" => "ghost",
+        _ => "question",
+    };
+
+    let status_text = match outcome {
+        "success" if dispatch.label.contains("fix") => "Fixed",
+        "success" => "Reproduced",
+        "failure" if dispatch.label.contains("fix") => "Could not fix",
+        "failure" => "Could not reproduce",
+        "exhausted" => "All attempts exhausted",
+        "orphaned" => "Orphaned (worktree removed)",
+        other => other,
+    };
+
+    let model = dispatch.model_used.as_deref().unwrap_or("unknown");
+    let gh_link = dispatch
+        .gh_issue_number
+        .map(|n| format!("GH#{n}"))
+        .unwrap_or_else(|| dispatch.signal_ref.clone());
+
+    let summary = if findings_summary.len() > 300 {
+        format!("{}...", &findings_summary[..300])
+    } else {
+        findings_summary.to_string()
+    };
+
+    NotificationMessage {
+        status_emoji: status_emoji.to_string(),
+        status_text: status_text.to_string(),
+        signal_ref: dispatch.signal_ref.clone(),
+        gh_link,
+        title: dispatch.signal_title.clone(),
+        model: model.to_string(),
+        attempt: dispatch.attempt_number,
+        summary,
+    }
+}
+
+struct NotificationMessage {
+    status_emoji: String,
+    status_text: String,
+    signal_ref: String,
+    gh_link: String,
+    title: String,
+    model: String,
+    attempt: i32,
+    summary: String,
+}
+
+impl NotificationMessage {
+    /// Format as a Slack Block Kit message.
+    fn to_slack_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "blocks": [
+                {
+                    "type": "header",
+                    "text": {
+                        "type": "plain_text",
+                        "text": format!(":{}: Sentinel: {}", self.status_emoji, self.status_text),
+                        "emoji": true,
+                    }
+                },
+                {
+                    "type": "section",
+                    "fields": [
+                        { "type": "mrkdwn", "text": format!("*Signal:* {}", self.signal_ref) },
+                        { "type": "mrkdwn", "text": format!("*Issue:* {}", self.gh_link) },
+                        { "type": "mrkdwn", "text": format!("*Model:* {}", self.model) },
+                        { "type": "mrkdwn", "text": format!("*Attempt:* {} of 2", self.attempt) },
+                    ]
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": format!("*{}*\n{}", self.title, self.summary),
+                    }
+                }
+            ]
+        })
+    }
+
+    /// Format as a generic JSON payload for non-Slack webhooks.
+    fn to_generic_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "event": "sentinel.dispatch.completed",
+            "status": self.status_text,
+            "signal_ref": self.signal_ref,
+            "title": self.title,
+            "model": self.model,
+            "attempt": self.attempt,
+            "summary": self.summary,
+        })
+    }
+}
+
+/// Send a JSON payload to a webhook URL via curl.
+///
+/// Uses `curl` instead of a Rust HTTP client to avoid adding another async
+/// dependency — sentinel notifications are fire-and-forget, not latency-critical.
+fn send_webhook(url: &str, message: &NotificationMessage, is_slack: bool) -> Result<()> {
+    let payload = if is_slack {
+        message.to_slack_json()
+    } else {
+        message.to_generic_json()
+    };
+
+    let body = serde_json::to_string(&payload)?;
+
+    let output = Command::new("curl")
+        .args([
+            "-s",
+            "-o",
+            "/dev/null",
+            "-w",
+            "%{http_code}",
+            "-X",
+            "POST",
+            "-H",
+            "Content-Type: application/json",
+            "-d",
+            &body,
+            url,
+        ])
+        .output()
+        .context("Failed to run curl for webhook notification")?;
+
+    let status_code = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if !status_code.starts_with('2') {
+        anyhow::bail!("webhook returned HTTP {status_code}");
+    }
+
+    Ok(())
+}
+
+/// Mask a URL for safe logging (hide everything after the host).
+fn mask_url(url: &str) -> String {
+    if let Some(pos) = url
+        .find("//")
+        .and_then(|p| url[p + 2..].find('/').map(|q| p + 2 + q))
+    {
+        format!("{}/*****", &url[..pos])
+    } else {
+        "***".to_string()
+    }
+}

--- a/crosslink/src/commands/sentinel/patterns.rs
+++ b/crosslink/src/commands/sentinel/patterns.rs
@@ -1,0 +1,161 @@
+use anyhow::Result;
+
+use crate::db::Database;
+
+/// A detected pattern from dispatch history.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct Pattern {
+    pub kind: String,
+    pub description: String,
+    pub signal_refs: Vec<String>,
+    pub count: i64,
+    pub severity: String,
+}
+
+/// Analyze dispatch history for recurring patterns and hotspots.
+pub fn detect_patterns(db: &Database, json: bool) -> Result<()> {
+    let mut patterns: Vec<Pattern> = Vec::new();
+
+    patterns.extend(find_repeat_failures(db)?);
+    patterns.extend(find_label_success_imbalance(db)?);
+    patterns.extend(find_escalation_heavy_signals(db)?);
+
+    if patterns.is_empty() {
+        if json {
+            println!("[]");
+        } else {
+            println!("No patterns detected yet. Need more dispatch history.");
+        }
+        return Ok(());
+    }
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&patterns)?);
+        return Ok(());
+    }
+
+    for pattern in &patterns {
+        let icon = match pattern.severity.as_str() {
+            "high" => "!!",
+            "medium" => " !",
+            _ => "  ",
+        };
+        println!(
+            "[{}] {} ({}x): {}",
+            icon, pattern.kind, pattern.count, pattern.description
+        );
+        if !pattern.signal_refs.is_empty() {
+            let refs = pattern
+                .signal_refs
+                .iter()
+                .take(5)
+                .cloned()
+                .collect::<Vec<_>>()
+                .join(", ");
+            println!("     signals: {refs}");
+        }
+    }
+
+    Ok(())
+}
+
+/// Signals that have failed 2+ times (both Sonnet and Opus exhausted multiple times).
+fn find_repeat_failures(db: &Database) -> Result<Vec<Pattern>> {
+    let mut stmt = db.conn.prepare(
+        "SELECT signal_ref, COUNT(*) as fail_count
+         FROM sentinel_dispatches
+         WHERE outcome IN ('failure', 'exhausted')
+         GROUP BY signal_ref
+         HAVING fail_count >= 2
+         ORDER BY fail_count DESC
+         LIMIT 10",
+    )?;
+
+    let rows: Vec<(String, i64)> = stmt
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    if rows.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    Ok(vec![Pattern {
+        kind: "repeat-failures".to_string(),
+        description: format!(
+            "{} signal(s) have failed multiple times despite escalation",
+            rows.len()
+        ),
+        signal_refs: rows.iter().map(|(r, _)| r.clone()).collect(),
+        count: rows.iter().map(|(_, c)| c).sum(),
+        severity: "high".to_string(),
+    }])
+}
+
+/// Labels where the success rate is significantly below average.
+fn find_label_success_imbalance(db: &Database) -> Result<Vec<Pattern>> {
+    let metrics = db.get_dispatch_metrics()?;
+
+    let mut patterns = Vec::new();
+    for m in &metrics {
+        let completed = m.total - m.pending;
+        if completed < 3 {
+            continue; // not enough data
+        }
+        if m.success_rate < 30.0 {
+            patterns.push(Pattern {
+                kind: "low-success-rate".to_string(),
+                description: format!(
+                    "'{}' with {} has only {:.0}% success rate ({}/{} completed)",
+                    m.label, m.model, m.success_rate, m.successes, completed
+                ),
+                signal_refs: Vec::new(),
+                count: completed,
+                severity: if m.success_rate < 10.0 {
+                    "high".to_string()
+                } else {
+                    "medium".to_string()
+                },
+            });
+        }
+    }
+
+    Ok(patterns)
+}
+
+/// Signals that always escalate from Sonnet to Opus (Sonnet never succeeds).
+fn find_escalation_heavy_signals(db: &Database) -> Result<Vec<Pattern>> {
+    let mut stmt = db.conn.prepare(
+        "SELECT label,
+                SUM(CASE WHEN attempt_number = 1 AND outcome = 'failure' THEN 1 ELSE 0 END) as sonnet_fails,
+                SUM(CASE WHEN attempt_number = 2 THEN 1 ELSE 0 END) as opus_attempts,
+                COUNT(*) as total
+         FROM sentinel_dispatches
+         WHERE disposition = 'dispatch'
+         GROUP BY label
+         HAVING total >= 4 AND sonnet_fails > opus_attempts * 0.8",
+    )?;
+
+    let rows: Vec<(String, i64, i64, i64)> = stmt
+        .query_map([], |row| {
+            Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
+        })?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    let mut patterns = Vec::new();
+    for (label, sonnet_fails, opus_attempts, _total) in &rows {
+        patterns.push(Pattern {
+            kind: "escalation-heavy".to_string(),
+            description: format!(
+                "'{}': Sonnet failed {sonnet_fails}x, escalated to Opus {opus_attempts}x — consider defaulting to Opus",
+                label
+            ),
+            signal_refs: Vec::new(),
+            count: *sonnet_fails,
+            severity: "medium".to_string(),
+        });
+    }
+
+    Ok(patterns)
+}

--- a/crosslink/src/commands/sentinel/patterns.rs
+++ b/crosslink/src/commands/sentinel/patterns.rs
@@ -73,7 +73,7 @@ fn find_repeat_failures(db: &Database) -> Result<Vec<Pattern>> {
 
     let rows: Vec<(String, i64)> = stmt
         .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?
-        .filter_map(|r| r.ok())
+        .filter_map(Result::ok)
         .collect();
 
     if rows.is_empty() {
@@ -140,7 +140,7 @@ fn find_escalation_heavy_signals(db: &Database) -> Result<Vec<Pattern>> {
         .query_map([], |row| {
             Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
         })?
-        .filter_map(|r| r.ok())
+        .filter_map(Result::ok)
         .collect();
 
     let mut patterns = Vec::new();
@@ -148,8 +148,7 @@ fn find_escalation_heavy_signals(db: &Database) -> Result<Vec<Pattern>> {
         patterns.push(Pattern {
             kind: "escalation-heavy".to_string(),
             description: format!(
-                "'{}': Sonnet failed {sonnet_fails}x, escalated to Opus {opus_attempts}x — consider defaulting to Opus",
-                label
+                "'{label}': Sonnet failed {sonnet_fails}x, escalated to Opus {opus_attempts}x — consider defaulting to Opus"
             ),
             signal_refs: Vec::new(),
             count: *sonnet_fails,

--- a/crosslink/src/commands/sentinel/seen_set.rs
+++ b/crosslink/src/commands/sentinel/seen_set.rs
@@ -1,0 +1,394 @@
+use std::collections::HashMap;
+
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+
+use crate::db::Database;
+
+use super::config::SentinelConfig;
+use super::sources::SignalDecision;
+
+/// Record of the most recent dispatch for a signal, used for dedup decisions.
+struct SeenRecord {
+    outcome: String,
+    attempt_number: i32,
+    completed_at: Option<DateTime<Utc>>,
+}
+
+/// In-memory dedup cache loaded from sentinel_dispatches.
+///
+/// Determines whether a signal should be dispatched (New), retried with
+/// escalation (Escalate), or skipped entirely (Skip).
+pub struct SeenSet {
+    /// signal_ref -> most recent dispatch record
+    seen: HashMap<String, SeenRecord>,
+}
+
+impl SeenSet {
+    /// Load the SeenSet from the database. Takes the most recent dispatch
+    /// per signal_ref.
+    pub fn load(db: &Database) -> Result<Self> {
+        let dispatches = db.load_dispatch_seen_set()?;
+        let mut seen = HashMap::with_capacity(dispatches.len());
+
+        for d in dispatches {
+            let completed_at = d.completed_at.as_ref().and_then(|s| {
+                DateTime::parse_from_rfc3339(s)
+                    .ok()
+                    .map(|dt| dt.with_timezone(&Utc))
+            });
+            seen.insert(
+                d.signal_ref.clone(),
+                SeenRecord {
+                    outcome: d.outcome,
+                    attempt_number: d.attempt_number,
+                    completed_at,
+                },
+            );
+        }
+
+        Ok(Self { seen })
+    }
+
+    /// Evaluate whether a signal should be dispatched, escalated, or skipped.
+    pub fn evaluate(&self, signal_ref: &str, config: &SentinelConfig) -> SignalDecision {
+        let Some(record) = self.seen.get(signal_ref) else {
+            return SignalDecision::New;
+        };
+
+        match record.outcome.as_str() {
+            "pending" => SignalDecision::Skip("agent in-flight"),
+            "success" => SignalDecision::Skip("already resolved"),
+            "exhausted" => SignalDecision::Skip("both attempts failed"),
+
+            "failure" | "timeout" => self.evaluate_retry(record, config),
+            "orphaned" => self.evaluate_retry(record, config),
+
+            _ => SignalDecision::Skip("unknown state"),
+        }
+    }
+
+    /// Check if a failed/orphaned dispatch is eligible for escalation retry.
+    fn evaluate_retry(&self, record: &SeenRecord, config: &SentinelConfig) -> SignalDecision {
+        if !config.escalation.enabled {
+            return SignalDecision::Skip("escalation disabled");
+        }
+        if record.attempt_number >= config.escalation.max_attempts as i32 {
+            return SignalDecision::Skip("max attempts reached");
+        }
+        if let Some(completed) = &record.completed_at {
+            let elapsed = Utc::now().signed_duration_since(*completed);
+            if elapsed.num_minutes() < config.escalation.cooldown_minutes as i64 {
+                return SignalDecision::Skip("cooldown not elapsed");
+            }
+        }
+        SignalDecision::Escalate
+    }
+}
+
+/// Layer 3: Authoritative database dedup check.
+///
+/// Even if the in-memory SeenSet is stale (e.g., sentinel restarted mid-cycle),
+/// this check prevents duplicate dispatches.
+pub fn db_dedup_check(
+    db: &Database,
+    gh_issue_number: i64,
+    label: &str,
+    config: &SentinelConfig,
+) -> Result<SignalDecision> {
+    let Some(dispatch) = db.get_latest_dispatch_for_signal(gh_issue_number, label)? else {
+        return Ok(SignalDecision::New);
+    };
+
+    // Mirror the SeenSet logic against the authoritative DB record
+    match dispatch.outcome.as_str() {
+        "pending" => Ok(SignalDecision::Skip("agent in-flight (db)")),
+        "success" => Ok(SignalDecision::Skip("already resolved (db)")),
+        "exhausted" => Ok(SignalDecision::Skip("both attempts failed (db)")),
+        "failure" | "timeout" | "orphaned" => {
+            if !config.escalation.enabled {
+                return Ok(SignalDecision::Skip("escalation disabled"));
+            }
+            if dispatch.attempt_number >= config.escalation.max_attempts as i32 {
+                return Ok(SignalDecision::Skip("max attempts reached (db)"));
+            }
+            let cooldown_ok = dispatch
+                .completed_at
+                .as_ref()
+                .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+                .map(|dt| {
+                    let elapsed = Utc::now().signed_duration_since(dt.with_timezone(&Utc));
+                    elapsed.num_minutes() >= config.escalation.cooldown_minutes as i64
+                })
+                .unwrap_or(true);
+            if cooldown_ok {
+                Ok(SignalDecision::Escalate)
+            } else {
+                Ok(SignalDecision::Skip("cooldown not elapsed (db)"))
+            }
+        }
+        _ => Ok(SignalDecision::Skip("unknown state (db)")),
+    }
+}
+
+/// Layer 4: GitHub comment dedup check.
+///
+/// Before posting a result comment, verify we haven't already posted for this
+/// dispatch ID. Checks for the marker string `sentinel #<dispatch-id>` in
+/// existing comments.
+pub fn gh_comment_already_posted(gh_issue_number: i64, dispatch_id: i64) -> Result<bool> {
+    let marker = format!("sentinel #{dispatch_id}");
+    let output = std::process::Command::new("gh")
+        .args([
+            "issue",
+            "view",
+            &gh_issue_number.to_string(),
+            "--json",
+            "comments",
+            "--jq",
+            ".comments[].body",
+        ])
+        .output();
+
+    match output {
+        Ok(out) if out.status.success() => {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            Ok(stdout.contains(&marker))
+        }
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            tracing::warn!(
+                "gh comment dedup check failed for GH#{}: {}",
+                gh_issue_number,
+                stderr.trim()
+            );
+            // On failure, assume not posted (proceed cautiously)
+            Ok(false)
+        }
+        Err(e) => {
+            tracing::warn!("gh command failed for comment dedup: {e}");
+            Ok(false)
+        }
+    }
+}
+
+/// Extract the GH issue number from a signal reference like "GH#499:replicate".
+pub fn parse_gh_issue_number(signal_ref: &str) -> Option<i64> {
+    let rest = signal_ref.strip_prefix("GH#")?;
+    let num_str = rest.split(':').next()?;
+    num_str.parse().ok()
+}
+
+/// Extract the label from a signal reference like "GH#499:replicate" -> "replicate".
+pub fn parse_signal_label_suffix(signal_ref: &str) -> Option<&str> {
+    signal_ref.split(':').nth(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_gh_issue_number() {
+        assert_eq!(parse_gh_issue_number("GH#499:replicate"), Some(499));
+        assert_eq!(parse_gh_issue_number("GH#1:fix"), Some(1));
+        assert_eq!(parse_gh_issue_number("GH#0:replicate"), Some(0));
+        assert_eq!(parse_gh_issue_number("not-a-signal"), None);
+        assert_eq!(parse_gh_issue_number("GH#abc:fix"), None);
+        assert_eq!(parse_gh_issue_number(""), None);
+    }
+
+    #[test]
+    fn test_parse_signal_label_suffix() {
+        assert_eq!(
+            parse_signal_label_suffix("GH#499:replicate"),
+            Some("replicate")
+        );
+        assert_eq!(parse_signal_label_suffix("GH#1:fix"), Some("fix"));
+        assert_eq!(parse_signal_label_suffix("no-colon"), None);
+    }
+
+    #[test]
+    fn test_seen_set_new_signal() {
+        let seen = SeenSet {
+            seen: HashMap::new(),
+        };
+        let config = SentinelConfig::default();
+        assert_eq!(
+            seen.evaluate("GH#499:replicate", &config),
+            SignalDecision::New
+        );
+    }
+
+    #[test]
+    fn test_seen_set_pending_skips() {
+        let mut seen_map = HashMap::new();
+        seen_map.insert(
+            "GH#499:replicate".to_string(),
+            SeenRecord {
+                outcome: "pending".to_string(),
+                attempt_number: 1,
+                completed_at: None,
+            },
+        );
+        let seen = SeenSet { seen: seen_map };
+        let config = SentinelConfig::default();
+        assert_eq!(
+            seen.evaluate("GH#499:replicate", &config),
+            SignalDecision::Skip("agent in-flight")
+        );
+    }
+
+    #[test]
+    fn test_seen_set_success_skips() {
+        let mut seen_map = HashMap::new();
+        seen_map.insert(
+            "GH#499:replicate".to_string(),
+            SeenRecord {
+                outcome: "success".to_string(),
+                attempt_number: 1,
+                completed_at: Some(Utc::now()),
+            },
+        );
+        let seen = SeenSet { seen: seen_map };
+        let config = SentinelConfig::default();
+        assert_eq!(
+            seen.evaluate("GH#499:replicate", &config),
+            SignalDecision::Skip("already resolved")
+        );
+    }
+
+    #[test]
+    fn test_seen_set_failure_with_cooldown_elapsed_escalates() {
+        let mut seen_map = HashMap::new();
+        seen_map.insert(
+            "GH#499:replicate".to_string(),
+            SeenRecord {
+                outcome: "failure".to_string(),
+                attempt_number: 1,
+                // Completed 2 hours ago — well past 30min cooldown
+                completed_at: Some(Utc::now() - chrono::Duration::hours(2)),
+            },
+        );
+        let seen = SeenSet { seen: seen_map };
+        let config = SentinelConfig::default();
+        assert_eq!(
+            seen.evaluate("GH#499:replicate", &config),
+            SignalDecision::Escalate
+        );
+    }
+
+    #[test]
+    fn test_seen_set_failure_within_cooldown_skips() {
+        let mut seen_map = HashMap::new();
+        seen_map.insert(
+            "GH#499:replicate".to_string(),
+            SeenRecord {
+                outcome: "failure".to_string(),
+                attempt_number: 1,
+                // Completed 5 minutes ago — within 30min cooldown
+                completed_at: Some(Utc::now() - chrono::Duration::minutes(5)),
+            },
+        );
+        let seen = SeenSet { seen: seen_map };
+        let config = SentinelConfig::default();
+        assert_eq!(
+            seen.evaluate("GH#499:replicate", &config),
+            SignalDecision::Skip("cooldown not elapsed")
+        );
+    }
+
+    #[test]
+    fn test_seen_set_max_attempts_skips() {
+        let mut seen_map = HashMap::new();
+        seen_map.insert(
+            "GH#499:replicate".to_string(),
+            SeenRecord {
+                outcome: "failure".to_string(),
+                attempt_number: 2, // max_attempts = 2
+                completed_at: Some(Utc::now() - chrono::Duration::hours(2)),
+            },
+        );
+        let seen = SeenSet { seen: seen_map };
+        let config = SentinelConfig::default();
+        assert_eq!(
+            seen.evaluate("GH#499:replicate", &config),
+            SignalDecision::Skip("max attempts reached")
+        );
+    }
+
+    #[test]
+    fn test_seen_set_exhausted_skips() {
+        let mut seen_map = HashMap::new();
+        seen_map.insert(
+            "GH#499:replicate".to_string(),
+            SeenRecord {
+                outcome: "exhausted".to_string(),
+                attempt_number: 2,
+                completed_at: Some(Utc::now()),
+            },
+        );
+        let seen = SeenSet { seen: seen_map };
+        let config = SentinelConfig::default();
+        assert_eq!(
+            seen.evaluate("GH#499:replicate", &config),
+            SignalDecision::Skip("both attempts failed")
+        );
+    }
+
+    #[test]
+    fn test_seen_set_orphaned_escalates() {
+        let mut seen_map = HashMap::new();
+        seen_map.insert(
+            "GH#499:replicate".to_string(),
+            SeenRecord {
+                outcome: "orphaned".to_string(),
+                attempt_number: 1,
+                completed_at: Some(Utc::now() - chrono::Duration::hours(1)),
+            },
+        );
+        let seen = SeenSet { seen: seen_map };
+        let config = SentinelConfig::default();
+        assert_eq!(
+            seen.evaluate("GH#499:replicate", &config),
+            SignalDecision::Escalate
+        );
+    }
+
+    #[test]
+    fn test_seen_set_escalation_disabled_skips() {
+        let mut seen_map = HashMap::new();
+        seen_map.insert(
+            "GH#499:replicate".to_string(),
+            SeenRecord {
+                outcome: "failure".to_string(),
+                attempt_number: 1,
+                completed_at: Some(Utc::now() - chrono::Duration::hours(2)),
+            },
+        );
+        let seen = SeenSet { seen: seen_map };
+        let mut config = SentinelConfig::default();
+        config.escalation.enabled = false;
+        assert_eq!(
+            seen.evaluate("GH#499:replicate", &config),
+            SignalDecision::Skip("escalation disabled")
+        );
+    }
+
+    #[test]
+    fn test_different_labels_independent() {
+        let mut seen_map = HashMap::new();
+        seen_map.insert(
+            "GH#499:replicate".to_string(),
+            SeenRecord {
+                outcome: "success".to_string(),
+                attempt_number: 1,
+                completed_at: Some(Utc::now()),
+            },
+        );
+        let seen = SeenSet { seen: seen_map };
+        let config = SentinelConfig::default();
+        // Same issue, different label = new signal
+        assert_eq!(seen.evaluate("GH#499:fix", &config), SignalDecision::New);
+    }
+}

--- a/crosslink/src/commands/sentinel/seen_set.rs
+++ b/crosslink/src/commands/sentinel/seen_set.rs
@@ -15,18 +15,18 @@ struct SeenRecord {
     completed_at: Option<DateTime<Utc>>,
 }
 
-/// In-memory dedup cache loaded from sentinel_dispatches.
+/// In-memory dedup cache loaded from `sentinel_dispatches`.
 ///
 /// Determines whether a signal should be dispatched (New), retried with
 /// escalation (Escalate), or skipped entirely (Skip).
 pub struct SeenSet {
-    /// signal_ref -> most recent dispatch record
+    /// `signal_ref` -> most recent dispatch record
     seen: HashMap<String, SeenRecord>,
 }
 
 impl SeenSet {
-    /// Load the SeenSet from the database. Takes the most recent dispatch
-    /// per signal_ref.
+    /// Load the `SeenSet` from the database. Takes the most recent dispatch
+    /// per `signal_ref`.
     pub fn load(db: &Database) -> Result<Self> {
         let dispatches = db.load_dispatch_seen_set()?;
         let mut seen = HashMap::with_capacity(dispatches.len());
@@ -61,15 +61,14 @@ impl SeenSet {
             "success" => SignalDecision::Skip("already resolved"),
             "exhausted" => SignalDecision::Skip("both attempts failed"),
 
-            "failure" | "timeout" => self.evaluate_retry(record, config),
-            "orphaned" => self.evaluate_retry(record, config),
+            "failure" | "timeout" | "orphaned" => Self::evaluate_retry(record, config),
 
             _ => SignalDecision::Skip("unknown state"),
         }
     }
 
     /// Check if a failed/orphaned dispatch is eligible for escalation retry.
-    fn evaluate_retry(&self, record: &SeenRecord, config: &SentinelConfig) -> SignalDecision {
+    fn evaluate_retry(record: &SeenRecord, config: &SentinelConfig) -> SignalDecision {
         if !config.escalation.enabled {
             return SignalDecision::Skip("escalation disabled");
         }
@@ -88,7 +87,7 @@ impl SeenSet {
 
 /// Layer 3: Authoritative database dedup check.
 ///
-/// Even if the in-memory SeenSet is stale (e.g., sentinel restarted mid-cycle),
+/// Even if the in-memory `SeenSet` is stale (e.g., sentinel restarted mid-cycle),
 /// this check prevents duplicate dispatches.
 pub fn db_dedup_check(
     db: &Database,
@@ -116,11 +115,10 @@ pub fn db_dedup_check(
                 .completed_at
                 .as_ref()
                 .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
-                .map(|dt| {
+                .is_none_or(|dt| {
                     let elapsed = Utc::now().signed_duration_since(dt.with_timezone(&Utc));
                     elapsed.num_minutes() >= config.escalation.cooldown_minutes as i64
-                })
-                .unwrap_or(true);
+                });
             if cooldown_ok {
                 Ok(SignalDecision::Escalate)
             } else {
@@ -136,7 +134,7 @@ pub fn db_dedup_check(
 /// Before posting a result comment, verify we haven't already posted for this
 /// dispatch ID. Checks for the marker string `sentinel #<dispatch-id>` in
 /// existing comments.
-pub fn gh_comment_already_posted(gh_issue_number: i64, dispatch_id: i64) -> Result<bool> {
+pub fn gh_comment_already_posted(gh_issue_number: i64, dispatch_id: i64) -> bool {
     let marker = format!("sentinel #{dispatch_id}");
     let output = std::process::Command::new("gh")
         .args([
@@ -153,7 +151,7 @@ pub fn gh_comment_already_posted(gh_issue_number: i64, dispatch_id: i64) -> Resu
     match output {
         Ok(out) if out.status.success() => {
             let stdout = String::from_utf8_lossy(&out.stdout);
-            Ok(stdout.contains(&marker))
+            stdout.contains(&marker)
         }
         Ok(out) => {
             let stderr = String::from_utf8_lossy(&out.stderr);
@@ -163,11 +161,11 @@ pub fn gh_comment_already_posted(gh_issue_number: i64, dispatch_id: i64) -> Resu
                 stderr.trim()
             );
             // On failure, assume not posted (proceed cautiously)
-            Ok(false)
+            false
         }
         Err(e) => {
             tracing::warn!("gh command failed for comment dedup: {e}");
-            Ok(false)
+            false
         }
     }
 }

--- a/crosslink/src/commands/sentinel/sources/ci.rs
+++ b/crosslink/src/commands/sentinel/sources/ci.rs
@@ -1,0 +1,130 @@
+use anyhow::{Context, Result};
+use chrono::Utc;
+use serde::Deserialize;
+use std::process::Command;
+
+use super::{Signal, SignalKind, Source, SourceKind};
+
+/// A GitHub Actions workflow run as returned by `gh run list --json`.
+#[derive(Debug, Deserialize)]
+struct GhRun {
+    #[serde(rename = "databaseId")]
+    database_id: i64,
+    #[serde(rename = "headBranch")]
+    head_branch: String,
+    name: String,
+    conclusion: Option<String>,
+    #[serde(rename = "createdAt")]
+    created_at: Option<String>,
+    url: Option<String>,
+}
+
+/// Polls GitHub Actions for failed workflow runs on the default branch.
+pub struct GitHubCISource {
+    default_branch: Option<String>,
+}
+
+impl GitHubCISource {
+    pub fn new() -> Self {
+        Self {
+            default_branch: None,
+        }
+    }
+
+    /// Detect the default branch via `gh repo view`.
+    fn detect_default_branch(&mut self) -> Result<String> {
+        if let Some(ref branch) = self.default_branch {
+            return Ok(branch.clone());
+        }
+        let output = Command::new("gh")
+            .args([
+                "repo",
+                "view",
+                "--json",
+                "defaultBranchRef",
+                "-q",
+                ".defaultBranchRef.name",
+            ])
+            .output()
+            .context("Failed to detect default branch")?;
+        if !output.status.success() {
+            anyhow::bail!(
+                "gh repo view failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if branch.is_empty() {
+            anyhow::bail!("Could not detect default branch");
+        }
+        self.default_branch = Some(branch.clone());
+        Ok(branch)
+    }
+}
+
+impl Source for GitHubCISource {
+    fn name(&self) -> &str {
+        "github-ci"
+    }
+
+    fn poll(&mut self) -> Result<Vec<Signal>> {
+        let branch = self.detect_default_branch()?;
+
+        let output = Command::new("gh")
+            .args([
+                "run",
+                "list",
+                "--branch",
+                &branch,
+                "--status",
+                "failure",
+                "--json",
+                "databaseId,headBranch,name,conclusion,createdAt,url",
+                "--limit",
+                "10",
+            ])
+            .output()
+            .context("Failed to run `gh run list`")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("gh run list failed: {}", stderr.trim());
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if stdout.trim().is_empty() || stdout.trim() == "[]" {
+            return Ok(Vec::new());
+        }
+
+        let runs: Vec<GhRun> =
+            serde_json::from_str(&stdout).context("Failed to parse gh run list output")?;
+
+        let now = Utc::now();
+        let signals = runs
+            .into_iter()
+            .filter(|r| r.conclusion.as_deref() == Some("failure"))
+            .map(|run| Signal {
+                source: SourceKind::CI,
+                kind: SignalKind::CIFailure,
+                reference: format!("CI:run/{}", run.database_id),
+                title: format!("CI failure: {} on {}", run.name, run.head_branch),
+                body: format!(
+                    "Workflow '{}' failed on branch '{}'. Run URL: {}",
+                    run.name,
+                    run.head_branch,
+                    run.url.as_deref().unwrap_or("unknown")
+                ),
+                metadata: serde_json::json!({
+                    "run_id": run.database_id,
+                    "workflow": run.name,
+                    "branch": run.head_branch,
+                    "created_at": run.created_at,
+                    "url": run.url,
+                }),
+                detected_at: now,
+            })
+            .collect();
+
+        Ok(signals)
+    }
+}

--- a/crosslink/src/commands/sentinel/sources/ci.rs
+++ b/crosslink/src/commands/sentinel/sources/ci.rs
@@ -25,7 +25,7 @@ pub struct GitHubCISource {
 }
 
 impl GitHubCISource {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             default_branch: None,
         }
@@ -63,7 +63,7 @@ impl GitHubCISource {
 }
 
 impl Source for GitHubCISource {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "github-ci"
     }
 

--- a/crosslink/src/commands/sentinel/sources/github.rs
+++ b/crosslink/src/commands/sentinel/sources/github.rs
@@ -12,16 +12,15 @@ struct GhIssue {
     number: i64,
     title: String,
     body: Option<String>,
-    #[serde(default, rename = "labels")]
-    _labels: Vec<GhLabel>,
+    #[serde(default)]
+    labels: Vec<GhLabel>,
     #[serde(rename = "createdAt")]
     created_at: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
 struct GhLabel {
-    #[serde(rename = "name")]
-    _name: String,
+    name: String,
 }
 
 /// Polls GitHub for issues with `agent-todo:*` labels via the `gh` CLI.
@@ -110,18 +109,36 @@ impl GitHubLabelSource {
 
         let signals = issues
             .into_iter()
-            .map(|issue| Signal {
-                source: SourceKind::GitHub,
-                kind: SignalKind::LabelAdded,
-                reference: format!("GH#{}:{}", issue.number, label_suffix),
-                title: issue.title,
-                body: issue.body.unwrap_or_default(),
-                metadata: serde_json::json!({
-                    "label": label,
-                    "number": issue.number,
-                    "created_at": issue.created_at,
-                }),
-                detected_at: now,
+            .filter_map(|issue| {
+                // Defensive: verify the label we asked for is actually present in the
+                // response. Protects against future `gh` API changes or filter bugs.
+                let all_label_names: Vec<String> =
+                    issue.labels.iter().map(|l| l.name.clone()).collect();
+                if !all_label_names.iter().any(|name| name == label) {
+                    tracing::warn!(
+                        "GH#{} returned for label '{}' but doesn't have it (has: {:?}); skipping",
+                        issue.number,
+                        label,
+                        all_label_names
+                    );
+                    return None;
+                }
+
+                Some(Signal {
+                    source: SourceKind::GitHub,
+                    kind: SignalKind::LabelAdded,
+                    reference: format!("GH#{}:{}", issue.number, label_suffix),
+                    title: issue.title,
+                    body: issue.body.unwrap_or_default(),
+                    metadata: serde_json::json!({
+                        "label": label,
+                        "number": issue.number,
+                        "created_at": issue.created_at,
+                        // Include all labels so triage engine can route on label combinations
+                        "all_labels": all_label_names,
+                    }),
+                    detected_at: now,
+                })
             })
             .collect();
 

--- a/crosslink/src/commands/sentinel/sources/github.rs
+++ b/crosslink/src/commands/sentinel/sources/github.rs
@@ -1,0 +1,32 @@
+use anyhow::Result;
+
+use super::{Signal, Source};
+use crate::commands::sentinel::config::SentinelConfig;
+
+/// Polls GitHub for issues with `agent-todo:*` labels via the `gh` CLI.
+#[allow(dead_code)]
+pub struct GitHubLabelSource {
+    labels: Vec<String>,
+    repo: Option<String>,
+}
+
+#[allow(dead_code)]
+impl GitHubLabelSource {
+    pub fn new(config: &SentinelConfig) -> Result<Self> {
+        Ok(Self {
+            labels: config.sources.github_labels.labels.clone(),
+            repo: None,
+        })
+    }
+}
+
+impl Source for GitHubLabelSource {
+    fn name(&self) -> &str {
+        "github-labels"
+    }
+
+    fn poll(&mut self) -> Result<Vec<Signal>> {
+        // Will be implemented in #652
+        Ok(Vec::new())
+    }
+}

--- a/crosslink/src/commands/sentinel/sources/github.rs
+++ b/crosslink/src/commands/sentinel/sources/github.rs
@@ -30,11 +30,11 @@ pub struct GitHubLabelSource {
 }
 
 impl GitHubLabelSource {
-    pub fn new(config: &SentinelConfig) -> Result<Self> {
-        Ok(Self {
+    pub fn new(config: &SentinelConfig) -> Self {
+        Self {
             labels: config.sources.github_labels.labels.clone(),
             repo: None,
-        })
+        }
     }
 
     /// Detect the current repo's owner/name via `gh repo view`.
@@ -69,7 +69,7 @@ impl GitHubLabelSource {
     }
 
     /// Poll GitHub for issues matching a single label.
-    fn poll_label(&self, repo: &str, label: &str) -> Result<Vec<Signal>> {
+    fn poll_label(repo: &str, label: &str) -> Result<Vec<Signal>> {
         let output = Command::new("gh")
             .args([
                 "issue",
@@ -147,7 +147,7 @@ impl GitHubLabelSource {
 }
 
 impl Source for GitHubLabelSource {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "github-labels"
     }
 
@@ -155,11 +155,11 @@ impl Source for GitHubLabelSource {
         let repo = self.detect_repo()?;
         let mut all_signals = Vec::new();
 
-        for label in &self.labels.clone() {
-            match self.poll_label(&repo, label) {
+        for label in self.labels.clone() {
+            match Self::poll_label(&repo, &label) {
                 Ok(signals) => all_signals.extend(signals),
                 Err(e) => {
-                    tracing::warn!("failed to poll label '{}': {}", label, e);
+                    tracing::warn!("failed to poll label '{label}': {e}");
                 }
             }
         }

--- a/crosslink/src/commands/sentinel/sources/github.rs
+++ b/crosslink/src/commands/sentinel/sources/github.rs
@@ -12,14 +12,16 @@ struct GhIssue {
     number: i64,
     title: String,
     body: Option<String>,
-    labels: Vec<GhLabel>,
+    #[serde(default, rename = "labels")]
+    _labels: Vec<GhLabel>,
     #[serde(rename = "createdAt")]
     created_at: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
 struct GhLabel {
-    name: String,
+    #[serde(rename = "name")]
+    _name: String,
 }
 
 /// Polls GitHub for issues with `agent-todo:*` labels via the `gh` CLI.

--- a/crosslink/src/commands/sentinel/sources/github.rs
+++ b/crosslink/src/commands/sentinel/sources/github.rs
@@ -1,22 +1,129 @@
-use anyhow::Result;
+use anyhow::{bail, Context, Result};
+use chrono::Utc;
+use serde::Deserialize;
+use std::process::Command;
 
-use super::{Signal, Source};
+use super::{Signal, SignalKind, Source, SourceKind};
 use crate::commands::sentinel::config::SentinelConfig;
 
+/// A GitHub issue as returned by `gh issue list --json`.
+#[derive(Debug, Deserialize)]
+struct GhIssue {
+    number: i64,
+    title: String,
+    body: Option<String>,
+    labels: Vec<GhLabel>,
+    #[serde(rename = "createdAt")]
+    created_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhLabel {
+    name: String,
+}
+
 /// Polls GitHub for issues with `agent-todo:*` labels via the `gh` CLI.
-#[allow(dead_code)]
 pub struct GitHubLabelSource {
     labels: Vec<String>,
     repo: Option<String>,
 }
 
-#[allow(dead_code)]
 impl GitHubLabelSource {
     pub fn new(config: &SentinelConfig) -> Result<Self> {
         Ok(Self {
             labels: config.sources.github_labels.labels.clone(),
             repo: None,
         })
+    }
+
+    /// Detect the current repo's owner/name via `gh repo view`.
+    fn detect_repo(&mut self) -> Result<String> {
+        if let Some(ref repo) = self.repo {
+            return Ok(repo.clone());
+        }
+        let output = Command::new("gh")
+            .args([
+                "repo",
+                "view",
+                "--json",
+                "nameWithOwner",
+                "-q",
+                ".nameWithOwner",
+            ])
+            .output()
+            .context("Failed to run `gh repo view`. Is `gh` installed?")?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            if stderr.contains("authentication") || stderr.contains("login") {
+                bail!("GitHub CLI not authenticated. Run `gh auth login` first.");
+            }
+            bail!("Failed to detect repository: {}", stderr.trim());
+        }
+        let repo = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if repo.is_empty() {
+            bail!("Could not detect repository. Are you in a git repo with a GitHub remote?");
+        }
+        self.repo = Some(repo.clone());
+        Ok(repo)
+    }
+
+    /// Poll GitHub for issues matching a single label.
+    fn poll_label(&self, repo: &str, label: &str) -> Result<Vec<Signal>> {
+        let output = Command::new("gh")
+            .args([
+                "issue",
+                "list",
+                "--repo",
+                repo,
+                "--label",
+                label,
+                "--json",
+                "number,title,body,labels,createdAt",
+                "--state",
+                "open",
+                "--limit",
+                "50",
+            ])
+            .output()
+            .context("Failed to run `gh issue list`")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            if stderr.contains("rate limit") || stderr.contains("403") || stderr.contains("429") {
+                bail!("GitHub API rate limit exceeded");
+            }
+            bail!("gh issue list failed: {}", stderr.trim());
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if stdout.trim().is_empty() || stdout.trim() == "[]" {
+            return Ok(Vec::new());
+        }
+
+        let issues: Vec<GhIssue> = serde_json::from_str(&stdout)
+            .with_context(|| format!("Failed to parse gh output for label '{label}'"))?;
+
+        let label_suffix = label.strip_prefix("agent-todo: ").unwrap_or(label);
+        let now = Utc::now();
+
+        let signals = issues
+            .into_iter()
+            .map(|issue| Signal {
+                source: SourceKind::GitHub,
+                kind: SignalKind::LabelAdded,
+                reference: format!("GH#{}:{}", issue.number, label_suffix),
+                title: issue.title,
+                body: issue.body.unwrap_or_default(),
+                metadata: serde_json::json!({
+                    "label": label,
+                    "number": issue.number,
+                    "created_at": issue.created_at,
+                }),
+                detected_at: now,
+            })
+            .collect();
+
+        Ok(signals)
     }
 }
 
@@ -26,7 +133,18 @@ impl Source for GitHubLabelSource {
     }
 
     fn poll(&mut self) -> Result<Vec<Signal>> {
-        // Will be implemented in #652
-        Ok(Vec::new())
+        let repo = self.detect_repo()?;
+        let mut all_signals = Vec::new();
+
+        for label in &self.labels.clone() {
+            match self.poll_label(&repo, label) {
+                Ok(signals) => all_signals.extend(signals),
+                Err(e) => {
+                    tracing::warn!("failed to poll label '{}': {}", label, e);
+                }
+            }
+        }
+
+        Ok(all_signals)
     }
 }

--- a/crosslink/src/commands/sentinel/sources/internal.rs
+++ b/crosslink/src/commands/sentinel/sources/internal.rs
@@ -30,7 +30,7 @@ impl InternalHygieneSource {
         }
     }
 
-    /// Find open issues with no activity for more than stale_threshold_days.
+    /// Find open issues with no activity for more than `stale_threshold_days`.
     fn find_stale_issues(&self) -> Result<Vec<Signal>> {
         let db = crate::db::Database::open(&self.db_path)?;
         let threshold = Utc::now() - chrono::Duration::days(self.config.stale_threshold_days);
@@ -50,13 +50,13 @@ impl InternalHygieneSource {
                 let updated_at: String = row.get(2)?;
                 Ok((id, title, updated_at))
             })?
-            .filter_map(|r| r.ok())
+            .filter_map(std::result::Result::ok)
             .map(|(id, title, updated_at)| Signal {
                 source: SourceKind::Internal,
                 kind: SignalKind::StaleIssue,
-                reference: format!("CL#{}:stale", id),
-                title: format!("Stale issue: {}", title),
-                body: format!("Issue #{} has not been updated since {}.", id, updated_at),
+                reference: format!("CL#{id}:stale"),
+                title: format!("Stale issue: {title}"),
+                body: format!("Issue #{id} has not been updated since {updated_at}."),
                 metadata: serde_json::json!({
                     "issue_id": id,
                     "last_updated": updated_at,
@@ -89,16 +89,13 @@ impl InternalHygieneSource {
                 let parent_id: i64 = row.get(2)?;
                 Ok((id, title, parent_id))
             })?
-            .filter_map(|r| r.ok())
+            .filter_map(std::result::Result::ok)
             .map(|(id, title, parent_id)| Signal {
                 source: SourceKind::Internal,
                 kind: SignalKind::StaleIssue,
-                reference: format!("CL#{}:orphan", id),
-                title: format!("Orphaned subissue: {}", title),
-                body: format!(
-                    "Issue #{} is open but its parent #{} is closed.",
-                    id, parent_id
-                ),
+                reference: format!("CL#{id}:orphan"),
+                title: format!("Orphaned subissue: {title}"),
+                body: format!("Issue #{id} is open but its parent #{parent_id} is closed."),
                 metadata: serde_json::json!({
                     "issue_id": id,
                     "parent_id": parent_id,
@@ -128,13 +125,13 @@ impl InternalHygieneSource {
                 let title: String = row.get(1)?;
                 Ok((id, title))
             })?
-            .filter_map(|r| r.ok())
+            .filter_map(std::result::Result::ok)
             .map(|(id, title)| Signal {
                 source: SourceKind::Internal,
                 kind: SignalKind::StaleIssue,
-                reference: format!("CL#{}:unlabeled", id),
-                title: format!("Unlabeled issue: {}", title),
-                body: format!("Issue #{} has no labels.", id),
+                reference: format!("CL#{id}:unlabeled"),
+                title: format!("Unlabeled issue: {title}"),
+                body: format!("Issue #{id} has no labels."),
                 metadata: serde_json::json!({
                     "issue_id": id,
                 }),
@@ -147,7 +144,7 @@ impl InternalHygieneSource {
 }
 
 impl Source for InternalHygieneSource {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "internal-hygiene"
     }
 

--- a/crosslink/src/commands/sentinel/sources/internal.rs
+++ b/crosslink/src/commands/sentinel/sources/internal.rs
@@ -1,0 +1,172 @@
+use anyhow::Result;
+use chrono::Utc;
+
+use super::{Signal, SignalKind, Source, SourceKind};
+
+/// Configuration for the internal hygiene source.
+pub struct InternalHygieneConfig {
+    pub stale_threshold_days: i64,
+}
+
+impl Default for InternalHygieneConfig {
+    fn default() -> Self {
+        Self {
+            stale_threshold_days: 30,
+        }
+    }
+}
+
+/// Checks crosslink issues for staleness, orphaned subissues, and missing labels.
+pub struct InternalHygieneSource {
+    config: InternalHygieneConfig,
+    db_path: std::path::PathBuf,
+}
+
+impl InternalHygieneSource {
+    pub fn new(crosslink_dir: &std::path::Path, config: InternalHygieneConfig) -> Self {
+        Self {
+            config,
+            db_path: crosslink_dir.join("issues.db"),
+        }
+    }
+
+    /// Find open issues with no activity for more than stale_threshold_days.
+    fn find_stale_issues(&self) -> Result<Vec<Signal>> {
+        let db = crate::db::Database::open(&self.db_path)?;
+        let threshold = Utc::now() - chrono::Duration::days(self.config.stale_threshold_days);
+        let threshold_str = threshold.to_rfc3339();
+
+        let mut stmt = db.conn.prepare(
+            "SELECT id, title, updated_at FROM issues
+             WHERE status = 'open' AND updated_at < ?1
+             ORDER BY updated_at ASC LIMIT 20",
+        )?;
+
+        let now = Utc::now();
+        let signals = stmt
+            .query_map([&threshold_str], |row| {
+                let id: i64 = row.get(0)?;
+                let title: String = row.get(1)?;
+                let updated_at: String = row.get(2)?;
+                Ok((id, title, updated_at))
+            })?
+            .filter_map(|r| r.ok())
+            .map(|(id, title, updated_at)| Signal {
+                source: SourceKind::Internal,
+                kind: SignalKind::StaleIssue,
+                reference: format!("CL#{}:stale", id),
+                title: format!("Stale issue: {}", title),
+                body: format!("Issue #{} has not been updated since {}.", id, updated_at),
+                metadata: serde_json::json!({
+                    "issue_id": id,
+                    "last_updated": updated_at,
+                    "stale_days": self.config.stale_threshold_days,
+                }),
+                detected_at: now,
+            })
+            .collect();
+
+        Ok(signals)
+    }
+
+    /// Find subissues whose parent has been closed (orphaned).
+    fn find_orphaned_subissues(&self) -> Result<Vec<Signal>> {
+        let db = crate::db::Database::open(&self.db_path)?;
+
+        let mut stmt = db.conn.prepare(
+            "SELECT c.id, c.title, c.parent_id, p.status
+             FROM issues c
+             JOIN issues p ON c.parent_id = p.id
+             WHERE c.status = 'open' AND p.status = 'closed'
+             LIMIT 20",
+        )?;
+
+        let now = Utc::now();
+        let signals = stmt
+            .query_map([], |row| {
+                let id: i64 = row.get(0)?;
+                let title: String = row.get(1)?;
+                let parent_id: i64 = row.get(2)?;
+                Ok((id, title, parent_id))
+            })?
+            .filter_map(|r| r.ok())
+            .map(|(id, title, parent_id)| Signal {
+                source: SourceKind::Internal,
+                kind: SignalKind::StaleIssue,
+                reference: format!("CL#{}:orphan", id),
+                title: format!("Orphaned subissue: {}", title),
+                body: format!(
+                    "Issue #{} is open but its parent #{} is closed.",
+                    id, parent_id
+                ),
+                metadata: serde_json::json!({
+                    "issue_id": id,
+                    "parent_id": parent_id,
+                }),
+                detected_at: now,
+            })
+            .collect();
+
+        Ok(signals)
+    }
+
+    /// Find open issues with no labels.
+    fn find_unlabeled_issues(&self) -> Result<Vec<Signal>> {
+        let db = crate::db::Database::open(&self.db_path)?;
+
+        let mut stmt = db.conn.prepare(
+            "SELECT i.id, i.title FROM issues i
+             WHERE i.status = 'open'
+             AND NOT EXISTS (SELECT 1 FROM labels l WHERE l.issue_id = i.id)
+             LIMIT 20",
+        )?;
+
+        let now = Utc::now();
+        let signals = stmt
+            .query_map([], |row| {
+                let id: i64 = row.get(0)?;
+                let title: String = row.get(1)?;
+                Ok((id, title))
+            })?
+            .filter_map(|r| r.ok())
+            .map(|(id, title)| Signal {
+                source: SourceKind::Internal,
+                kind: SignalKind::StaleIssue,
+                reference: format!("CL#{}:unlabeled", id),
+                title: format!("Unlabeled issue: {}", title),
+                body: format!("Issue #{} has no labels.", id),
+                metadata: serde_json::json!({
+                    "issue_id": id,
+                }),
+                detected_at: now,
+            })
+            .collect();
+
+        Ok(signals)
+    }
+}
+
+impl Source for InternalHygieneSource {
+    fn name(&self) -> &str {
+        "internal-hygiene"
+    }
+
+    fn poll(&mut self) -> Result<Vec<Signal>> {
+        let mut signals = Vec::new();
+
+        match self.find_stale_issues() {
+            Ok(s) => signals.extend(s),
+            Err(e) => tracing::warn!("stale issue scan failed: {e}"),
+        }
+        match self.find_orphaned_subissues() {
+            Ok(s) => signals.extend(s),
+            Err(e) => tracing::warn!("orphan scan failed: {e}"),
+        }
+        match self.find_unlabeled_issues() {
+            Ok(s) => signals.extend(s),
+            Err(e) => tracing::warn!("unlabeled scan failed: {e}"),
+        }
+
+        Ok(signals)
+    }
+}

--- a/crosslink/src/commands/sentinel/sources/maintenance.rs
+++ b/crosslink/src/commands/sentinel/sources/maintenance.rs
@@ -1,0 +1,157 @@
+use anyhow::Result;
+use chrono::Utc;
+use std::path::Path;
+use std::process::Command;
+
+use super::{Signal, SignalKind, Source, SourceKind};
+
+/// Configuration for the maintenance sweep source.
+pub struct MaintenanceSweepConfig {
+    pub lint_enabled: bool,
+    pub test_coverage_enabled: bool,
+    pub lint_warning_threshold: u64,
+}
+
+impl Default for MaintenanceSweepConfig {
+    fn default() -> Self {
+        Self {
+            lint_enabled: true,
+            test_coverage_enabled: false,
+            lint_warning_threshold: 10,
+        }
+    }
+}
+
+/// Runs local maintenance commands and emits signals when quality drifts.
+///
+/// Checks:
+/// - Lint warnings above threshold (`cargo clippy` / `npm run lint`)
+/// - Test failures (`cargo test` / `npm test`)
+pub struct MaintenanceSweepSource {
+    config: MaintenanceSweepConfig,
+    repo_root: std::path::PathBuf,
+}
+
+impl MaintenanceSweepSource {
+    pub fn new(repo_root: &Path, config: MaintenanceSweepConfig) -> Self {
+        Self {
+            config,
+            repo_root: repo_root.to_path_buf(),
+        }
+    }
+
+    /// Count lint warnings from `cargo clippy`.
+    fn check_clippy_warnings(&self) -> Result<Option<Signal>> {
+        let output = Command::new("cargo")
+            .args(["clippy", "--message-format=short", "--quiet"])
+            .current_dir(&self.repo_root)
+            .output();
+
+        let output = match output {
+            Ok(o) => o,
+            Err(_) => return Ok(None), // cargo not available
+        };
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let warning_count = stderr.lines().filter(|l| l.contains("warning")).count() as u64;
+
+        if warning_count >= self.config.lint_warning_threshold {
+            let now = Utc::now();
+            Ok(Some(Signal {
+                source: SourceKind::Internal,
+                kind: SignalKind::StaleIssue,
+                reference: format!("MAINT:clippy:{}", now.format("%Y%m%d")),
+                title: format!("Lint drift: {warning_count} clippy warnings"),
+                body: format!(
+                    "{warning_count} clippy warnings detected (threshold: {}). \
+                     Run `cargo clippy` for details.",
+                    self.config.lint_warning_threshold
+                ),
+                metadata: serde_json::json!({
+                    "type": "lint_drift",
+                    "tool": "clippy",
+                    "warning_count": warning_count,
+                    "threshold": self.config.lint_warning_threshold,
+                }),
+                detected_at: now,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Run `cargo test` and check for failures.
+    fn check_test_failures(&self) -> Result<Option<Signal>> {
+        let output = Command::new("cargo")
+            .args(["test", "--no-fail-fast", "--quiet"])
+            .current_dir(&self.repo_root)
+            .env("RUST_BACKTRACE", "0")
+            .output();
+
+        let output = match output {
+            Ok(o) => o,
+            Err(_) => return Ok(None),
+        };
+
+        if output.status.success() {
+            return Ok(None);
+        }
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let failure_lines: Vec<&str> = stderr
+            .lines()
+            .filter(|l| l.contains("FAILED") || l.contains("test result: FAILED"))
+            .collect();
+
+        let failure_count = failure_lines.len();
+        if failure_count > 0 {
+            let now = Utc::now();
+            let details = failure_lines.join("\n");
+            Ok(Some(Signal {
+                source: SourceKind::Internal,
+                kind: SignalKind::StaleIssue,
+                reference: format!("MAINT:test-fail:{}", now.format("%Y%m%d")),
+                title: format!("Test regression: {failure_count} failure(s)"),
+                body: format!(
+                    "{failure_count} test failure(s) detected:\n```\n{}\n```",
+                    &details[..details.len().min(2000)]
+                ),
+                metadata: serde_json::json!({
+                    "type": "test_regression",
+                    "failure_count": failure_count,
+                }),
+                detected_at: now,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+impl Source for MaintenanceSweepSource {
+    fn name(&self) -> &str {
+        "maintenance-sweep"
+    }
+
+    fn poll(&mut self) -> Result<Vec<Signal>> {
+        let mut signals = Vec::new();
+
+        if self.config.lint_enabled {
+            match self.check_clippy_warnings() {
+                Ok(Some(s)) => signals.push(s),
+                Ok(None) => {}
+                Err(e) => tracing::warn!("clippy sweep failed: {e}"),
+            }
+        }
+
+        if self.config.test_coverage_enabled {
+            match self.check_test_failures() {
+                Ok(Some(s)) => signals.push(s),
+                Ok(None) => {}
+                Err(e) => tracing::warn!("test sweep failed: {e}"),
+            }
+        }
+
+        Ok(signals)
+    }
+}

--- a/crosslink/src/commands/sentinel/sources/maintenance.rs
+++ b/crosslink/src/commands/sentinel/sources/maintenance.rs
@@ -41,15 +41,13 @@ impl MaintenanceSweepSource {
     }
 
     /// Count lint warnings from `cargo clippy`.
-    fn check_clippy_warnings(&self) -> Result<Option<Signal>> {
-        let output = Command::new("cargo")
+    fn check_clippy_warnings(&self) -> Option<Signal> {
+        let Ok(output) = Command::new("cargo")
             .args(["clippy", "--message-format=short", "--quiet"])
             .current_dir(&self.repo_root)
-            .output();
-
-        let output = match output {
-            Ok(o) => o,
-            Err(_) => return Ok(None), // cargo not available
+            .output()
+        else {
+            return None; // cargo not available
         };
 
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -57,7 +55,7 @@ impl MaintenanceSweepSource {
 
         if warning_count >= self.config.lint_warning_threshold {
             let now = Utc::now();
-            Ok(Some(Signal {
+            Some(Signal {
                 source: SourceKind::Internal,
                 kind: SignalKind::StaleIssue,
                 reference: format!("MAINT:clippy:{}", now.format("%Y%m%d")),
@@ -74,27 +72,25 @@ impl MaintenanceSweepSource {
                     "threshold": self.config.lint_warning_threshold,
                 }),
                 detected_at: now,
-            }))
+            })
         } else {
-            Ok(None)
+            None
         }
     }
 
     /// Run `cargo test` and check for failures.
-    fn check_test_failures(&self) -> Result<Option<Signal>> {
-        let output = Command::new("cargo")
+    fn check_test_failures(&self) -> Option<Signal> {
+        let Ok(output) = Command::new("cargo")
             .args(["test", "--no-fail-fast", "--quiet"])
             .current_dir(&self.repo_root)
             .env("RUST_BACKTRACE", "0")
-            .output();
-
-        let output = match output {
-            Ok(o) => o,
-            Err(_) => return Ok(None),
+            .output()
+        else {
+            return None;
         };
 
         if output.status.success() {
-            return Ok(None);
+            return None;
         }
 
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -107,7 +103,7 @@ impl MaintenanceSweepSource {
         if failure_count > 0 {
             let now = Utc::now();
             let details = failure_lines.join("\n");
-            Ok(Some(Signal {
+            Some(Signal {
                 source: SourceKind::Internal,
                 kind: SignalKind::StaleIssue,
                 reference: format!("MAINT:test-fail:{}", now.format("%Y%m%d")),
@@ -121,15 +117,15 @@ impl MaintenanceSweepSource {
                     "failure_count": failure_count,
                 }),
                 detected_at: now,
-            }))
+            })
         } else {
-            Ok(None)
+            None
         }
     }
 }
 
 impl Source for MaintenanceSweepSource {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "maintenance-sweep"
     }
 
@@ -137,18 +133,14 @@ impl Source for MaintenanceSweepSource {
         let mut signals = Vec::new();
 
         if self.config.lint_enabled {
-            match self.check_clippy_warnings() {
-                Ok(Some(s)) => signals.push(s),
-                Ok(None) => {}
-                Err(e) => tracing::warn!("clippy sweep failed: {e}"),
+            if let Some(s) = self.check_clippy_warnings() {
+                signals.push(s);
             }
         }
 
         if self.config.test_coverage_enabled {
-            match self.check_test_failures() {
-                Ok(Some(s)) => signals.push(s),
-                Ok(None) => {}
-                Err(e) => tracing::warn!("test sweep failed: {e}"),
+            if let Some(s) = self.check_test_failures() {
+                signals.push(s);
             }
         }
 

--- a/crosslink/src/commands/sentinel/sources/mod.rs
+++ b/crosslink/src/commands/sentinel/sources/mod.rs
@@ -1,0 +1,60 @@
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+pub mod github;
+
+/// Classification of where a signal originated.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[allow(dead_code)]
+pub enum SourceKind {
+    GitHub,
+    Internal,
+    CI,
+}
+
+/// Classification of the signal event type.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[allow(dead_code)]
+pub enum SignalKind {
+    LabelAdded,
+    StaleIssue,
+    CIFailure,
+}
+
+/// A maintenance signal detected by a source adapter.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct Signal {
+    pub source: SourceKind,
+    pub kind: SignalKind,
+    /// Composite reference: "GH#499:replicate", "GH#499:fix"
+    pub reference: String,
+    pub title: String,
+    pub body: String,
+    pub metadata: serde_json::Value,
+    pub detected_at: DateTime<Utc>,
+}
+
+/// Dedup decision for a signal based on prior dispatch history.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum SignalDecision {
+    /// Never seen before — dispatch with Sonnet (attempt 1).
+    New,
+    /// Previous attempt failed — dispatch with Opus (attempt 2).
+    Escalate,
+    /// Already handled or ineligible — do not dispatch.
+    Skip(&'static str),
+}
+
+/// A source adapter that polls for maintenance signals.
+#[allow(dead_code)]
+pub trait Source {
+    /// Human-readable name for logging.
+    fn name(&self) -> &str;
+
+    /// Poll for new signals. The implementation should use the `SeenSet`
+    /// passed by the engine to pre-filter already-handled signals.
+    fn poll(&mut self) -> Result<Vec<Signal>>;
+}

--- a/crosslink/src/commands/sentinel/sources/mod.rs
+++ b/crosslink/src/commands/sentinel/sources/mod.rs
@@ -6,6 +6,7 @@ pub mod ci;
 #[allow(dead_code)]
 pub mod github;
 pub mod internal;
+pub mod maintenance;
 
 /// Classification of where a signal originated.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crosslink/src/commands/sentinel/sources/mod.rs
+++ b/crosslink/src/commands/sentinel/sources/mod.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+pub mod ci;
 #[allow(dead_code)]
 pub mod github;
 pub mod internal;

--- a/crosslink/src/commands/sentinel/sources/mod.rs
+++ b/crosslink/src/commands/sentinel/sources/mod.rs
@@ -50,7 +50,7 @@ pub enum SignalDecision {
 /// A source adapter that polls for maintenance signals.
 pub trait Source {
     /// Human-readable name for logging.
-    fn name(&self) -> &str;
+    fn name(&self) -> &'static str;
 
     /// Poll for new signals. The implementation should use the `SeenSet`
     /// passed by the engine to pre-filter already-handled signals.

--- a/crosslink/src/commands/sentinel/sources/mod.rs
+++ b/crosslink/src/commands/sentinel/sources/mod.rs
@@ -3,14 +3,12 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 pub mod ci;
-#[allow(dead_code)]
 pub mod github;
 pub mod internal;
 pub mod maintenance;
 
 /// Classification of where a signal originated.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[allow(dead_code)]
 pub enum SourceKind {
     GitHub,
     Internal,
@@ -19,7 +17,6 @@ pub enum SourceKind {
 
 /// Classification of the signal event type.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[allow(dead_code)]
 pub enum SignalKind {
     LabelAdded,
     StaleIssue,
@@ -28,7 +25,6 @@ pub enum SignalKind {
 
 /// A maintenance signal detected by a source adapter.
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct Signal {
     pub source: SourceKind,
     pub kind: SignalKind,
@@ -42,7 +38,6 @@ pub struct Signal {
 
 /// Dedup decision for a signal based on prior dispatch history.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(dead_code)]
 pub enum SignalDecision {
     /// Never seen before — dispatch with Sonnet (attempt 1).
     New,
@@ -53,7 +48,6 @@ pub enum SignalDecision {
 }
 
 /// A source adapter that polls for maintenance signals.
-#[allow(dead_code)]
 pub trait Source {
     /// Human-readable name for logging.
     fn name(&self) -> &str;

--- a/crosslink/src/commands/sentinel/sources/mod.rs
+++ b/crosslink/src/commands/sentinel/sources/mod.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+#[allow(dead_code)]
 pub mod github;
 
 /// Classification of where a signal originated.

--- a/crosslink/src/commands/sentinel/sources/mod.rs
+++ b/crosslink/src/commands/sentinel/sources/mod.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 #[allow(dead_code)]
 pub mod github;
+pub mod internal;
 
 /// Classification of where a signal originated.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crosslink/src/commands/sentinel/tuning.rs
+++ b/crosslink/src/commands/sentinel/tuning.rs
@@ -50,7 +50,7 @@ impl TuningOverride {
 
     /// Get the model to use for a given label, or None if no override.
     pub fn model_for_label(&self, label: &str) -> Option<&str> {
-        self.overrides.get(label).map(|s| s.as_str())
+        self.overrides.get(label).map(String::as_str)
     }
 
     /// Check if any overrides are active.

--- a/crosslink/src/commands/sentinel/tuning.rs
+++ b/crosslink/src/commands/sentinel/tuning.rs
@@ -1,0 +1,67 @@
+use anyhow::Result;
+use std::collections::HashMap;
+
+use crate::db::Database;
+
+use super::config::SentinelConfig;
+
+/// Model override recommendation from historical data.
+#[derive(Debug, Clone)]
+pub struct TuningOverride {
+    /// label -> recommended model (if different from default)
+    overrides: HashMap<String, String>,
+}
+
+impl TuningOverride {
+    /// Analyze dispatch history and recommend model overrides for labels
+    /// where the default model (Sonnet) has a success rate below the threshold.
+    pub fn from_history(db: &Database, config: &SentinelConfig) -> Result<Self> {
+        let metrics = db.get_dispatch_metrics()?;
+        let mut overrides = HashMap::new();
+
+        let default_model = &config.default_agent.model;
+        let escalation_model = &config.escalation.model;
+        let threshold = 40.0; // promote to Opus if Sonnet success rate < 40%
+
+        for m in &metrics {
+            // Only look at the default model's performance
+            if m.model != *default_model {
+                continue;
+            }
+            let completed = m.total - m.pending;
+            if completed < 5 {
+                continue; // not enough data to be confident
+            }
+            if m.success_rate < threshold {
+                tracing::info!(
+                    "self-tuning: promoting '{}' from {} to {} (success rate {:.0}% < {:.0}%)",
+                    m.label,
+                    default_model,
+                    escalation_model,
+                    m.success_rate,
+                    threshold
+                );
+                overrides.insert(m.label.clone(), escalation_model.clone());
+            }
+        }
+
+        Ok(Self { overrides })
+    }
+
+    /// Get the model to use for a given label, or None if no override.
+    pub fn model_for_label(&self, label: &str) -> Option<&str> {
+        self.overrides.get(label).map(|s| s.as_str())
+    }
+
+    /// Check if any overrides are active.
+    pub fn has_overrides(&self) -> bool {
+        !self.overrides.is_empty()
+    }
+
+    /// Empty tuning — no overrides.
+    pub fn none() -> Self {
+        Self {
+            overrides: HashMap::new(),
+        }
+    }
+}

--- a/crosslink/src/commands/sentinel/watch.rs
+++ b/crosslink/src/commands/sentinel/watch.rs
@@ -84,18 +84,21 @@ pub fn stop(crosslink_dir: &Path) -> Result<()> {
 pub fn status(crosslink_dir: &Path, db: &Database) -> Result<()> {
     let pid_file = crosslink_dir.join("sentinel.pid");
 
-    let running = if let Some(pid) = read_pid(&pid_file) {
-        if is_process_running(pid) {
-            println!("Sentinel running (PID {pid})");
-            true
-        } else {
-            println!("Sentinel not running (stale PID file)");
+    let running = read_pid(&pid_file).map_or_else(
+        || {
+            println!("Sentinel not running");
             false
-        }
-    } else {
-        println!("Sentinel not running");
-        false
-    };
+        },
+        |pid| {
+            if is_process_running(pid) {
+                println!("Sentinel running (PID {pid})");
+                true
+            } else {
+                println!("Sentinel not running (stale PID file)");
+                false
+            }
+        },
+    );
 
     let pending_dispatches = db.get_pending_dispatches()?;
     let config = SentinelConfig::load(crosslink_dir)?;
@@ -257,7 +260,7 @@ async fn async_watch_loop(
 
         tokio::select! {
             // Polling timer fired
-            _ = &mut sleep_until => {
+            () = &mut sleep_until => {
                 let cycle_dir = crosslink_dir.clone();
                 let cycle_config = config.clone();
                 let result = tokio::task::spawn_blocking(move || {
@@ -266,14 +269,11 @@ async fn async_watch_loop(
                 .await
                 .context("polling cycle task panicked")?;
 
-                match result {
-                    Ok(()) => {
-                        backoff_multiplier = 1;
-                    }
-                    Err(e) => {
-                        tracing::error!("sentinel polling cycle failed: {e}");
-                        backoff_multiplier = (backoff_multiplier * 2).min(8);
-                    }
+                if let Err(e) = result {
+                    tracing::error!("sentinel polling cycle failed: {e}");
+                    backoff_multiplier = (backoff_multiplier * 2).min(8);
+                } else {
+                    backoff_multiplier = 1;
                 }
 
                 next_poll_at = tokio::time::Instant::now() + interval * backoff_multiplier;
@@ -324,7 +324,7 @@ async fn recv_webhook(
     }
 }
 
-/// Execute a single polling cycle (sync, called via spawn_blocking).
+/// Execute a single polling cycle (sync, called via `spawn_blocking`).
 fn run_polling_cycle(crosslink_dir: &Path, config: &SentinelConfig) -> Result<()> {
     let db = Database::open(&crosslink_dir.join("issues.db"))?;
     let writer = crate::shared_writer::SharedWriter::new(crosslink_dir)
@@ -356,7 +356,7 @@ fn run_polling_cycle(crosslink_dir: &Path, config: &SentinelConfig) -> Result<()
     Ok(())
 }
 
-/// Execute a single webhook-driven cycle for one signal (sync, via spawn_blocking).
+/// Execute a single webhook-driven cycle for one signal (sync, via `spawn_blocking`).
 fn run_webhook_cycle(
     crosslink_dir: &Path,
     config: &SentinelConfig,
@@ -373,7 +373,7 @@ fn run_webhook_cycle(
         &db,
         writer.as_ref(),
         config,
-        vec![signal],
+        &[signal],
         "webhook",
         true, // quiet in daemon mode
     )?;

--- a/crosslink/src/commands/sentinel/watch.rs
+++ b/crosslink/src/commands/sentinel/watch.rs
@@ -99,12 +99,24 @@ pub fn status(crosslink_dir: &Path, db: &Database) -> Result<()> {
     };
 
     // Show in-flight agents regardless of daemon state
-    let pending = db.count_pending_dispatches()?;
+    let pending_dispatches = db.get_pending_dispatches()?;
     let config = SentinelConfig::load(crosslink_dir)?;
     println!(
         "  In-flight: {} / {} agents",
-        pending, config.max_concurrent_agents
+        pending_dispatches.len(),
+        config.max_concurrent_agents
     );
+
+    // List each in-flight agent
+    for d in &pending_dispatches {
+        let elapsed = super::collect::format_elapsed(&d.created_at);
+        let agent = d.agent_id.as_deref().unwrap_or("unknown");
+        let model = d.model_used.as_deref().unwrap_or("?");
+        println!(
+            "    {} — {} (attempt {}, {}, {})",
+            d.signal_ref, agent, d.attempt_number, model, elapsed
+        );
+    }
 
     // Show last run
     let runs = db.list_sentinel_runs(1)?;
@@ -120,10 +132,10 @@ pub fn status(crosslink_dir: &Path, db: &Database) -> Result<()> {
         );
     }
 
-    if !running && pending > 0 {
+    if !running && !pending_dispatches.is_empty() {
         println!(
             "  Warning: {} agent(s) in-flight but daemon not running — results won't be collected",
-            pending
+            pending_dispatches.len()
         );
     }
 

--- a/crosslink/src/commands/sentinel/watch.rs
+++ b/crosslink/src/commands/sentinel/watch.rs
@@ -1,0 +1,301 @@
+use anyhow::{Context, Result};
+use std::fs;
+use std::io::Read;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+use crate::db::Database;
+
+use super::config::SentinelConfig;
+use super::engine;
+
+/// Start the sentinel daemon as a background process.
+pub fn start(crosslink_dir: &Path, interval: u64) -> Result<()> {
+    let pid_file = crosslink_dir.join("sentinel.pid");
+    let log_file = crosslink_dir.join("sentinel.log");
+
+    // Check if already running
+    if let Some(pid) = read_pid(&pid_file) {
+        if is_process_running(pid) {
+            println!("Sentinel already running (PID {pid})");
+            return Ok(());
+        }
+        fs::remove_file(&pid_file).with_context(|| {
+            format!(
+                "Cannot remove stale sentinel PID file at {}",
+                pid_file.display()
+            )
+        })?;
+    }
+
+    let exe = std::env::current_exe().context("Failed to get executable path")?;
+
+    let log_handle = fs::File::create(&log_file).context("Failed to create sentinel log file")?;
+    let log_handle_err = log_handle
+        .try_clone()
+        .context("Failed to clone log file handle")?;
+    let child = Command::new(&exe)
+        .arg("sentinel")
+        .arg("run-daemon")
+        .arg("--dir")
+        .arg(crosslink_dir)
+        .arg("--interval")
+        .arg(interval.to_string())
+        .stdin(Stdio::null())
+        .stdout(log_handle)
+        .stderr(log_handle_err)
+        .spawn()
+        .context("Failed to spawn sentinel daemon")?;
+
+    let pid = child.id();
+    fs::write(&pid_file, pid.to_string()).context("Failed to write sentinel PID file")?;
+
+    println!("Sentinel started (PID {pid})");
+    println!("  Interval: {interval} minutes");
+    println!("  Log file: {}", log_file.display());
+    Ok(())
+}
+
+/// Stop the sentinel daemon.
+pub fn stop(crosslink_dir: &Path) -> Result<()> {
+    let pid_file = crosslink_dir.join("sentinel.pid");
+
+    let Some(pid) = read_pid(&pid_file) else {
+        println!("Sentinel not running (no PID file)");
+        return Ok(());
+    };
+
+    if !is_process_running(pid) {
+        fs::remove_file(&pid_file).ok();
+        println!("Sentinel not running (stale PID file removed)");
+        return Ok(());
+    }
+
+    kill_process(pid)?;
+    fs::remove_file(&pid_file).ok();
+    println!("Sentinel stopped (PID {pid})");
+    Ok(())
+}
+
+/// Show sentinel daemon status.
+pub fn status(crosslink_dir: &Path, db: &Database) -> Result<()> {
+    let pid_file = crosslink_dir.join("sentinel.pid");
+
+    let running = if let Some(pid) = read_pid(&pid_file) {
+        if is_process_running(pid) {
+            println!("Sentinel running (PID {pid})");
+            true
+        } else {
+            println!("Sentinel not running (stale PID file)");
+            false
+        }
+    } else {
+        println!("Sentinel not running");
+        false
+    };
+
+    // Show in-flight agents regardless of daemon state
+    let pending = db.count_pending_dispatches()?;
+    let config = SentinelConfig::load(crosslink_dir)?;
+    println!(
+        "  In-flight: {} / {} agents",
+        pending, config.max_concurrent_agents
+    );
+
+    // Show last run
+    let runs = db.list_sentinel_runs(1)?;
+    if let Some(last) = runs.first() {
+        let started = last
+            .started_at
+            .get(..19)
+            .unwrap_or(&last.started_at)
+            .replace('T', " ");
+        println!(
+            "  Last run:  {} ({} signals, {} dispatched)",
+            started, last.signals_found, last.dispatched
+        );
+    }
+
+    if !running && pending > 0 {
+        println!(
+            "  Warning: {} agent(s) in-flight but daemon not running — results won't be collected",
+            pending
+        );
+    }
+
+    Ok(())
+}
+
+/// Run the sentinel watch loop (called by the spawned daemon process).
+pub fn run_watch_loop(crosslink_dir: &Path, interval_minutes: u64) -> Result<()> {
+    let db_path = crosslink_dir.join("issues.db");
+    if !db_path.exists() {
+        anyhow::bail!(
+            "Invalid crosslink directory: {} does not contain issues.db",
+            crosslink_dir.display()
+        );
+    }
+
+    let config = SentinelConfig::load(crosslink_dir)?;
+    if !config.enabled {
+        println!("Sentinel is disabled in hook-config.json");
+        return Ok(());
+    }
+
+    let interval = Duration::from_secs(interval_minutes * 60);
+    let mut backoff_multiplier: u32 = 1;
+
+    println!("Sentinel daemon starting...");
+    println!("  Watching: {}", crosslink_dir.display());
+    println!("  Interval: {interval_minutes} minutes");
+
+    // Graceful shutdown via SIGTERM/SIGINT
+    let should_exit = Arc::new(AtomicBool::new(false));
+
+    #[cfg(unix)]
+    {
+        let flag = Arc::clone(&should_exit);
+        if let Err(e) = signal_hook::flag::register(signal_hook::consts::SIGTERM, Arc::clone(&flag))
+        {
+            tracing::warn!("could not register SIGTERM handler: {e}");
+        }
+        if let Err(e) = signal_hook::flag::register(signal_hook::consts::SIGINT, flag) {
+            tracing::warn!("could not register SIGINT handler: {e}");
+        }
+    }
+
+    // Zombie prevention: exit when stdin closes (parent died)
+    let should_exit_stdin = Arc::clone(&should_exit);
+    thread::spawn(move || {
+        let mut stdin = std::io::stdin();
+        let mut buf = [0u8; 1];
+        loop {
+            match stdin.read(&mut buf) {
+                Ok(0) | Err(_) => {
+                    tracing::info!("Stdin closed, sentinel shutting down");
+                    should_exit_stdin.store(true, Ordering::SeqCst);
+                    break;
+                }
+                Ok(_) => {}
+            }
+        }
+    });
+
+    loop {
+        if should_exit.load(Ordering::SeqCst) {
+            println!("Sentinel exiting");
+            break;
+        }
+
+        // Run one cycle
+        match run_cycle(crosslink_dir) {
+            Ok(()) => {
+                backoff_multiplier = 1;
+            }
+            Err(e) => {
+                tracing::error!("sentinel cycle failed: {e}");
+                backoff_multiplier = (backoff_multiplier * 2).min(8);
+            }
+        }
+
+        // Sleep with early exit check
+        let sleep_duration = interval * backoff_multiplier;
+        let sleep_step = Duration::from_secs(5);
+        let mut slept = Duration::ZERO;
+        while slept < sleep_duration {
+            if should_exit.load(Ordering::SeqCst) {
+                println!("Sentinel exiting");
+                return Ok(());
+            }
+            thread::sleep(sleep_step.min(sleep_duration - slept));
+            slept += sleep_step;
+        }
+    }
+
+    Ok(())
+}
+
+/// Execute a single sentinel cycle within the watch loop.
+fn run_cycle(crosslink_dir: &Path) -> Result<()> {
+    let db = Database::open(&crosslink_dir.join("issues.db"))?;
+    let config = SentinelConfig::load(crosslink_dir)?;
+
+    // Construct SharedWriter if hub is available
+    let writer = crate::shared_writer::SharedWriter::new(crosslink_dir)
+        .ok()
+        .flatten();
+
+    let stats = engine::run_oneshot(
+        crosslink_dir,
+        &db,
+        writer.as_ref(),
+        &config,
+        false, // not dry run
+        None,  // no label filter
+        true,  // quiet in daemon mode (output goes to log)
+    )?;
+
+    if stats.signals_found > 0 || stats.collected > 0 {
+        println!(
+            "Cycle complete at {}: {} signals, {} dispatched, {} collected",
+            chrono::Utc::now().format("%H:%M:%S"),
+            stats.signals_found,
+            stats.dispatched,
+            stats.collected,
+        );
+    }
+
+    Ok(())
+}
+
+// --- Process management helpers (mirrored from daemon.rs) ---
+
+fn read_pid(pid_file: &Path) -> Option<u32> {
+    let mut file = fs::File::open(pid_file).ok()?;
+    let mut contents = String::new();
+    file.read_to_string(&mut contents).ok()?;
+    contents.trim().parse().ok()
+}
+
+#[cfg(not(windows))]
+fn is_process_running(pid: u32) -> bool {
+    Command::new("kill")
+        .args(["-0", &pid.to_string()])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+#[cfg(windows)]
+fn is_process_running(pid: u32) -> bool {
+    Command::new("tasklist")
+        .args(["/FI", &format!("PID eq {}", pid), "/NH"])
+        .output()
+        .map(|output| {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            stdout.contains(&pid.to_string())
+        })
+        .unwrap_or(false)
+}
+
+#[cfg(not(windows))]
+fn kill_process(pid: u32) -> Result<()> {
+    Command::new("kill")
+        .arg(pid.to_string())
+        .status()
+        .context("Failed to kill sentinel process")?;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn kill_process(pid: u32) -> Result<()> {
+    Command::new("taskkill")
+        .args(["/PID", &pid.to_string(), "/F"])
+        .status()
+        .context("Failed to kill sentinel process")?;
+    Ok(())
+}

--- a/crosslink/src/commands/sentinel/watch.rs
+++ b/crosslink/src/commands/sentinel/watch.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use std::fs;
 use std::io::Read;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -18,7 +18,6 @@ pub fn start(crosslink_dir: &Path, interval: u64) -> Result<()> {
     let pid_file = crosslink_dir.join("sentinel.pid");
     let log_file = crosslink_dir.join("sentinel.log");
 
-    // Check if already running
     if let Some(pid) = read_pid(&pid_file) {
         if is_process_running(pid) {
             println!("Sentinel already running (PID {pid})");
@@ -98,7 +97,6 @@ pub fn status(crosslink_dir: &Path, db: &Database) -> Result<()> {
         false
     };
 
-    // Show in-flight agents regardless of daemon state
     let pending_dispatches = db.get_pending_dispatches()?;
     let config = SentinelConfig::load(crosslink_dir)?;
     println!(
@@ -107,7 +105,6 @@ pub fn status(crosslink_dir: &Path, db: &Database) -> Result<()> {
         config.max_concurrent_agents
     );
 
-    // List each in-flight agent
     for d in &pending_dispatches {
         let elapsed = super::collect::format_elapsed(&d.created_at);
         let agent = d.agent_id.as_deref().unwrap_or("unknown");
@@ -118,7 +115,6 @@ pub fn status(crosslink_dir: &Path, db: &Database) -> Result<()> {
         );
     }
 
-    // Show last run
     let runs = db.list_sentinel_runs(1)?;
     if let Some(last) = runs.first() {
         let started = last
@@ -129,6 +125,18 @@ pub fn status(crosslink_dir: &Path, db: &Database) -> Result<()> {
         println!(
             "  Last run:  {} ({} signals, {} dispatched)",
             started, last.signals_found, last.dispatched
+        );
+    }
+
+    if config.webhook.enabled {
+        println!(
+            "  Webhook:   enabled on port {} ({})",
+            config.webhook.port,
+            if config.webhook.secret.is_some() {
+                "secret configured"
+            } else {
+                "no secret — signature verification disabled"
+            }
         );
     }
 
@@ -143,6 +151,12 @@ pub fn status(crosslink_dir: &Path, db: &Database) -> Result<()> {
 }
 
 /// Run the sentinel watch loop (called by the spawned daemon process).
+///
+/// Builds a tokio runtime and drives the async event loop. The loop multiplexes:
+/// - Polling timer ticks (every `interval_minutes`)
+/// - Webhook events from the optional GitHub webhook server
+/// - SIGTERM/SIGINT shutdown signals
+/// - Stdin closure (zombie prevention when parent dies)
 pub fn run_watch_loop(crosslink_dir: &Path, interval_minutes: u64) -> Result<()> {
     let db_path = crosslink_dir.join("issues.db");
     if !db_path.exists() {
@@ -158,6 +172,24 @@ pub fn run_watch_loop(crosslink_dir: &Path, interval_minutes: u64) -> Result<()>
         return Ok(());
     }
 
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .context("Failed to build tokio runtime for sentinel daemon")?;
+
+    runtime.block_on(async_watch_loop(
+        crosslink_dir.to_path_buf(),
+        interval_minutes,
+        config,
+    ))
+}
+
+/// The actual async watch loop body.
+async fn async_watch_loop(
+    crosslink_dir: PathBuf,
+    interval_minutes: u64,
+    config: SentinelConfig,
+) -> Result<()> {
     let interval = Duration::from_secs(interval_minutes * 60);
     let mut backoff_multiplier: u32 = 1;
 
@@ -165,23 +197,37 @@ pub fn run_watch_loop(crosslink_dir: &Path, interval_minutes: u64) -> Result<()>
     println!("  Watching: {}", crosslink_dir.display());
     println!("  Interval: {interval_minutes} minutes");
 
-    // Graceful shutdown via SIGTERM/SIGINT
+    // Optionally start the webhook server for real-time events
+    let mut webhook_rx = if config.webhook.enabled {
+        let webhook_config = super::webhook::WebhookConfig {
+            port: config.webhook.port,
+            secret: config.webhook.secret.clone(),
+        };
+        match super::webhook::start_webhook_server(&webhook_config).await {
+            Ok(rx) => {
+                println!("  Webhook:  listening on port {}", config.webhook.port);
+                Some(rx)
+            }
+            Err(e) => {
+                tracing::error!("Failed to start webhook server: {e}");
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    // Shutdown signaling: SIGTERM/SIGINT/stdin-closure all set this flag
     let should_exit = Arc::new(AtomicBool::new(false));
 
-    #[cfg(unix)]
-    {
-        let flag = Arc::clone(&should_exit);
-        if let Err(e) = signal_hook::flag::register(signal_hook::consts::SIGTERM, Arc::clone(&flag))
-        {
-            tracing::warn!("could not register SIGTERM handler: {e}");
-        }
-        if let Err(e) = signal_hook::flag::register(signal_hook::consts::SIGINT, flag) {
-            tracing::warn!("could not register SIGINT handler: {e}");
-        }
-    }
+    // Use tokio signal handlers (these compose with select!)
+    let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+        .context("Failed to register SIGTERM handler")?;
+    let mut sigint = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())
+        .context("Failed to register SIGINT handler")?;
 
-    // Zombie prevention: exit when stdin closes (parent died)
-    let should_exit_stdin = Arc::clone(&should_exit);
+    // Zombie prevention: spawn a blocking thread to detect stdin closure
+    let stdin_flag = Arc::clone(&should_exit);
     thread::spawn(move || {
         let mut stdin = std::io::stdin();
         let mut buf = [0u8; 1];
@@ -189,7 +235,7 @@ pub fn run_watch_loop(crosslink_dir: &Path, interval_minutes: u64) -> Result<()>
             match stdin.read(&mut buf) {
                 Ok(0) | Err(_) => {
                     tracing::info!("Stdin closed, sentinel shutting down");
-                    should_exit_stdin.store(true, Ordering::SeqCst);
+                    stdin_flag.store(true, Ordering::SeqCst);
                     break;
                 }
                 Ok(_) => {}
@@ -197,46 +243,90 @@ pub fn run_watch_loop(crosslink_dir: &Path, interval_minutes: u64) -> Result<()>
         }
     });
 
+    // Run an initial cycle immediately so the first poll doesn't wait `interval_minutes`
+    let mut next_poll_at = tokio::time::Instant::now();
+
     loop {
         if should_exit.load(Ordering::SeqCst) {
             println!("Sentinel exiting");
             break;
         }
 
-        // Run one cycle
-        match run_cycle(crosslink_dir) {
-            Ok(()) => {
-                backoff_multiplier = 1;
-            }
-            Err(e) => {
-                tracing::error!("sentinel cycle failed: {e}");
-                backoff_multiplier = (backoff_multiplier * 2).min(8);
-            }
-        }
+        let sleep_until = tokio::time::sleep_until(next_poll_at);
+        tokio::pin!(sleep_until);
 
-        // Sleep with early exit check
-        let sleep_duration = interval * backoff_multiplier;
-        let sleep_step = Duration::from_secs(5);
-        let mut slept = Duration::ZERO;
-        while slept < sleep_duration {
-            if should_exit.load(Ordering::SeqCst) {
-                println!("Sentinel exiting");
-                return Ok(());
+        tokio::select! {
+            // Polling timer fired
+            _ = &mut sleep_until => {
+                let cycle_dir = crosslink_dir.clone();
+                let cycle_config = config.clone();
+                let result = tokio::task::spawn_blocking(move || {
+                    run_polling_cycle(&cycle_dir, &cycle_config)
+                })
+                .await
+                .context("polling cycle task panicked")?;
+
+                match result {
+                    Ok(()) => {
+                        backoff_multiplier = 1;
+                    }
+                    Err(e) => {
+                        tracing::error!("sentinel polling cycle failed: {e}");
+                        backoff_multiplier = (backoff_multiplier * 2).min(8);
+                    }
+                }
+
+                next_poll_at = tokio::time::Instant::now() + interval * backoff_multiplier;
             }
-            thread::sleep(sleep_step.min(sleep_duration - slept));
-            slept += sleep_step;
+
+            // Webhook event received (only listen if webhook is enabled)
+            maybe_event = recv_webhook(&mut webhook_rx) => {
+                if let Some(event) = maybe_event {
+                    let cycle_dir = crosslink_dir.clone();
+                    let cycle_config = config.clone();
+                    let signal = event.signal;
+                    let result = tokio::task::spawn_blocking(move || {
+                        run_webhook_cycle(&cycle_dir, &cycle_config, signal)
+                    })
+                    .await
+                    .context("webhook cycle task panicked")?;
+
+                    if let Err(e) = result {
+                        tracing::error!("webhook cycle failed: {e}");
+                    }
+                }
+            }
+
+            // Shutdown signals
+            _ = sigterm.recv() => {
+                println!("Sentinel received SIGTERM, exiting");
+                break;
+            }
+            _ = sigint.recv() => {
+                println!("Sentinel received SIGINT, exiting");
+                break;
+            }
         }
     }
 
     Ok(())
 }
 
-/// Execute a single sentinel cycle within the watch loop.
-fn run_cycle(crosslink_dir: &Path) -> Result<()> {
-    let db = Database::open(&crosslink_dir.join("issues.db"))?;
-    let config = SentinelConfig::load(crosslink_dir)?;
+/// Helper to await a webhook event from an Option<Receiver>.
+/// If the receiver is None, returns a future that never resolves so `select!`
+/// will fall through to other branches.
+async fn recv_webhook(
+    rx: &mut Option<tokio::sync::mpsc::Receiver<super::webhook::WebhookEvent>>,
+) -> Option<super::webhook::WebhookEvent> {
+    match rx {
+        Some(receiver) => receiver.recv().await,
+        None => std::future::pending().await,
+    }
+}
 
-    // Construct SharedWriter if hub is available
+/// Execute a single polling cycle (sync, called via spawn_blocking).
+fn run_polling_cycle(crosslink_dir: &Path, config: &SentinelConfig) -> Result<()> {
+    let db = Database::open(&crosslink_dir.join("issues.db"))?;
     let writer = crate::shared_writer::SharedWriter::new(crosslink_dir)
         .ok()
         .flatten();
@@ -245,7 +335,7 @@ fn run_cycle(crosslink_dir: &Path) -> Result<()> {
         crosslink_dir,
         &db,
         writer.as_ref(),
-        &config,
+        config,
         false, // not dry run
         None,  // no label filter
         true,  // quiet in daemon mode (output goes to log)
@@ -253,13 +343,49 @@ fn run_cycle(crosslink_dir: &Path) -> Result<()> {
 
     if stats.signals_found > 0 || stats.collected > 0 {
         println!(
-            "Cycle complete at {}: {} signals, {} dispatched, {} collected",
+            "Polling cycle at {}: {} signals, {} dispatched, {} skipped, {} deferred, {} collected",
             chrono::Utc::now().format("%H:%M:%S"),
             stats.signals_found,
             stats.dispatched,
+            stats.skipped,
+            stats.deferred,
             stats.collected,
         );
     }
+
+    Ok(())
+}
+
+/// Execute a single webhook-driven cycle for one signal (sync, via spawn_blocking).
+fn run_webhook_cycle(
+    crosslink_dir: &Path,
+    config: &SentinelConfig,
+    signal: super::sources::Signal,
+) -> Result<()> {
+    let db = Database::open(&crosslink_dir.join("issues.db"))?;
+    let writer = crate::shared_writer::SharedWriter::new(crosslink_dir)
+        .ok()
+        .flatten();
+
+    let signal_ref = signal.reference.clone();
+    let stats = engine::process_signal_batch(
+        crosslink_dir,
+        &db,
+        writer.as_ref(),
+        config,
+        vec![signal],
+        "webhook",
+        true, // quiet in daemon mode
+    )?;
+
+    println!(
+        "Webhook cycle at {}: {} ({} dispatched, {} skipped, {} deferred)",
+        chrono::Utc::now().format("%H:%M:%S"),
+        signal_ref,
+        stats.dispatched,
+        stats.skipped,
+        stats.deferred,
+    );
 
     Ok(())
 }

--- a/crosslink/src/commands/sentinel/webhook.rs
+++ b/crosslink/src/commands/sentinel/webhook.rs
@@ -129,15 +129,14 @@ async fn handle_github_webhook(
         .and_then(|v| v.to_str().ok())
         .unwrap_or("unknown");
 
-    match event_type {
-        "issues" => handle_issue_event(&state, &body).await,
-        _ => {
-            tracing::debug!("Ignoring webhook event type: {event_type}");
-            Ok(Json(WebhookResponse {
-                status: "ignored".into(),
-                signal_ref: None,
-            }))
-        }
+    if event_type == "issues" {
+        handle_issue_event(&state, &body).await
+    } else {
+        tracing::debug!("Ignoring webhook event type: {event_type}");
+        Ok(Json(WebhookResponse {
+            status: "ignored".into(),
+            signal_ref: None,
+        }))
     }
 }
 

--- a/crosslink/src/commands/sentinel/webhook.rs
+++ b/crosslink/src/commands/sentinel/webhook.rs
@@ -7,7 +7,6 @@ use axum::{
     Router,
 };
 use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::mpsc;
 
@@ -23,7 +22,6 @@ pub struct WebhookEvent {
 struct WebhookState {
     sender: mpsc::Sender<WebhookEvent>,
     webhook_secret: Option<String>,
-    crosslink_dir: PathBuf,
 }
 
 /// GitHub webhook payload for issue events.
@@ -73,16 +71,12 @@ impl Default for WebhookConfig {
 ///
 /// The server runs in the background on a tokio runtime. The caller reads
 /// signals from the returned receiver and feeds them into the sentinel engine.
-pub async fn start_webhook_server(
-    config: &WebhookConfig,
-    crosslink_dir: &Path,
-) -> Result<mpsc::Receiver<WebhookEvent>> {
+pub async fn start_webhook_server(config: &WebhookConfig) -> Result<mpsc::Receiver<WebhookEvent>> {
     let (sender, receiver) = mpsc::channel(100);
 
     let state = Arc::new(WebhookState {
         sender,
         webhook_secret: config.secret.clone(),
-        crosslink_dir: crosslink_dir.to_path_buf(),
     });
 
     let app = Router::new()

--- a/crosslink/src/commands/sentinel/webhook.rs
+++ b/crosslink/src/commands/sentinel/webhook.rs
@@ -1,0 +1,235 @@
+use anyhow::{Context, Result};
+use axum::{
+    extract::State,
+    http::{HeaderMap, StatusCode},
+    response::Json,
+    routing::post,
+    Router,
+};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tokio::sync::mpsc;
+
+use super::sources::{Signal, SignalKind, SourceKind};
+
+/// Webhook event pushed into the signal channel for the sentinel engine.
+#[derive(Debug, Clone)]
+pub struct WebhookEvent {
+    pub signal: Signal,
+}
+
+/// Shared state for the webhook server.
+struct WebhookState {
+    sender: mpsc::Sender<WebhookEvent>,
+    webhook_secret: Option<String>,
+    crosslink_dir: PathBuf,
+}
+
+/// GitHub webhook payload for issue events.
+#[derive(Debug, Deserialize)]
+struct GitHubIssueEvent {
+    action: String,
+    issue: GitHubIssue,
+    label: Option<GitHubLabel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubIssue {
+    number: i64,
+    title: String,
+    body: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubLabel {
+    name: String,
+}
+
+#[derive(Debug, Serialize)]
+struct WebhookResponse {
+    status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    signal_ref: Option<String>,
+}
+
+/// Configuration for the webhook server.
+#[derive(Debug, Clone)]
+pub struct WebhookConfig {
+    pub port: u16,
+    pub secret: Option<String>,
+}
+
+impl Default for WebhookConfig {
+    fn default() -> Self {
+        Self {
+            port: 9876,
+            secret: None,
+        }
+    }
+}
+
+/// Start the webhook server. Returns a channel receiver for incoming signals.
+///
+/// The server runs in the background on a tokio runtime. The caller reads
+/// signals from the returned receiver and feeds them into the sentinel engine.
+pub async fn start_webhook_server(
+    config: &WebhookConfig,
+    crosslink_dir: &Path,
+) -> Result<mpsc::Receiver<WebhookEvent>> {
+    let (sender, receiver) = mpsc::channel(100);
+
+    let state = Arc::new(WebhookState {
+        sender,
+        webhook_secret: config.secret.clone(),
+        crosslink_dir: crosslink_dir.to_path_buf(),
+    });
+
+    let app = Router::new()
+        .route("/webhook/github", post(handle_github_webhook))
+        .route("/health", axum::routing::get(health))
+        .with_state(state);
+
+    let addr = format!("0.0.0.0:{}", config.port);
+    let listener = tokio::net::TcpListener::bind(&addr)
+        .await
+        .with_context(|| format!("Failed to bind webhook server to {addr}"))?;
+
+    tracing::info!("Sentinel webhook server listening on {addr}");
+
+    tokio::spawn(async move {
+        if let Err(e) = axum::serve(listener, app).await {
+            tracing::error!("Webhook server error: {e}");
+        }
+    });
+
+    Ok(receiver)
+}
+
+/// Health check endpoint.
+async fn health() -> Json<serde_json::Value> {
+    Json(serde_json::json!({ "status": "ok", "service": "sentinel-webhook" }))
+}
+
+/// Handle incoming GitHub webhook events.
+async fn handle_github_webhook(
+    State(state): State<Arc<WebhookState>>,
+    headers: HeaderMap,
+    body: String,
+) -> Result<Json<WebhookResponse>, StatusCode> {
+    // Verify webhook signature if secret is configured
+    if let Some(ref secret) = state.webhook_secret {
+        let signature = headers
+            .get("x-hub-signature-256")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        if !verify_signature(secret, &body, signature) {
+            tracing::warn!("Webhook signature verification failed");
+            return Err(StatusCode::UNAUTHORIZED);
+        }
+    }
+
+    // Determine event type
+    let event_type = headers
+        .get("x-github-event")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("unknown");
+
+    match event_type {
+        "issues" => handle_issue_event(&state, &body).await,
+        _ => {
+            tracing::debug!("Ignoring webhook event type: {event_type}");
+            Ok(Json(WebhookResponse {
+                status: "ignored".into(),
+                signal_ref: None,
+            }))
+        }
+    }
+}
+
+/// Process a GitHub issue event (labeled, unlabeled, opened, etc.)
+async fn handle_issue_event(
+    state: &WebhookState,
+    body: &str,
+) -> Result<Json<WebhookResponse>, StatusCode> {
+    let event: GitHubIssueEvent = serde_json::from_str(body).map_err(|e| {
+        tracing::warn!("Failed to parse issue event: {e}");
+        StatusCode::BAD_REQUEST
+    })?;
+
+    // We only care about "labeled" events with agent-todo: prefixes
+    if event.action != "labeled" {
+        return Ok(Json(WebhookResponse {
+            status: "ignored".into(),
+            signal_ref: None,
+        }));
+    }
+
+    let Some(label) = &event.label else {
+        return Ok(Json(WebhookResponse {
+            status: "ignored".into(),
+            signal_ref: None,
+        }));
+    };
+
+    if !label.name.starts_with("agent-todo:") {
+        return Ok(Json(WebhookResponse {
+            status: "ignored".into(),
+            signal_ref: None,
+        }));
+    }
+
+    let label_suffix = label
+        .name
+        .strip_prefix("agent-todo: ")
+        .unwrap_or(&label.name);
+    let signal_ref = format!("GH#{}:{}", event.issue.number, label_suffix);
+
+    let signal = Signal {
+        source: SourceKind::GitHub,
+        kind: SignalKind::LabelAdded,
+        reference: signal_ref.clone(),
+        title: event.issue.title,
+        body: event.issue.body.unwrap_or_default(),
+        metadata: serde_json::json!({
+            "label": &label.name,
+            "number": event.issue.number,
+            "via": "webhook",
+        }),
+        detected_at: chrono::Utc::now(),
+    };
+
+    let event = WebhookEvent { signal };
+    if let Err(e) = state.sender.send(event).await {
+        tracing::error!("Failed to queue webhook signal: {e}");
+        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    tracing::info!("Webhook received: {signal_ref}");
+    Ok(Json(WebhookResponse {
+        status: "queued".into(),
+        signal_ref: Some(signal_ref),
+    }))
+}
+
+/// Verify GitHub webhook HMAC-SHA256 signature.
+fn verify_signature(secret: &str, body: &str, signature: &str) -> bool {
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+
+    let Some(hex_sig) = signature.strip_prefix("sha256=") else {
+        return false;
+    };
+
+    let Ok(mut mac) = Hmac::<Sha256>::new_from_slice(secret.as_bytes()) else {
+        return false;
+    };
+
+    mac.update(body.as_bytes());
+
+    let Ok(expected) = hex::decode(hex_sig) else {
+        return false;
+    };
+
+    mac.verify_slice(&expected).is_ok()
+}

--- a/crosslink/src/commands/session.rs
+++ b/crosslink/src/commands/session.rs
@@ -348,9 +348,9 @@ mod tests {
 
     #[test]
     fn test_start_session() {
-        let (db, _dir) = setup_test_db();
+        let (db, dir) = setup_test_db();
 
-        let result = start(&db, _dir.path());
+        let result = start(&db, dir.path());
         assert!(result.is_ok());
 
         let session = db.get_current_session().unwrap();
@@ -359,13 +359,13 @@ mod tests {
 
     #[test]
     fn test_start_already_active() {
-        let (db, _dir) = setup_test_db();
+        let (db, dir) = setup_test_db();
 
-        start(&db, _dir.path()).unwrap();
+        start(&db, dir.path()).unwrap();
         let first_session = db.get_current_session().unwrap().unwrap();
 
         // Starting again should not create new session
-        let result = start(&db, _dir.path());
+        let result = start(&db, dir.path());
         assert!(result.is_ok());
 
         let current = db.get_current_session().unwrap().unwrap();
@@ -376,10 +376,10 @@ mod tests {
 
     #[test]
     fn test_end_session() {
-        let (db, _dir) = setup_test_db();
+        let (db, dir) = setup_test_db();
 
-        start(&db, _dir.path()).unwrap();
-        let result = end(&db, None, _dir.path());
+        start(&db, dir.path()).unwrap();
+        let result = end(&db, None, dir.path());
         assert!(result.is_ok());
 
         let session = db.get_current_session().unwrap();
@@ -388,10 +388,10 @@ mod tests {
 
     #[test]
     fn test_end_session_with_notes() {
-        let (db, _dir) = setup_test_db();
+        let (db, dir) = setup_test_db();
 
-        start(&db, _dir.path()).unwrap();
-        let result = end(&db, Some("Completed auth feature"), _dir.path());
+        start(&db, dir.path()).unwrap();
+        let result = end(&db, Some("Completed auth feature"), dir.path());
         assert!(result.is_ok());
 
         let last = db.get_last_session().unwrap().unwrap();
@@ -403,9 +403,9 @@ mod tests {
 
     #[test]
     fn test_end_no_active_session() {
-        let (db, _dir) = setup_test_db();
+        let (db, dir) = setup_test_db();
 
-        let result = end(&db, None, _dir.path());
+        let result = end(&db, None, dir.path());
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -417,18 +417,18 @@ mod tests {
 
     #[test]
     fn test_status_no_session() {
-        let (db, _dir) = setup_test_db();
+        let (db, dir) = setup_test_db();
 
-        let result = status(&db, _dir.path(), false);
+        let result = status(&db, dir.path(), false);
         assert!(result.is_ok());
     }
 
     #[test]
     fn test_status_with_session() {
-        let (db, _dir) = setup_test_db();
+        let (db, dir) = setup_test_db();
 
-        start(&db, _dir.path()).unwrap();
-        let result = status(&db, _dir.path(), false);
+        start(&db, dir.path()).unwrap();
+        let result = status(&db, dir.path(), false);
         assert!(result.is_ok());
     }
 
@@ -506,33 +506,33 @@ mod tests {
 
     #[test]
     fn test_last_handoff_no_sessions() {
-        let (db, _dir) = setup_test_db();
+        let (db, dir) = setup_test_db();
 
-        let result = last_handoff(&db, _dir.path());
+        let result = last_handoff(&db, dir.path());
         assert!(result.is_ok());
         // Should handle gracefully when no sessions exist
     }
 
     #[test]
     fn test_last_handoff_no_notes() {
-        let (db, _dir) = setup_test_db();
+        let (db, dir) = setup_test_db();
 
-        start(&db, _dir.path()).unwrap();
-        end(&db, None, _dir.path()).unwrap();
+        start(&db, dir.path()).unwrap();
+        end(&db, None, dir.path()).unwrap();
 
-        let result = last_handoff(&db, _dir.path());
+        let result = last_handoff(&db, dir.path());
         assert!(result.is_ok());
         // Should handle gracefully when last session has no notes
     }
 
     #[test]
     fn test_last_handoff_with_notes() {
-        let (db, _dir) = setup_test_db();
+        let (db, dir) = setup_test_db();
 
-        start(&db, _dir.path()).unwrap();
-        end(&db, Some("Important handoff notes"), _dir.path()).unwrap();
+        start(&db, dir.path()).unwrap();
+        end(&db, Some("Important handoff notes"), dir.path()).unwrap();
 
-        let result = last_handoff(&db, _dir.path());
+        let result = last_handoff(&db, dir.path());
         assert!(result.is_ok());
         // Notes should be retrievable
         let last = db.get_last_session().unwrap().unwrap();
@@ -577,22 +577,22 @@ mod tests {
     proptest! {
         #[test]
         fn prop_start_end_cycle(iterations in 1usize..5) {
-            let (db, _dir) = setup_test_db();
+            let (db, dir) = setup_test_db();
 
             for _ in 0..iterations {
-                start(&db, _dir.path()).unwrap();
+                start(&db, dir.path()).unwrap();
                 prop_assert!(db.get_current_session().unwrap().is_some());
-                end(&db, None, _dir.path()).unwrap();
+                end(&db, None, dir.path()).unwrap();
                 prop_assert!(db.get_current_session().unwrap().is_none());
             }
         }
 
         #[test]
         fn prop_handoff_notes_roundtrip(notes in "[a-zA-Z0-9 ]{0,100}") {
-            let (db, _dir) = setup_test_db();
+            let (db, dir) = setup_test_db();
 
-            start(&db, _dir.path()).unwrap();
-            end(&db, Some(&notes), _dir.path()).unwrap();
+            start(&db, dir.path()).unwrap();
+            end(&db, Some(&notes), dir.path()).unwrap();
 
             let last = db.get_last_session().unwrap().unwrap();
             prop_assert_eq!(last.handoff_notes, Some(notes));

--- a/crosslink/src/commands/show.rs
+++ b/crosslink/src/commands/show.rs
@@ -377,7 +377,7 @@ mod tests {
 
         run(&db, issue_id).unwrap();
         let issue = db.get_issue(issue_id).unwrap().unwrap();
-        assert_eq!(issue.description, Some("".to_string()));
+        assert_eq!(issue.description, Some(String::new()));
     }
 
     // ==================== Property-Based Tests ====================

--- a/crosslink/src/commands/style.rs
+++ b/crosslink/src/commands/style.rs
@@ -795,13 +795,13 @@ mod tests {
             Some("normal")
         );
         assert_eq!(
-            config.get("new_field").and_then(|v| v.as_bool()),
+            config.get("new_field").and_then(serde_json::Value::as_bool),
             Some(true)
         );
         assert_eq!(
             config
                 .get("intervention_tracking")
-                .and_then(|v| v.as_bool()),
+                .and_then(serde_json::Value::as_bool),
             Some(true)
         );
         let hs = config.get("house_style").unwrap();

--- a/crosslink/src/commands/swarm/mod.rs
+++ b/crosslink/src/commands/swarm/mod.rs
@@ -42,7 +42,7 @@ mod tests {
     use crate::findings::{Finding, FindingSeverity, ReviewReport};
     use std::path::PathBuf;
 
-    /// Helper to build seam::Partition from a label and file list (for tests).
+    /// Helper to build `seam::Partition` from a label and file list (for tests).
     fn make_partition(label: &str, files: Vec<&str>) -> crate::seam::Partition {
         crate::seam::Partition {
             label: label.to_string(),
@@ -180,7 +180,7 @@ mod tests {
         let doc = DesignDoc {
             title: "Big Feature".to_string(),
             summary: String::new(),
-            requirements: (1..=12).map(|i| format!("REQ-{}: Task {}", i, i)).collect(),
+            requirements: (1..=12).map(|i| format!("REQ-{i}: Task {i}")).collect(),
             requirement_groups: Vec::new(),
             acceptance_criteria: vec![],
             architecture: String::new(),
@@ -789,7 +789,7 @@ mod tests {
                 assert!(recommended_count > 0);
                 assert!(recommended_count < 4);
             }
-            other => panic!("Expected Split, got {:?}", other),
+            other => panic!("Expected Split, got {other:?}"),
         }
     }
 
@@ -799,7 +799,7 @@ mod tests {
         let rec = budget_recommendation(20000, 500, 4);
         match rec {
             BudgetRecommendation::Block { .. } => {}
-            other => panic!("Expected Block, got {:?}", other),
+            other => panic!("Expected Block, got {other:?}"),
         }
     }
 
@@ -1116,9 +1116,9 @@ mod tests {
 
         assert_eq!(assignments.len(), 1);
         assert_eq!(assignments[0].files.len(), 3);
-        assert!(assignments[0].partition_label.contains("a"));
-        assert!(assignments[0].partition_label.contains("b"));
-        assert!(assignments[0].partition_label.contains("c"));
+        assert!(assignments[0].partition_label.contains('a'));
+        assert!(assignments[0].partition_label.contains('b'));
+        assert!(assignments[0].partition_label.contains('c'));
     }
 
     #[test]
@@ -1232,7 +1232,7 @@ mod tests {
                 FixTarget {
                     issue_number: 327,
                     title: "Memory leak".to_string(),
-                    body: "".to_string(),
+                    body: String::new(),
                     labels: vec![],
                     agent_slug: "fix-327-memory-leak".to_string(),
                     status: AgentStatus::Running,

--- a/crosslink/src/commands/timer.rs
+++ b/crosslink/src/commands/timer.rs
@@ -201,7 +201,7 @@ mod tests {
         #[test]
         fn prop_start_stop_roundtrip(idx in 0usize..5) {
             let (db, _dir) = setup_test_db();
-            let ids: Vec<i64> = (0..5).map(|i| db.create_issue(&format!("Issue {}", i), None, "medium").unwrap()).collect();
+            let ids: Vec<i64> = (0..5).map(|i| db.create_issue(&format!("Issue {i}"), None, "medium").unwrap()).collect();
             let id = ids[idx];
 
             start(&db, id).unwrap();

--- a/crosslink/src/commands/tree.rs
+++ b/crosslink/src/commands/tree.rs
@@ -230,7 +230,7 @@ mod tests {
         fn prop_run_never_panics(count in 0usize..5) {
             let (db, _dir) = setup_test_db();
             for i in 0..count {
-                db.create_issue(&format!("Issue {}", i), None, "medium").unwrap();
+                db.create_issue(&format!("Issue {i}"), None, "medium").unwrap();
             }
             let result = run(&db, None, false);
             prop_assert!(result.is_ok());
@@ -241,7 +241,7 @@ mod tests {
             let (db, _dir) = setup_test_db();
             let mut parent_id = db.create_issue("Root", None, "high").unwrap();
             for i in 0..depth {
-                parent_id = db.create_subissue(parent_id, &format!("Child {}", i), None, "medium").unwrap();
+                parent_id = db.create_subissue(parent_id, &format!("Child {i}"), None, "medium").unwrap();
             }
             let result = run(&db, None, false);
             prop_assert!(result.is_ok());

--- a/crosslink/src/commands/update.rs
+++ b/crosslink/src/commands/update.rs
@@ -184,7 +184,7 @@ mod tests {
         assert!(result.is_ok());
 
         let issue = db.get_issue(issue_id).unwrap().unwrap();
-        assert_eq!(issue.description, Some("".to_string()));
+        assert_eq!(issue.description, Some(String::new()));
     }
 
     #[test]

--- a/crosslink/src/compaction.rs
+++ b/crosslink/src/compaction.rs
@@ -741,7 +741,7 @@ mod tests {
     use chrono::Duration;
 
     /// Try to acquire the compaction lease. Returns true if acquired.
-    /// (Test-only helper — production code uses CompactionLockGuard.)
+    /// (Test-only helper — production code uses `CompactionLockGuard`.)
     fn try_acquire_lease(state: &mut CheckpointState, agent_id: &str) -> bool {
         let now = Utc::now();
         if let Some(ref lease) = state.compaction_lease {
@@ -751,7 +751,7 @@ mod tests {
                 // Another agent holds an unexpired lease — but check if the
                 // holding process is still alive. If the PID is dead, treat
                 // the lease as stale regardless of expiry time.
-                let holder_dead = lease.pid.map(|pid| !is_pid_alive(pid)).unwrap_or(false);
+                let holder_dead = lease.pid.is_some_and(|pid| !is_pid_alive(pid));
                 if !holder_dead {
                     return false;
                 }
@@ -795,7 +795,7 @@ mod tests {
     }
 
     /// Release the compaction lease.
-    /// (Test-only helper — production code uses CompactionLockGuard.)
+    /// (Test-only helper — production code uses `CompactionLockGuard`.)
     fn release_lease(state: &mut CheckpointState) {
         state.compaction_lease = None;
     }
@@ -1952,7 +1952,7 @@ mod tests {
         let now = Utc::now();
 
         for (agent, seq_offset) in &[("agent-a", 3), ("agent-b", 2), ("agent-c", 1)] {
-            let log = cache_dir.join(format!("agents/{}/events.log", agent));
+            let log = cache_dir.join(format!("agents/{agent}/events.log"));
             let mut e = make_envelope(
                 agent,
                 1,
@@ -3436,7 +3436,7 @@ mod tests {
         std::fs::write(&legacy_wm_path, &wm_json).unwrap();
 
         // Strip embedded watermark from checkpoint state to simulate legacy state
-        let mut state_no_wm = state.clone();
+        let mut state_no_wm = state;
         state_no_wm.watermark = None;
         write_checkpoint(cache_dir, &state_no_wm).unwrap();
 
@@ -3565,7 +3565,7 @@ mod tests {
         // Use "check-agent@crosslink" as the principal (matching envelope.agent_id + "@crosslink")
         std::fs::write(
             &signers_path,
-            format!("check-agent@crosslink {}\n", public_key),
+            format!("check-agent@crosslink {public_key}\n"),
         )
         .unwrap();
 

--- a/crosslink/src/db/core.rs
+++ b/crosslink/src/db/core.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use rusqlite::Connection;
 use std::path::Path;
 
-pub const SCHEMA_VERSION: i32 = 15;
+pub const SCHEMA_VERSION: i32 = 16;
 
 /// Valid values for issue priority.
 pub const VALID_PRIORITIES: &[&str] = &["low", "medium", "high", "critical"];
@@ -366,6 +366,56 @@ impl Database {
                     CREATE INDEX IF NOT EXISTS idx_token_usage_agent ON token_usage(agent_id);
                     CREATE INDEX IF NOT EXISTS idx_token_usage_session ON token_usage(session_id);
                     CREATE INDEX IF NOT EXISTS idx_token_usage_timestamp ON token_usage(timestamp);
+                    ",
+            );
+        }
+
+        // Migration v16: Sentinel autonomous maintenance tables
+        if version < 16 {
+            self.migrate_batch(
+                r"
+                    CREATE TABLE IF NOT EXISTS sentinel_runs (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        run_id TEXT NOT NULL UNIQUE,
+                        started_at TEXT NOT NULL,
+                        completed_at TEXT,
+                        mode TEXT NOT NULL,
+                        signals_found INTEGER DEFAULT 0,
+                        dispatched INTEGER DEFAULT 0,
+                        collected INTEGER DEFAULT 0,
+                        triaged INTEGER DEFAULT 0,
+                        skipped INTEGER DEFAULT 0,
+                        deferred INTEGER DEFAULT 0
+                    );
+
+                    CREATE TABLE IF NOT EXISTS sentinel_dispatches (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        run_id TEXT NOT NULL,
+                        signal_ref TEXT NOT NULL,
+                        signal_title TEXT NOT NULL,
+                        source TEXT NOT NULL,
+                        disposition TEXT NOT NULL,
+                        agent_id TEXT,
+                        crosslink_issue_id INTEGER,
+                        gh_issue_number INTEGER,
+                        label TEXT NOT NULL,
+                        attempt_number INTEGER DEFAULT 1,
+                        model_used TEXT,
+                        outcome TEXT DEFAULT 'pending',
+                        outcome_detail TEXT,
+                        created_at TEXT NOT NULL,
+                        completed_at TEXT,
+                        FOREIGN KEY (crosslink_issue_id) REFERENCES issues(id)
+                    );
+
+                    CREATE INDEX IF NOT EXISTS idx_sentinel_dispatches_signal_ref
+                        ON sentinel_dispatches(signal_ref);
+                    CREATE INDEX IF NOT EXISTS idx_sentinel_dispatches_outcome
+                        ON sentinel_dispatches(outcome);
+                    CREATE INDEX IF NOT EXISTS idx_sentinel_dispatches_run_id
+                        ON sentinel_dispatches(run_id);
+                    CREATE INDEX IF NOT EXISTS idx_sentinel_dispatches_gh_label
+                        ON sentinel_dispatches(gh_issue_number, label);
                     ",
             );
         }

--- a/crosslink/src/db/mod.rs
+++ b/crosslink/src/db/mod.rs
@@ -6,7 +6,6 @@ mod issues;
 mod labels;
 mod milestones;
 mod relations;
-#[allow(dead_code)]
 pub mod sentinel;
 mod sessions;
 mod time_entries;

--- a/crosslink/src/db/mod.rs
+++ b/crosslink/src/db/mod.rs
@@ -6,6 +6,8 @@ mod issues;
 mod labels;
 mod milestones;
 mod relations;
+#[allow(dead_code)]
+pub mod sentinel;
 mod sessions;
 mod time_entries;
 mod token_usage;

--- a/crosslink/src/db/sentinel.rs
+++ b/crosslink/src/db/sentinel.rs
@@ -55,6 +55,17 @@ pub struct DispatchMetric {
     pub success_rate: f64,
 }
 
+/// Counter columns for completing a sentinel run.
+#[derive(Debug, Clone, Default)]
+pub struct RunCounters {
+    pub signals_found: i64,
+    pub dispatched: i64,
+    pub collected: i64,
+    pub triaged: i64,
+    pub skipped: i64,
+    pub deferred: i64,
+}
+
 /// Parameters for inserting a new sentinel dispatch record.
 pub struct NewDispatch<'a> {
     pub run_id: &'a str,
@@ -84,16 +95,7 @@ impl Database {
     }
 
     /// Update a sentinel run with final statistics.
-    pub fn complete_sentinel_run(
-        &self,
-        run_id: &str,
-        signals_found: i64,
-        dispatched: i64,
-        collected: i64,
-        triaged: i64,
-        skipped: i64,
-        deferred: i64,
-    ) -> Result<()> {
+    pub fn complete_sentinel_run(&self, run_id: &str, counters: &RunCounters) -> Result<()> {
         let now = Utc::now().to_rfc3339();
         self.conn.execute(
             "UPDATE sentinel_runs
@@ -102,13 +104,13 @@ impl Database {
              WHERE run_id = ?8",
             params![
                 now,
-                signals_found,
-                dispatched,
-                collected,
-                triaged,
-                skipped,
-                deferred,
-                run_id
+                counters.signals_found,
+                counters.dispatched,
+                counters.collected,
+                counters.triaged,
+                counters.skipped,
+                counters.deferred,
+                run_id,
             ],
         )?;
         Ok(())
@@ -211,7 +213,7 @@ impl Database {
         Ok(count)
     }
 
-    /// Get the most recent dispatch for a given (gh_issue_number, label) pair.
+    /// Get the most recent dispatch for a given `(gh_issue_number, label)` pair.
     /// Used for the authoritative dedup check (Layer 3).
     pub fn get_latest_dispatch_for_signal(
         &self,
@@ -233,7 +235,7 @@ impl Database {
         Ok(rows.pop())
     }
 
-    /// Load all dispatches for SeenSet construction (most recent per signal_ref).
+    /// Load all dispatches for `SeenSet` construction (most recent per `signal_ref`).
     pub fn load_dispatch_seen_set(&self) -> Result<Vec<SentinelDispatch>> {
         let mut stmt = self.conn.prepare(
             "SELECT d.id, d.run_id, d.signal_ref, d.signal_title, d.source, d.disposition,
@@ -312,7 +314,7 @@ impl Database {
         Ok(rows)
     }
 
-    /// Shared row mapper for sentinel_dispatches queries.
+    /// Shared row mapper for `sentinel_dispatches` queries.
     fn map_dispatch_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SentinelDispatch> {
         Ok(SentinelDispatch {
             id: row.get(0)?,

--- a/crosslink/src/db/sentinel.rs
+++ b/crosslink/src/db/sentinel.rs
@@ -253,6 +253,22 @@ impl Database {
         Ok(rows)
     }
 
+    /// List all dispatches for a given sentinel run, ordered by creation time.
+    pub fn list_dispatches_for_run(&self, run_id: &str) -> Result<Vec<SentinelDispatch>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, run_id, signal_ref, signal_title, source, disposition,
+                    agent_id, crosslink_issue_id, gh_issue_number, label,
+                    attempt_number, model_used, outcome, outcome_detail,
+                    created_at, completed_at
+             FROM sentinel_dispatches WHERE run_id = ?1
+             ORDER BY created_at",
+        )?;
+        let rows = stmt
+            .query_map(params![run_id], Self::map_dispatch_row)?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
     /// Get success rate metrics grouped by model and label.
     pub fn get_dispatch_metrics(&self) -> Result<Vec<DispatchMetric>> {
         let mut stmt = self.conn.prepare(

--- a/crosslink/src/db/sentinel.rs
+++ b/crosslink/src/db/sentinel.rs
@@ -1,0 +1,278 @@
+use anyhow::Result;
+use chrono::Utc;
+use rusqlite::params;
+
+use super::core::Database;
+
+/// A row from the `sentinel_runs` table.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SentinelRun {
+    pub id: i64,
+    pub run_id: String,
+    pub started_at: String,
+    pub completed_at: Option<String>,
+    pub mode: String,
+    pub signals_found: i64,
+    pub dispatched: i64,
+    pub collected: i64,
+    pub triaged: i64,
+    pub skipped: i64,
+    pub deferred: i64,
+}
+
+/// A row from the `sentinel_dispatches` table.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SentinelDispatch {
+    pub id: i64,
+    pub run_id: String,
+    pub signal_ref: String,
+    pub signal_title: String,
+    pub source: String,
+    pub disposition: String,
+    pub agent_id: Option<String>,
+    pub crosslink_issue_id: Option<i64>,
+    pub gh_issue_number: Option<i64>,
+    pub label: String,
+    pub attempt_number: i32,
+    pub model_used: Option<String>,
+    pub outcome: String,
+    pub outcome_detail: Option<String>,
+    pub created_at: String,
+    pub completed_at: Option<String>,
+}
+
+impl Database {
+    // === Sentinel runs ===
+
+    /// Insert a new sentinel run record. Returns the auto-generated row ID.
+    pub fn insert_sentinel_run(&self, run_id: &str, mode: &str) -> Result<i64> {
+        let now = Utc::now().to_rfc3339();
+        self.conn.execute(
+            "INSERT INTO sentinel_runs (run_id, started_at, mode) VALUES (?1, ?2, ?3)",
+            params![run_id, now, mode],
+        )?;
+        Ok(self.conn.last_insert_rowid())
+    }
+
+    /// Update a sentinel run with final statistics.
+    pub fn complete_sentinel_run(
+        &self,
+        run_id: &str,
+        signals_found: i64,
+        dispatched: i64,
+        collected: i64,
+        triaged: i64,
+        skipped: i64,
+        deferred: i64,
+    ) -> Result<()> {
+        let now = Utc::now().to_rfc3339();
+        self.conn.execute(
+            "UPDATE sentinel_runs
+             SET completed_at = ?1, signals_found = ?2, dispatched = ?3,
+                 collected = ?4, triaged = ?5, skipped = ?6, deferred = ?7
+             WHERE run_id = ?8",
+            params![
+                now,
+                signals_found,
+                dispatched,
+                collected,
+                triaged,
+                skipped,
+                deferred,
+                run_id
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// List recent sentinel runs, most recent first.
+    pub fn list_sentinel_runs(&self, limit: usize) -> Result<Vec<SentinelRun>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, run_id, started_at, completed_at, mode,
+                    signals_found, dispatched, collected, triaged, skipped, deferred
+             FROM sentinel_runs ORDER BY started_at DESC LIMIT ?1",
+        )?;
+        let rows = stmt
+            .query_map(params![limit as i64], |row| {
+                Ok(SentinelRun {
+                    id: row.get(0)?,
+                    run_id: row.get(1)?,
+                    started_at: row.get(2)?,
+                    completed_at: row.get(3)?,
+                    mode: row.get(4)?,
+                    signals_found: row.get(5)?,
+                    dispatched: row.get(6)?,
+                    collected: row.get(7)?,
+                    triaged: row.get(8)?,
+                    skipped: row.get(9)?,
+                    deferred: row.get(10)?,
+                })
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
+    // === Sentinel dispatches ===
+
+    /// Insert a new sentinel dispatch record. Returns the auto-generated row ID.
+    #[allow(clippy::too_many_arguments)]
+    pub fn insert_sentinel_dispatch(
+        &self,
+        run_id: &str,
+        signal_ref: &str,
+        signal_title: &str,
+        source: &str,
+        disposition: &str,
+        agent_id: Option<&str>,
+        crosslink_issue_id: Option<i64>,
+        gh_issue_number: Option<i64>,
+        label: &str,
+        attempt_number: i32,
+        model_used: Option<&str>,
+    ) -> Result<i64> {
+        let now = Utc::now().to_rfc3339();
+        self.conn.execute(
+            "INSERT INTO sentinel_dispatches
+             (run_id, signal_ref, signal_title, source, disposition, agent_id,
+              crosslink_issue_id, gh_issue_number, label, attempt_number, model_used, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+            params![
+                run_id,
+                signal_ref,
+                signal_title,
+                source,
+                disposition,
+                agent_id,
+                crosslink_issue_id,
+                gh_issue_number,
+                label,
+                attempt_number,
+                model_used,
+                now,
+            ],
+        )?;
+        Ok(self.conn.last_insert_rowid())
+    }
+
+    /// Update a dispatch record with its outcome.
+    pub fn update_dispatch_outcome(
+        &self,
+        dispatch_id: i64,
+        outcome: &str,
+        outcome_detail: &str,
+    ) -> Result<()> {
+        let now = Utc::now().to_rfc3339();
+        self.conn.execute(
+            "UPDATE sentinel_dispatches
+             SET outcome = ?1, outcome_detail = ?2, completed_at = ?3
+             WHERE id = ?4",
+            params![outcome, outcome_detail, now, dispatch_id],
+        )?;
+        Ok(())
+    }
+
+    /// Get all dispatches with outcome = 'pending'.
+    pub fn get_pending_dispatches(&self) -> Result<Vec<SentinelDispatch>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, run_id, signal_ref, signal_title, source, disposition,
+                    agent_id, crosslink_issue_id, gh_issue_number, label,
+                    attempt_number, model_used, outcome, outcome_detail,
+                    created_at, completed_at
+             FROM sentinel_dispatches WHERE outcome = 'pending'",
+        )?;
+        let rows = stmt
+            .query_map([], Self::map_dispatch_row)?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
+    /// Count dispatches with outcome = 'pending'.
+    pub fn count_pending_dispatches(&self) -> Result<i64> {
+        let count: i64 = self.conn.query_row(
+            "SELECT COUNT(*) FROM sentinel_dispatches WHERE outcome = 'pending'",
+            [],
+            |row| row.get(0),
+        )?;
+        Ok(count)
+    }
+
+    /// Get the most recent dispatch for a given (gh_issue_number, label) pair.
+    /// Used for the authoritative dedup check (Layer 3).
+    pub fn get_latest_dispatch_for_signal(
+        &self,
+        gh_issue_number: i64,
+        label: &str,
+    ) -> Result<Option<SentinelDispatch>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, run_id, signal_ref, signal_title, source, disposition,
+                    agent_id, crosslink_issue_id, gh_issue_number, label,
+                    attempt_number, model_used, outcome, outcome_detail,
+                    created_at, completed_at
+             FROM sentinel_dispatches
+             WHERE gh_issue_number = ?1 AND label = ?2
+             ORDER BY created_at DESC LIMIT 1",
+        )?;
+        let mut rows = stmt
+            .query_map(params![gh_issue_number, label], Self::map_dispatch_row)?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows.pop())
+    }
+
+    /// Load all dispatches for SeenSet construction (most recent per signal_ref).
+    pub fn load_dispatch_seen_set(&self) -> Result<Vec<SentinelDispatch>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT d.id, d.run_id, d.signal_ref, d.signal_title, d.source, d.disposition,
+                    d.agent_id, d.crosslink_issue_id, d.gh_issue_number, d.label,
+                    d.attempt_number, d.model_used, d.outcome, d.outcome_detail,
+                    d.created_at, d.completed_at
+             FROM sentinel_dispatches d
+             INNER JOIN (
+                 SELECT signal_ref, MAX(created_at) as max_created
+                 FROM sentinel_dispatches
+                 GROUP BY signal_ref
+             ) latest ON d.signal_ref = latest.signal_ref AND d.created_at = latest.max_created",
+        )?;
+        let rows = stmt
+            .query_map([], Self::map_dispatch_row)?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
+    /// List dispatches for a given run_id.
+    pub fn list_dispatches_for_run(&self, run_id: &str) -> Result<Vec<SentinelDispatch>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, run_id, signal_ref, signal_title, source, disposition,
+                    agent_id, crosslink_issue_id, gh_issue_number, label,
+                    attempt_number, model_used, outcome, outcome_detail,
+                    created_at, completed_at
+             FROM sentinel_dispatches WHERE run_id = ?1
+             ORDER BY created_at",
+        )?;
+        let rows = stmt
+            .query_map(params![run_id], Self::map_dispatch_row)?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
+    /// Shared row mapper for sentinel_dispatches queries.
+    fn map_dispatch_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SentinelDispatch> {
+        Ok(SentinelDispatch {
+            id: row.get(0)?,
+            run_id: row.get(1)?,
+            signal_ref: row.get(2)?,
+            signal_title: row.get(3)?,
+            source: row.get(4)?,
+            disposition: row.get(5)?,
+            agent_id: row.get(6)?,
+            crosslink_issue_id: row.get(7)?,
+            gh_issue_number: row.get(8)?,
+            label: row.get(9)?,
+            attempt_number: row.get(10)?,
+            model_used: row.get(11)?,
+            outcome: row.get(12)?,
+            outcome_detail: row.get(13)?,
+            created_at: row.get(14)?,
+            completed_at: row.get(15)?,
+        })
+    }
+}

--- a/crosslink/src/db/sentinel.rs
+++ b/crosslink/src/db/sentinel.rs
@@ -55,6 +55,21 @@ pub struct DispatchMetric {
     pub success_rate: f64,
 }
 
+/// Parameters for inserting a new sentinel dispatch record.
+pub struct NewDispatch<'a> {
+    pub run_id: &'a str,
+    pub signal_ref: &'a str,
+    pub signal_title: &'a str,
+    pub source: &'a str,
+    pub disposition: &'a str,
+    pub agent_id: Option<&'a str>,
+    pub crosslink_issue_id: Option<i64>,
+    pub gh_issue_number: Option<i64>,
+    pub label: &'a str,
+    pub attempt_number: i32,
+    pub model_used: Option<&'a str>,
+}
+
 impl Database {
     // === Sentinel runs ===
 
@@ -129,21 +144,7 @@ impl Database {
     // === Sentinel dispatches ===
 
     /// Insert a new sentinel dispatch record. Returns the auto-generated row ID.
-    #[allow(clippy::too_many_arguments)]
-    pub fn insert_sentinel_dispatch(
-        &self,
-        run_id: &str,
-        signal_ref: &str,
-        signal_title: &str,
-        source: &str,
-        disposition: &str,
-        agent_id: Option<&str>,
-        crosslink_issue_id: Option<i64>,
-        gh_issue_number: Option<i64>,
-        label: &str,
-        attempt_number: i32,
-        model_used: Option<&str>,
-    ) -> Result<i64> {
+    pub fn insert_sentinel_dispatch(&self, d: &NewDispatch<'_>) -> Result<i64> {
         let now = Utc::now().to_rfc3339();
         self.conn.execute(
             "INSERT INTO sentinel_dispatches
@@ -151,17 +152,17 @@ impl Database {
               crosslink_issue_id, gh_issue_number, label, attempt_number, model_used, created_at)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
             params![
-                run_id,
-                signal_ref,
-                signal_title,
-                source,
-                disposition,
-                agent_id,
-                crosslink_issue_id,
-                gh_issue_number,
-                label,
-                attempt_number,
-                model_used,
+                d.run_id,
+                d.signal_ref,
+                d.signal_title,
+                d.source,
+                d.disposition,
+                d.agent_id,
+                d.crosslink_issue_id,
+                d.gh_issue_number,
+                d.label,
+                d.attempt_number,
+                d.model_used,
                 now,
             ],
         )?;
@@ -248,22 +249,6 @@ impl Database {
         )?;
         let rows = stmt
             .query_map([], Self::map_dispatch_row)?
-            .collect::<std::result::Result<Vec<_>, _>>()?;
-        Ok(rows)
-    }
-
-    /// List dispatches for a given run_id.
-    pub fn list_dispatches_for_run(&self, run_id: &str) -> Result<Vec<SentinelDispatch>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT id, run_id, signal_ref, signal_title, source, disposition,
-                    agent_id, crosslink_issue_id, gh_issue_number, label,
-                    attempt_number, model_used, outcome, outcome_detail,
-                    created_at, completed_at
-             FROM sentinel_dispatches WHERE run_id = ?1
-             ORDER BY created_at",
-        )?;
-        let rows = stmt
-            .query_map(params![run_id], Self::map_dispatch_row)?
             .collect::<std::result::Result<Vec<_>, _>>()?;
         Ok(rows)
     }

--- a/crosslink/src/db/sentinel.rs
+++ b/crosslink/src/db/sentinel.rs
@@ -41,6 +41,20 @@ pub struct SentinelDispatch {
     pub completed_at: Option<String>,
 }
 
+/// Aggregated dispatch metrics grouped by model and label.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DispatchMetric {
+    pub model: String,
+    pub label: String,
+    pub total: i64,
+    pub successes: i64,
+    pub failures: i64,
+    pub exhausted: i64,
+    pub pending: i64,
+    pub orphaned: i64,
+    pub success_rate: f64,
+}
+
 impl Database {
     // === Sentinel runs ===
 
@@ -250,6 +264,49 @@ impl Database {
         )?;
         let rows = stmt
             .query_map(params![run_id], Self::map_dispatch_row)?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
+    /// Get success rate metrics grouped by model and label.
+    pub fn get_dispatch_metrics(&self) -> Result<Vec<DispatchMetric>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT
+                COALESCE(model_used, 'unknown') as model,
+                label,
+                COUNT(*) as total,
+                SUM(CASE WHEN outcome = 'success' THEN 1 ELSE 0 END) as successes,
+                SUM(CASE WHEN outcome = 'failure' THEN 1 ELSE 0 END) as failures,
+                SUM(CASE WHEN outcome = 'exhausted' THEN 1 ELSE 0 END) as exhausted,
+                SUM(CASE WHEN outcome = 'pending' THEN 1 ELSE 0 END) as pending,
+                SUM(CASE WHEN outcome = 'orphaned' THEN 1 ELSE 0 END) as orphaned
+             FROM sentinel_dispatches
+             WHERE disposition = 'dispatch'
+             GROUP BY model_used, label
+             ORDER BY label, model_used",
+        )?;
+        let rows = stmt
+            .query_map([], |row| {
+                let total: i64 = row.get(2)?;
+                let successes: i64 = row.get(3)?;
+                let completed = total - row.get::<_, i64>(6)?; // total - pending
+                let success_rate = if completed > 0 {
+                    (successes as f64 / completed as f64) * 100.0
+                } else {
+                    0.0
+                };
+                Ok(DispatchMetric {
+                    model: row.get(0)?,
+                    label: row.get(1)?,
+                    total,
+                    successes,
+                    failures: row.get(4)?,
+                    exhausted: row.get(5)?,
+                    pending: row.get(6)?,
+                    orphaned: row.get(7)?,
+                    success_rate,
+                })
+            })?
             .collect::<std::result::Result<Vec<_>, _>>()?;
         Ok(rows)
     }

--- a/crosslink/src/db/sessions.rs
+++ b/crosslink/src/db/sessions.rs
@@ -9,7 +9,7 @@ use crate::models::Session;
 impl Database {
     // Sessions
 
-    /// Convenience wrapper for tests -- starts a session with no agent_id.
+    /// Convenience wrapper for tests -- starts a session with no `agent_id`.
     #[cfg(test)]
     pub fn start_session(&self) -> Result<i64> {
         self.start_session_with_agent(None)

--- a/crosslink/src/db/tests.rs
+++ b/crosslink/src/db/tests.rs
@@ -1024,14 +1024,13 @@ fn test_corrupted_db_file_truncated() {
     let result = Database::open(&db_path);
     match result {
         Err(e) => {
-            let err_msg = format!("{}", e);
+            let err_msg = format!("{e}");
             assert!(
                 err_msg.contains("not a database")
                     || err_msg.contains("malformed")
                     || err_msg.contains("corrupt")
                     || err_msg.contains("disk image"),
-                "Error should indicate corruption, got: {}",
-                err_msg
+                "Error should indicate corruption, got: {err_msg}"
             );
         }
         Ok(db) => {
@@ -1270,7 +1269,7 @@ fn test_get_related_issue_ids() {
 
     // From id1's perspective, both id2 and id3 should be related
     let mut related = db.get_related_issue_ids(id1).unwrap();
-    related.sort();
+    related.sort_unstable();
     assert_eq!(related, vec![id2, id3]);
 
     // From id2's perspective, only id1 is related
@@ -1842,7 +1841,7 @@ fn test_get_schema_version() {
     let (db, _dir) = setup_test_db();
     let version = db.get_schema_version().unwrap();
     // Should be the latest migration version (at least > 0)
-    assert!(version > 0, "Schema version should be > 0, got {}", version);
+    assert!(version > 0, "Schema version should be > 0, got {version}");
 }
 
 #[test]
@@ -2040,7 +2039,7 @@ mod proptest_tests {
         fn prop_create_increases_count(count in 1usize..20) {
             let (db, _dir) = setup_test_db();
             for i in 0..count {
-                db.create_issue(&format!("Issue {}", i), None, "medium").unwrap();
+                db.create_issue(&format!("Issue {i}"), None, "medium").unwrap();
             }
             let issues = db.list_issues(None, None, None).unwrap();
             prop_assert_eq!(issues.len(), count);
@@ -2071,7 +2070,7 @@ mod proptest_tests {
 
             // Create both issues
             for i in 1..=std::cmp::max(a, b) {
-                db.create_issue(&format!("Issue {}", i), None, "medium").unwrap();
+                db.create_issue(&format!("Issue {i}"), None, "medium").unwrap();
             }
 
             db.add_dependency(a, b).unwrap();
@@ -2086,7 +2085,7 @@ mod proptest_tests {
             suffix in "[a-zA-Z]{3,10}"
         ) {
             let (db, _dir) = setup_test_db();
-            let title = format!("{} unique marker {}", prefix, suffix);
+            let title = format!("{prefix} unique marker {suffix}");
             db.create_issue(&title, None, "medium").unwrap();
 
             // Search for the unique marker
@@ -2103,7 +2102,7 @@ mod proptest_tests {
             // Create a chain of issues
             let mut ids = Vec::new();
             for i in 0..chain_len {
-                let id = db.create_issue(&format!("Issue {}", i), None, "medium").unwrap();
+                let id = db.create_issue(&format!("Issue {i}"), None, "medium").unwrap();
                 ids.push(id);
             }
 
@@ -2128,7 +2127,7 @@ mod proptest_tests {
             // Create children
             let mut child_ids = Vec::new();
             for i in 0..child_count {
-                let id = db.create_subissue(parent_id, &format!("Child {}", i), None, "low").unwrap();
+                let id = db.create_subissue(parent_id, &format!("Child {i}"), None, "low").unwrap();
                 child_ids.push(id);
             }
 
@@ -2158,7 +2157,7 @@ mod proptest_tests {
             // Create issues
             let mut ids = Vec::new();
             for i in 0..issue_count {
-                let id = db.create_issue(&format!("Issue {}", i), None, "medium").unwrap();
+                let id = db.create_issue(&format!("Issue {i}"), None, "medium").unwrap();
                 ids.push(id);
             }
 
@@ -2217,7 +2216,7 @@ mod proptest_tests {
             let (db, _dir) = setup_test_db();
 
             // Create an issue with % and _ in title
-            let special_title = format!("{}%test_marker{}", prefix, suffix);
+            let special_title = format!("{prefix}%test_marker{suffix}");
             db.create_issue(&special_title, None, "medium").unwrap();
 
             // Create another issue that would match if wildcards weren't escaped

--- a/crosslink/src/events.rs
+++ b/crosslink/src/events.rs
@@ -949,7 +949,7 @@ mod tests {
         let public_key = public_key.trim();
         let signers_path = dir.path().join("allowed_signers");
         let principal = "test-agent@crosslink".to_string();
-        std::fs::write(&signers_path, format!("{} {}\n", principal, public_key)).unwrap();
+        std::fs::write(&signers_path, format!("{principal} {public_key}\n")).unwrap();
 
         // Verify the signature
         let verified = verify_event_signature(&envelope, &signers_path).unwrap();
@@ -991,7 +991,7 @@ mod tests {
         let signers_path = dir.path().join("allowed_signers");
         std::fs::write(
             &signers_path,
-            format!("test-agent@crosslink {}\n", public_key),
+            format!("test-agent@crosslink {public_key}\n"),
         )
         .unwrap();
 
@@ -1004,9 +1004,8 @@ mod tests {
         let result = verify_event_signature(&envelope, &signers_path);
         // Either Ok(false) or an Err — either way the signature is not valid
         match result {
-            Ok(false) => {} // expected
+            Ok(false) | Err(_) => {} // expected — invalid sig or ssh-keygen error
             Ok(true) => panic!("Should not verify a garbage signature"),
-            Err(_) => {} // also acceptable — ssh-keygen may error on garbage input
         }
     }
 

--- a/crosslink/src/external.rs
+++ b/crosslink/src/external.rs
@@ -805,7 +805,7 @@ mod tests {
         let result = resolve_repo_inner(repo_path.to_str().unwrap());
         match result {
             RepoSource::Local(p) => assert_eq!(p, repo_path),
-            _ => panic!("Expected Local variant"),
+            RepoSource::Remote(_) => panic!("Expected Local variant"),
         }
     }
 
@@ -814,7 +814,7 @@ mod tests {
         let result = resolve_repo_inner("https://github.com/org/repo");
         match result {
             RepoSource::Remote(url) => assert_eq!(url, "https://github.com/org/repo"),
-            _ => panic!("Expected Remote variant"),
+            RepoSource::Local(_) => panic!("Expected Remote variant"),
         }
     }
 
@@ -823,7 +823,7 @@ mod tests {
         let result = resolve_repo_inner("github.com/org/repo");
         match result {
             RepoSource::Remote(url) => assert_eq!(url, "github.com/org/repo"),
-            _ => panic!("Expected Remote variant"),
+            RepoSource::Local(_) => panic!("Expected Remote variant"),
         }
     }
 
@@ -918,7 +918,7 @@ mod tests {
             .iter()
             .enumerate()
         {
-            let uuid = format!("00000000-0000-0000-0000-{:012}", i);
+            let uuid = format!("00000000-0000-0000-0000-{i:012}");
             let issue = serde_json::json!({
                 "uuid": uuid,
                 "display_id": i as i64 + 1,

--- a/crosslink/src/findings.rs
+++ b/crosslink/src/findings.rs
@@ -583,7 +583,7 @@ mod tests {
     #[test]
     fn consolidation_severity_boost_three_agents() {
         // Three agents report the same Medium finding → should boost to High.
-        let findings: Vec<Finding> = (1..=3)
+        let reports: Vec<ReviewReport> = (1..=3)
             .map(|i| {
                 make_finding(
                     "Hardcoded secret",
@@ -593,10 +593,6 @@ mod tests {
                     &format!("agent-{i}"),
                 )
             })
-            .collect();
-
-        let reports: Vec<ReviewReport> = findings
-            .into_iter()
             .map(|f| {
                 let agent = f.agent.clone();
                 make_report(&agent, vec![f])
@@ -649,7 +645,7 @@ mod tests {
 
     #[test]
     fn consolidation_critical_stays_critical_on_boost() {
-        let findings: Vec<Finding> = (1..=3)
+        let reports: Vec<ReviewReport> = (1..=3)
             .map(|i| {
                 make_finding(
                     "RCE via deserialization",
@@ -659,10 +655,6 @@ mod tests {
                     &format!("agent-{i}"),
                 )
             })
-            .collect();
-
-        let reports: Vec<ReviewReport> = findings
-            .into_iter()
             .map(|f| {
                 let agent = f.agent.clone();
                 make_report(&agent, vec![f])
@@ -698,10 +690,7 @@ mod tests {
             "agent-1",
         );
 
-        let reports = vec![make_report(
-            "agent-1",
-            vec![low.clone(), critical.clone(), high.clone()],
-        )];
+        let reports = vec![make_report("agent-1", vec![low, critical, high])];
 
         let consolidated = consolidate(reports);
         let severities: Vec<FindingSeverity> = consolidated

--- a/crosslink/src/hydration.rs
+++ b/crosslink/src/hydration.rs
@@ -908,7 +908,7 @@ mod tests {
         let issue_b = make_issue(2, "Blocker issue");
 
         // issue_a is blocked by issue_b
-        let mut issue_a_with_dep = issue_a.clone();
+        let mut issue_a_with_dep = issue_a;
         issue_a_with_dep.blockers = vec![issue_b.uuid];
 
         write_issues_to_cache(cache.path(), &[issue_a_with_dep, issue_b]);
@@ -945,7 +945,7 @@ mod tests {
         let issue_a = make_issue(1, "Issue A");
         let issue_b = make_issue(2, "Issue B");
 
-        let mut issue_a_related = issue_a.clone();
+        let mut issue_a_related = issue_a;
         issue_a_related.related = vec![issue_b.uuid];
 
         write_issues_to_cache(cache.path(), &[issue_a_related, issue_b]);
@@ -1057,7 +1057,7 @@ mod tests {
             created_at: Utc::now(),
             closed_at: None,
         };
-        crate::issue_file::write_milestone_file(&ms_dir.join(format!("{}.json", ms_uuid)), &entry)
+        crate::issue_file::write_milestone_file(&ms_dir.join(format!("{ms_uuid}.json")), &entry)
             .unwrap();
 
         let stats = hydrate_to_sqlite(cache.path(), &db).unwrap();
@@ -1334,7 +1334,7 @@ mod tests {
             created_at: Utc::now(),
             closed_at: None,
         };
-        crate::issue_file::write_milestone_file(&ms_dir.join(format!("{}.json", ms_uuid)), &entry)
+        crate::issue_file::write_milestone_file(&ms_dir.join(format!("{ms_uuid}.json")), &entry)
             .unwrap();
 
         let stats = hydrate_to_sqlite(cache.path(), &db).unwrap();
@@ -1384,7 +1384,7 @@ mod tests {
             created_at: Utc::now(),
             closed_at: Some(Utc::now()),
         };
-        crate::issue_file::write_milestone_file(&ms_dir.join(format!("{}.json", ms_uuid)), &entry)
+        crate::issue_file::write_milestone_file(&ms_dir.join(format!("{ms_uuid}.json")), &entry)
             .unwrap();
 
         let stats = hydrate_to_sqlite(cache.path(), &db).unwrap();
@@ -1425,7 +1425,7 @@ mod tests {
             signed_by: None,
             signature: None,
         };
-        write_comment_file(&comments_dir.join(format!("{}.json", comment_uuid)), &cf).unwrap();
+        write_comment_file(&comments_dir.join(format!("{comment_uuid}.json")), &cf).unwrap();
 
         // Write layout version 2
         let meta_dir = cache.path().join("meta");
@@ -1468,7 +1468,7 @@ mod tests {
             signed_by: Some("SHA256:abc123".to_string()),
             signature: Some("base64sig==".to_string()),
         };
-        write_comment_file(&comments_dir.join(format!("{}.json", comment_uuid)), &cf).unwrap();
+        write_comment_file(&comments_dir.join(format!("{comment_uuid}.json")), &cf).unwrap();
 
         let meta_dir = cache.path().join("meta");
         write_layout_version(&meta_dir, 2).unwrap();
@@ -1628,13 +1628,12 @@ mod tests {
             .join("comments");
         let entries: Vec<_> = std::fs::read_dir(&comments_dir)
             .unwrap()
-            .filter_map(|e| e.ok())
+            .filter_map(std::result::Result::ok)
             .filter(|e| {
                 e.path()
                     .extension()
                     .and_then(|x| x.to_str())
-                    .map(|x| x == "json")
-                    .unwrap_or(false)
+                    .is_some_and(|x| x == "json")
             })
             .collect();
         assert_eq!(entries.len(), 2);
@@ -1671,13 +1670,12 @@ mod tests {
             .join("comments");
         let json_path = std::fs::read_dir(&comments_dir)
             .unwrap()
-            .filter_map(|e| e.ok())
+            .filter_map(std::result::Result::ok)
             .find(|e| {
                 e.path()
                     .extension()
                     .and_then(|x| x.to_str())
-                    .map(|x| x == "json")
-                    .unwrap_or(false)
+                    .is_some_and(|x| x == "json")
             })
             .unwrap()
             .path();

--- a/crosslink/src/identity.rs
+++ b/crosslink/src/identity.rs
@@ -184,7 +184,7 @@ mod tests {
         assert!(config.description.is_none());
     }
 
-    /// Helper to build a minimal AgentConfig for tests.
+    /// Helper to build a minimal `AgentConfig` for tests.
     fn test_config(agent_id: &str) -> AgentConfig {
         AgentConfig {
             agent_id: agent_id.to_string(),
@@ -227,7 +227,7 @@ mod tests {
     #[test]
     fn test_validate_valid_ids() {
         for id in &["worker-1", "agent_2", "MyAgent", "abc", "test-agent-42"] {
-            assert!(test_config(id).validate().is_ok(), "Failed for id: {}", id);
+            assert!(test_config(id).validate().is_ok(), "Failed for id: {id}");
         }
     }
 
@@ -235,13 +235,12 @@ mod tests {
     fn test_validate_rejects_windows_reserved_names() {
         for id in &["CON", "con", "PRN", "AUX", "NUL", "COM1", "LPT1"] {
             let err = test_config(id).validate();
-            assert!(err.is_err(), "Should reject Windows reserved name: {}", id);
+            assert!(err.is_err(), "Should reject Windows reserved name: {id}");
             assert!(
                 err.unwrap_err()
                     .to_string()
                     .contains("Windows reserved filename"),
-                "Error message should mention Windows reserved filename for: {}",
-                id
+                "Error message should mention Windows reserved filename for: {id}"
             );
         }
     }

--- a/crosslink/src/issue_filing.rs
+++ b/crosslink/src/issue_filing.rs
@@ -444,8 +444,7 @@ mod tests {
             let tmpl = build_issue_template(&make_finding(sev));
             assert!(
                 tmpl.labels.contains(&"review-finding".to_string()),
-                "missing review-finding label for severity {}",
-                sev
+                "missing review-finding label for severity {sev}"
             );
         }
     }
@@ -613,34 +612,42 @@ mod tests {
 
     #[test]
     fn jaccard_identical_sets_returns_one() {
-        let a: HashSet<String> = ["foo", "bar"].iter().map(|s| s.to_string()).collect();
+        let a: HashSet<String> = ["foo", "bar"]
+            .iter()
+            .map(std::string::ToString::to_string)
+            .collect();
         let b = a.clone();
         assert!((jaccard(&a, &b) - 1.0).abs() < f64::EPSILON);
     }
 
     #[test]
     fn jaccard_disjoint_sets_returns_zero() {
-        let a: HashSet<String> = ["foo"].iter().map(|s| s.to_string()).collect();
-        let b: HashSet<String> = ["bar"].iter().map(|s| s.to_string()).collect();
+        let a: HashSet<String> = std::iter::once("foo".to_string()).collect();
+        let b: HashSet<String> = std::iter::once("bar".to_string()).collect();
         assert!((jaccard(&a, &b)).abs() < f64::EPSILON);
     }
 
     #[test]
     fn jaccard_partial_overlap() {
-        let a: HashSet<String> = ["a", "b", "c"].iter().map(|s| s.to_string()).collect();
-        let b: HashSet<String> = ["b", "c", "d"].iter().map(|s| s.to_string()).collect();
+        let a: HashSet<String> = ["a", "b", "c"]
+            .iter()
+            .map(std::string::ToString::to_string)
+            .collect();
+        let b: HashSet<String> = ["b", "c", "d"]
+            .iter()
+            .map(std::string::ToString::to_string)
+            .collect();
         // intersection = {b,c} = 2, union = {a,b,c,d} = 4 => 0.5
         let score = jaccard(&a, &b);
         assert!(
             (score - 0.5).abs() < f64::EPSILON,
-            "expected 0.5 got {}",
-            score
+            "expected 0.5 got {score}"
         );
     }
 
     #[test]
     fn jaccard_one_empty_returns_zero() {
-        let a: HashSet<String> = ["foo"].iter().map(|s| s.to_string()).collect();
+        let a: HashSet<String> = std::iter::once("foo".to_string()).collect();
         let b: HashSet<String> = HashSet::new();
         assert!((jaccard(&a, &b)).abs() < f64::EPSILON);
     }
@@ -732,7 +739,7 @@ mod tests {
         let findings: Vec<FindingForFiling> = ["critical", "high", "medium", "low", "info"]
             .iter()
             .map(|sev| FindingForFiling {
-                title: format!("Finding for {}", sev),
+                title: format!("Finding for {sev}"),
                 severity: sev.to_string(),
                 file: "src/lib.rs".to_string(),
                 line: None,
@@ -859,7 +866,7 @@ mod tests {
         let cloned = tmpl.clone();
         assert_eq!(cloned.title, tmpl.title);
         // Debug formatting should not panic
-        let _ = format!("{:?}", tmpl);
+        let _ = format!("{tmpl:?}");
     }
 
     #[test]
@@ -867,7 +874,7 @@ mod tests {
         let f = make_finding("medium");
         let cloned = f.clone();
         assert_eq!(cloned.severity, f.severity);
-        let _ = format!("{:?}", f);
+        let _ = format!("{f:?}");
     }
 
     #[test]
@@ -879,7 +886,7 @@ mod tests {
         };
         let cloned = issue.clone();
         assert_eq!(cloned.number, issue.number);
-        let _ = format!("{:?}", issue);
+        let _ = format!("{issue:?}");
     }
 
     #[test]
@@ -890,7 +897,7 @@ mod tests {
         };
         let cloned = s.clone();
         assert_eq!(cloned.reason, s.reason);
-        let _ = format!("{:?}", s);
+        let _ = format!("{s:?}");
     }
 
     #[test]
@@ -901,7 +908,7 @@ mod tests {
         };
         let cloned = r.clone();
         assert_eq!(cloned.filed.len(), 0);
-        let _ = format!("{:?}", r);
+        let _ = format!("{r:?}");
     }
 
     // -- file_issues non-dry-run with empty findings (covers line 251, 295) --
@@ -1001,7 +1008,7 @@ mod tests {
     fn jaccard_one_non_empty_one_empty_does_not_divide_by_zero() {
         // When exactly one set is non-empty, union > 0 so the `if union == 0`
         // guard on line 139 is false; intersection is 0; result is 0.
-        let a: HashSet<String> = ["only"].iter().map(|s| s.to_string()).collect();
+        let a: HashSet<String> = std::iter::once("only".to_string()).collect();
         let b: HashSet<String> = HashSet::new();
         let score = jaccard(&a, &b);
         assert!((score).abs() < f64::EPSILON);

--- a/crosslink/src/knowledge/tests.rs
+++ b/crosslink/src/knowledge/tests.rs
@@ -407,7 +407,7 @@ fn test_write_page_without_init_fails() {
 
 // --- Search tests ---
 
-/// Helper: create a KnowledgeManager with pre-populated pages.
+/// Helper: create a `KnowledgeManager` with pre-populated pages.
 fn setup_search_manager(pages: &[(&str, &str)]) -> (tempfile::TempDir, KnowledgeManager) {
     let dir = tempdir().unwrap();
     let crosslink_dir = dir.path().join(".crosslink");
@@ -602,13 +602,11 @@ fn test_safe_page_path_rejects_windows_reserved_names() {
         let result = manager.safe_page_path(name);
         assert!(
             result.is_err(),
-            "Should reject Windows reserved name: {}",
-            name
+            "Should reject Windows reserved name: {name}"
         );
         assert!(
             result.unwrap_err().to_string().contains("Windows reserved"),
-            "Error should mention Windows reserved for: {}",
-            name
+            "Error should mention Windows reserved for: {name}"
         );
     }
 }
@@ -1832,7 +1830,7 @@ fn test_page_frontmatter_clone_and_debug() {
     };
     let cloned = fm.clone();
     assert_eq!(cloned, fm);
-    let debug_str = format!("{:?}", fm);
+    let debug_str = format!("{fm:?}");
     assert!(debug_str.contains("Clone Test"));
 }
 
@@ -1845,7 +1843,7 @@ fn test_source_clone_and_debug() {
     };
     let cloned = src.clone();
     assert_eq!(cloned, src);
-    let debug_str = format!("{:?}", src);
+    let debug_str = format!("{src:?}");
     assert!(debug_str.contains("example.com"));
 }
 
@@ -1856,7 +1854,7 @@ fn test_search_match_debug() {
         line_number: 5,
         context_lines: vec![(5, "hello".to_string())],
     };
-    let debug_str = format!("{:?}", m);
+    let debug_str = format!("{m:?}");
     assert!(debug_str.contains("test"));
 }
 
@@ -1873,7 +1871,7 @@ fn test_page_info_debug() {
             updated: String::new(),
         },
     };
-    let debug_str = format!("{:?}", info);
+    let debug_str = format!("{info:?}");
     assert!(debug_str.contains("test-slug"));
 }
 
@@ -1882,7 +1880,7 @@ fn test_sync_outcome_debug() {
     let outcome = SyncOutcome {
         resolved_conflicts: vec!["page-a".to_string()],
     };
-    let debug_str = format!("{:?}", outcome);
+    let debug_str = format!("{outcome:?}");
     assert!(debug_str.contains("page-a"));
 }
 
@@ -3009,7 +3007,7 @@ fn test_handle_rebase_conflict_merge_succeeds() {
         .output()
         .unwrap();
 
-    let remote_ref = format!("origin/{}", KNOWLEDGE_BRANCH);
+    let remote_ref = format!("origin/{KNOWLEDGE_BRANCH}");
     let manager = KnowledgeManager::new(&crosslink_dir).unwrap();
     let result = manager.handle_rebase_conflict(&remote_ref);
     assert!(result.is_ok());
@@ -3097,7 +3095,7 @@ fn test_handle_rebase_conflict_with_md_conflicts() {
         .output()
         .unwrap();
 
-    let remote_ref = format!("origin/{}", KNOWLEDGE_BRANCH);
+    let remote_ref = format!("origin/{KNOWLEDGE_BRANCH}");
     let manager = KnowledgeManager::new(&crosslink_dir).unwrap();
 
     let result = manager.handle_rebase_conflict(&remote_ref);
@@ -3510,8 +3508,7 @@ fn test_init_cache_from_existing_remote_knowledge_branch() {
     let result = mgr2.init_cache();
     assert!(
         result.is_ok(),
-        "init_cache from remote should succeed: {:?}",
-        result
+        "init_cache from remote should succeed: {result:?}"
     );
     assert!(mgr2.is_initialized());
 }

--- a/crosslink/src/lock_check.rs
+++ b/crosslink/src/lock_check.rs
@@ -331,7 +331,7 @@ mod tests {
         Database::open(std::path::Path::new(":memory:")).unwrap()
     }
 
-    /// Write a minimal agent.json to crosslink_dir so AgentConfig::load succeeds.
+    /// Write a minimal agent.json to `crosslink_dir` so `AgentConfig::load` succeeds.
     fn write_agent_config(crosslink_dir: &Path, agent_id: &str) {
         let agent_json = serde_json::json!({
             "agent_id": agent_id,
@@ -392,7 +392,7 @@ mod tests {
             },
         ];
         for s in statuses {
-            let _ = format!("{:?}", s);
+            let _ = format!("{s:?}");
         }
     }
 
@@ -438,7 +438,7 @@ mod tests {
     // ─── check_lock with agent config but no git cache ────────────────────────
 
     /// When agent.json is present but the hub cache directory does not exist
-    /// (no git remote), check_lock must return NotConfigured to stay non-blocking.
+    /// (no git remote), `check_lock` must return `NotConfigured` to stay non-blocking.
     #[test]
     fn test_check_lock_agent_config_no_cache_returns_not_configured() {
         let dir = tempdir().unwrap();
@@ -451,7 +451,7 @@ mod tests {
         assert_eq!(status, LockStatus::NotConfigured);
     }
 
-    /// enforce_lock with an agent config but no hub cache must succeed (non-blocking).
+    /// `enforce_lock` with an agent config but no hub cache must succeed (non-blocking).
     #[test]
     fn test_enforce_lock_agent_config_no_cache_allows() {
         let dir = tempdir().unwrap();
@@ -512,7 +512,7 @@ mod tests {
     #[test]
     fn test_auto_steal_config_missing_key() {
         let dir = tempdir().unwrap();
-        std::fs::write(dir.path().join("hook-config.json"), r#"{}"#).unwrap();
+        std::fs::write(dir.path().join("hook-config.json"), r"{}").unwrap();
         assert_eq!(read_auto_steal_config(dir.path()), None);
     }
 
@@ -631,7 +631,7 @@ mod tests {
 
     // ─── auto_steal_if_configured direct tests ────────────────────────────────
 
-    /// When no hook-config.json is present, auto_steal returns Ok(false) immediately.
+    /// When no hook-config.json is present, `auto_steal` returns Ok(false) immediately.
     #[test]
     fn test_auto_steal_no_config_returns_false() {
         let dir = tempdir().unwrap();
@@ -643,7 +643,7 @@ mod tests {
         assert!(!result.unwrap());
     }
 
-    /// When config is disabled (false), auto_steal returns Ok(false).
+    /// When config is disabled (false), `auto_steal` returns Ok(false).
     #[test]
     fn test_auto_steal_disabled_config_returns_false() {
         let dir = tempdir().unwrap();
@@ -660,7 +660,7 @@ mod tests {
         assert!(!result.unwrap());
     }
 
-    /// When multiplier > 0 but hub cache doesn't exist, auto_steal returns Ok(false).
+    /// When multiplier > 0 but hub cache doesn't exist, `auto_steal` returns Ok(false).
     #[test]
     fn test_auto_steal_config_enabled_but_no_cache_returns_false() {
         let dir = tempdir().unwrap();
@@ -681,13 +681,13 @@ mod tests {
 
     // ─── enforce_lock: LockedByOther (non-stale) → error ─────────────────────
 
-    /// enforce_lock must return an error when the lock is held by another agent
+    /// `enforce_lock` must return an error when the lock is held by another agent
     /// and the lock is not stale. We exercise this by building a fake hub cache
     /// directory containing a locks.json with a lock entry and an agent.json that
     /// identifies us as a *different* agent.
     ///
-    /// We use a real git repo so that SyncManager, is_initialized, and
-    /// read_locks_auto all succeed and return the prepared lock data.
+    /// We use a real git repo so that `SyncManager`, `is_initialized`, and
+    /// `read_locks_auto` all succeed and return the prepared lock data.
     #[test]
     fn test_enforce_lock_locked_by_other_non_stale_returns_error() {
         let dir = tempdir().unwrap();
@@ -757,13 +757,12 @@ mod tests {
         let msg = result.unwrap_err().to_string();
         assert!(
             msg.contains("other-agent"),
-            "error should name the holder: {}",
-            msg
+            "error should name the holder: {msg}"
         );
-        assert!(msg.contains("7"), "error should name the issue id: {}", msg);
+        assert!(msg.contains('7'), "error should name the issue id: {msg}");
     }
 
-    /// enforce_lock with a stale lock and no auto-steal config must still succeed
+    /// `enforce_lock` with a stale lock and no auto-steal config must still succeed
     /// (it prints a warning and proceeds).
     #[test]
     fn test_enforce_lock_locked_by_other_stale_no_auto_steal_proceeds() {
@@ -823,21 +822,20 @@ mod tests {
         .unwrap();
 
         // No auto_steal_stale_locks in hook-config → auto_steal returns Ok(false)
-        std::fs::write(crosslink_dir.join("hook-config.json"), r#"{}"#).unwrap();
+        std::fs::write(crosslink_dir.join("hook-config.json"), r"{}").unwrap();
 
         let db = temp_db();
         // Stale lock + no auto-steal → warning printed, Ok(()) returned
         let result = enforce_lock(&crosslink_dir, 8, &db);
         assert!(
             result.is_ok(),
-            "stale lock without auto-steal should proceed: {:?}",
-            result
+            "stale lock without auto-steal should proceed: {result:?}"
         );
     }
 
     // ─── enforce_lock: LockedBySelf / Available via agent + git setup ─────────
 
-    /// When the agent holds the lock itself, enforce_lock succeeds.
+    /// When the agent holds the lock itself, `enforce_lock` succeeds.
     #[test]
     fn test_enforce_lock_locked_by_self_succeeds() {
         let dir = tempdir().unwrap();
@@ -885,7 +883,7 @@ mod tests {
         assert!(enforce_lock(&crosslink_dir, 9, &db).is_ok());
     }
 
-    /// When the issue has no lock entry, enforce_lock returns Ok(()) (Available).
+    /// When the issue has no lock entry, `enforce_lock` returns Ok(()) (Available).
     #[test]
     fn test_enforce_lock_available_succeeds() {
         let dir = tempdir().unwrap();
@@ -926,7 +924,7 @@ mod tests {
 
     // ─── check_lock: LockedBySelf / Available / LockedByOther via fake cache ──
 
-    /// check_lock returns LockedBySelf when the current agent holds the lock.
+    /// `check_lock` returns `LockedBySelf` when the current agent holds the lock.
     #[test]
     fn test_check_lock_locked_by_self() {
         let dir = tempdir().unwrap();
@@ -970,7 +968,7 @@ mod tests {
         assert_eq!(status, LockStatus::LockedBySelf);
     }
 
-    /// check_lock returns Available when no lock exists for the issue.
+    /// `check_lock` returns Available when no lock exists for the issue.
     #[test]
     fn test_check_lock_available() {
         let dir = tempdir().unwrap();
@@ -1007,7 +1005,7 @@ mod tests {
         assert_eq!(status, LockStatus::Available);
     }
 
-    /// check_lock returns LockedByOther (non-stale) when a different agent holds the
+    /// `check_lock` returns `LockedByOther` (non-stale) when a different agent holds the
     /// lock and has a recent heartbeat.
     #[test]
     fn test_check_lock_locked_by_other_non_stale() {
@@ -1070,11 +1068,11 @@ mod tests {
                 assert_eq!(agent_id, "other-agent");
                 assert!(!stale);
             }
-            other => panic!("Expected LockedByOther, got {:?}", other),
+            other => panic!("Expected LockedByOther, got {other:?}"),
         }
     }
 
-    /// check_lock returns LockedByOther with stale=true when the heartbeat is old.
+    /// `check_lock` returns `LockedByOther` with stale=true when the heartbeat is old.
     #[test]
     fn test_check_lock_locked_by_other_stale() {
         let dir = tempdir().unwrap();
@@ -1138,7 +1136,7 @@ mod tests {
                 // what matters is that we get LockedByOther (not a panic/error).
                 let _ = stale;
             }
-            other => panic!("Expected LockedByOther, got {:?}", other),
+            other => panic!("Expected LockedByOther, got {other:?}"),
         }
     }
 
@@ -1299,15 +1297,14 @@ mod tests {
         let result = enforce_lock(&crosslink_dir, 60, &db);
         assert!(
             result.is_ok(),
-            "enforce_lock should proceed even when auto-steal errors: {:?}",
-            result
+            "enforce_lock should proceed even when auto-steal errors: {result:?}"
         );
     }
 
     // ─── Requested test names from task spec ──────────────────────────────────
 
-    /// check_lock with a non-existent crosslink dir (no parent → SyncManager fails).
-    /// Exercises line 36: `SyncManager::new` returns Err → NotConfigured.
+    /// `check_lock` with a non-existent crosslink dir (no parent → `SyncManager` fails).
+    /// Exercises line 36: `SyncManager::new` returns Err → `NotConfigured`.
     #[test]
     fn test_check_lock_no_crosslink_dir() {
         // A crosslink_dir that is the filesystem root has no parent,
@@ -1370,7 +1367,7 @@ mod tests {
         // The important thing is it does not panic.
         match result {
             Ok(LockStatus::NotConfigured) | Err(_) => {}
-            Ok(other) => panic!("unexpected status: {:?}", other),
+            Ok(other) => panic!("unexpected status: {other:?}"),
         }
     }
 
@@ -1433,7 +1430,7 @@ mod tests {
         assert_eq!(read_auto_steal_config(dir.path()), None);
     }
 
-    /// check_lock returns NotConfigured when `read_locks_auto` would fail
+    /// `check_lock` returns `NotConfigured` when `read_locks_auto` would fail
     /// due to a corrupt locks.json (exercises line 50).
     #[test]
     fn test_check_lock_corrupt_locks_json_returns_not_configured() {

--- a/crosslink/src/main.rs
+++ b/crosslink/src/main.rs
@@ -1817,6 +1817,12 @@ pub enum SentinelCommands {
         #[arg(long)]
         json: bool,
     },
+    /// Analyze dispatch history for recurring patterns and hotspots
+    Patterns {
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
     /// Internal: run the sentinel watch loop (used by watch)
     #[command(hide = true)]
     RunDaemon {

--- a/crosslink/src/main.rs
+++ b/crosslink/src/main.rs
@@ -327,6 +327,11 @@ enum Commands {
         #[command(subcommand)]
         action: SwarmCommands,
     },
+    /// Autonomous maintenance sentinel (monitors sources, dispatches agents)
+    Sentinel {
+        #[command(subcommand)]
+        action: SentinelCommands,
+    },
     /// Interactive terminal dashboard (read-only)
     Tui,
     /// Mission control: tmux dashboard showing all active agents
@@ -1776,6 +1781,38 @@ enum SwarmCommands {
     },
 }
 
+#[derive(Subcommand)]
+pub enum SentinelCommands {
+    /// One-shot sentinel sweep
+    Run {
+        /// Print what would be dispatched without acting
+        #[arg(long)]
+        dry_run: bool,
+        /// Only process signals matching this label
+        #[arg(long)]
+        label: Option<String>,
+    },
+    /// Start persistent sentinel daemon
+    Watch {
+        /// Poll interval in minutes
+        #[arg(long, default_value = "10")]
+        interval: u64,
+    },
+    /// Show sentinel daemon status and in-flight agents
+    Status,
+    /// Show past sentinel runs and outcomes
+    History {
+        /// Maximum number of runs to show
+        #[arg(long, default_value = "10")]
+        limit: usize,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Stop the sentinel daemon
+    Stop,
+}
+
 #[derive(Subcommand, Clone, Copy)]
 enum ContextCommands {
     /// Measure context injection sizes and estimate token overhead
@@ -2854,6 +2891,19 @@ fn main() -> Result<()> {
                     commands::swarm::trust_init(&crosslink_dir, &model)
                 }
             }
+        }
+        Commands::Sentinel { action } => {
+            let crosslink_dir = find_crosslink_dir()?;
+            let db = get_db()?;
+            let writer = get_writer(&crosslink_dir);
+            commands::sentinel::dispatch_cmd(
+                action,
+                &crosslink_dir,
+                &db,
+                writer.as_ref(),
+                cli.quiet,
+                cli.json,
+            )
         }
         Commands::Tui => {
             let db = get_db()?;

--- a/crosslink/src/main.rs
+++ b/crosslink/src/main.rs
@@ -36,6 +36,11 @@
 #![allow(clippy::struct_excessive_bools, clippy::fn_params_excessive_bools)]
 // Option<&T> vs &Option<T>: both are valid depending on context.
 #![allow(clippy::ref_option)]
+// Large stack arrays in test code: `vec![...]` literals expand to array literals
+// internally, and clippy can't trace the span back through macro expansion to
+// suggest a fix. Test code where stack frame size doesn't matter for production.
+// See https://github.com/rust-lang/rust-clippy/issues for the underlying span bug.
+#![allow(clippy::large_stack_arrays)]
 
 mod checkpoint;
 mod clock_skew;

--- a/crosslink/src/main.rs
+++ b/crosslink/src/main.rs
@@ -1805,6 +1805,9 @@ pub enum SentinelCommands {
         /// Maximum number of runs to show
         #[arg(long, default_value = "10")]
         limit: usize,
+        /// Show per-dispatch details for each run
+        #[arg(long)]
+        detail: bool,
         /// Output as JSON
         #[arg(long)]
         json: bool,

--- a/crosslink/src/main.rs
+++ b/crosslink/src/main.rs
@@ -1811,6 +1811,14 @@ pub enum SentinelCommands {
     },
     /// Stop the sentinel daemon
     Stop,
+    /// Internal: run the sentinel watch loop (used by watch)
+    #[command(hide = true)]
+    RunDaemon {
+        #[arg(long)]
+        dir: std::path::PathBuf,
+        #[arg(long, default_value = "10")]
+        interval: u64,
+    },
 }
 
 #[derive(Subcommand, Clone, Copy)]
@@ -2893,6 +2901,10 @@ fn main() -> Result<()> {
             }
         }
         Commands::Sentinel { action } => {
+            // RunDaemon is the internal loop entry point — dir is explicit, no auto-detection
+            if let SentinelCommands::RunDaemon { ref dir, interval } = action {
+                return commands::sentinel::watch::run_watch_loop(dir, interval);
+            }
             let crosslink_dir = find_crosslink_dir()?;
             let db = get_db()?;
             let writer = get_writer(&crosslink_dir);

--- a/crosslink/src/main.rs
+++ b/crosslink/src/main.rs
@@ -1811,6 +1811,12 @@ pub enum SentinelCommands {
     },
     /// Stop the sentinel daemon
     Stop,
+    /// Show dispatch success rates per model and rule
+    Metrics {
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
     /// Internal: run the sentinel watch loop (used by watch)
     #[command(hide = true)]
     RunDaemon {

--- a/crosslink/src/models.rs
+++ b/crosslink/src/models.rs
@@ -399,7 +399,7 @@ mod tests {
         let comment = Comment {
             id: 1,
             issue_id: 1,
-            content: "".to_string(),
+            content: String::new(),
             created_at: Utc::now(),
             kind: "note".to_string(),
             trigger_type: None,

--- a/crosslink/src/orchestrator/dag.rs
+++ b/crosslink/src/orchestrator/dag.rs
@@ -548,9 +548,9 @@ mod tests {
     fn make_node(id: &str, phase: &str, deps: &[&str]) -> DagNode {
         DagNode {
             id: id.to_string(),
-            title: format!("Stage {}", id),
+            title: format!("Stage {id}"),
             status: StageStatus::Pending,
-            depends_on: deps.iter().map(|d| d.to_string()).collect(),
+            depends_on: deps.iter().map(std::string::ToString::to_string).collect(),
             issue_id: None,
             agent_id: None,
             phase_id: phase.to_string(),
@@ -563,13 +563,13 @@ mod tests {
         assert!(dag.is_empty());
         assert_eq!(dag.len(), 0);
         assert!(dag.is_complete());
-        assert_eq!(dag.progress(), 1.0);
+        assert!((dag.progress() - 1.0).abs() < f64::EPSILON);
         assert!(dag.ready_nodes().is_empty());
     }
 
     #[test]
     fn test_single_node_no_deps() {
-        let dag = Dag::from_nodes(&vec![make_node("a", "p1", &[])]).unwrap();
+        let dag = Dag::from_nodes(&[make_node("a", "p1", &[])]).unwrap();
         assert_eq!(dag.len(), 1);
         assert_eq!(dag.ready_nodes(), vec!["a"]);
         assert!(!dag.is_complete());
@@ -577,7 +577,7 @@ mod tests {
 
     #[test]
     fn test_linear_chain() {
-        let dag = Dag::from_nodes(&vec![
+        let dag = Dag::from_nodes(&[
             make_node("a", "p1", &[]),
             make_node("b", "p1", &["a"]),
             make_node("c", "p1", &["b"]),
@@ -590,7 +590,7 @@ mod tests {
 
     #[test]
     fn test_diamond_dag() {
-        let dag = Dag::from_nodes(&vec![
+        let dag = Dag::from_nodes(&[
             make_node("a", "p1", &[]),
             make_node("b", "p1", &["a"]),
             make_node("c", "p1", &["a"]),
@@ -610,36 +610,32 @@ mod tests {
 
     #[test]
     fn test_cycle_detection() {
-        let result = Dag::from_nodes(&vec![
-            make_node("a", "p1", &["b"]),
-            make_node("b", "p1", &["a"]),
-        ]);
+        let result = Dag::from_nodes(&[make_node("a", "p1", &["b"]), make_node("b", "p1", &["a"])]);
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string().to_lowercase();
         assert!(
             err_msg.contains("cycle"),
-            "Expected 'cycle' in error: {}",
-            err_msg
+            "Expected 'cycle' in error: {err_msg}"
         );
     }
 
     #[test]
     fn test_missing_dependency() {
-        let result = Dag::from_nodes(&vec![make_node("a", "p1", &["nonexistent"])]);
+        let result = Dag::from_nodes(&[make_node("a", "p1", &["nonexistent"])]);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("does not exist"));
     }
 
     #[test]
     fn test_duplicate_id() {
-        let result = Dag::from_nodes(&vec![make_node("a", "p1", &[]), make_node("a", "p1", &[])]);
+        let result = Dag::from_nodes(&[make_node("a", "p1", &[]), make_node("a", "p1", &[])]);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Duplicate"));
     }
 
     #[test]
     fn test_mark_running_and_done() {
-        let mut dag = Dag::from_nodes(&vec![
+        let mut dag = Dag::from_nodes(&[
             make_node("a", "p1", &[]),
             make_node("b", "p1", &["a"]),
             make_node("c", "p1", &["a"]),
@@ -666,11 +662,8 @@ mod tests {
 
     #[test]
     fn test_mark_failed() {
-        let mut dag = Dag::from_nodes(&vec![
-            make_node("a", "p1", &[]),
-            make_node("b", "p1", &["a"]),
-        ])
-        .unwrap();
+        let mut dag =
+            Dag::from_nodes(&[make_node("a", "p1", &[]), make_node("b", "p1", &["a"])]).unwrap();
 
         dag.mark_running("a", "agent-1").unwrap();
         dag.mark_failed("a").unwrap();
@@ -682,15 +675,15 @@ mod tests {
 
     #[test]
     fn test_mark_skipped() {
-        let mut dag = Dag::from_nodes(&vec![make_node("a", "p1", &[])]).unwrap();
+        let mut dag = Dag::from_nodes(&[make_node("a", "p1", &[])]).unwrap();
         dag.mark_skipped("a").unwrap();
         assert!(dag.is_complete());
-        assert_eq!(dag.progress(), 1.0);
+        assert!((dag.progress() - 1.0).abs() < f64::EPSILON);
     }
 
     #[test]
     fn test_progress_tracking() {
-        let mut dag = Dag::from_nodes(&vec![
+        let mut dag = Dag::from_nodes(&[
             make_node("a", "p1", &[]),
             make_node("b", "p1", &[]),
             make_node("c", "p1", &[]),
@@ -698,7 +691,7 @@ mod tests {
         ])
         .unwrap();
 
-        assert_eq!(dag.progress(), 0.0);
+        assert!(dag.progress() < f64::EPSILON);
 
         dag.mark_running("a", "agent-1").unwrap();
         dag.mark_done("a").unwrap();
@@ -711,27 +704,27 @@ mod tests {
 
     #[test]
     fn test_cannot_mark_done_if_not_running() {
-        let mut dag = Dag::from_nodes(&vec![make_node("a", "p1", &[])]).unwrap();
+        let mut dag = Dag::from_nodes(&[make_node("a", "p1", &[])]).unwrap();
         assert!(dag.mark_done("a").is_err());
     }
 
     #[test]
     fn test_cannot_mark_running_if_not_pending() {
-        let mut dag = Dag::from_nodes(&vec![make_node("a", "p1", &[])]).unwrap();
+        let mut dag = Dag::from_nodes(&[make_node("a", "p1", &[])]).unwrap();
         dag.mark_running("a", "agent-1").unwrap();
         assert!(dag.mark_running("a", "agent-2").is_err());
     }
 
     #[test]
     fn test_set_issue_id() {
-        let mut dag = Dag::from_nodes(&vec![make_node("a", "p1", &[])]).unwrap();
+        let mut dag = Dag::from_nodes(&[make_node("a", "p1", &[])]).unwrap();
         dag.set_issue_id("a", 42).unwrap();
         assert_eq!(dag.get("a").unwrap().issue_id, Some(42));
     }
 
     #[test]
     fn test_dependents_and_dependencies() {
-        let dag = Dag::from_nodes(&vec![
+        let dag = Dag::from_nodes(&[
             make_node("a", "p1", &[]),
             make_node("b", "p1", &["a"]),
             make_node("c", "p1", &["a"]),
@@ -747,7 +740,7 @@ mod tests {
 
     #[test]
     fn test_stages_by_phase() {
-        let dag = Dag::from_nodes(&vec![
+        let dag = Dag::from_nodes(&[
             make_node("a", "p1", &[]),
             make_node("b", "p1", &["a"]),
             make_node("c", "p2", &[]),
@@ -762,7 +755,7 @@ mod tests {
     #[test]
     fn test_status_and_agent_maps() {
         let mut dag =
-            Dag::from_nodes(&vec![make_node("a", "p1", &[]), make_node("b", "p1", &[])]).unwrap();
+            Dag::from_nodes(&[make_node("a", "p1", &[]), make_node("b", "p1", &[])]).unwrap();
 
         dag.mark_running("a", "agent-1").unwrap();
 
@@ -778,7 +771,7 @@ mod tests {
     #[test]
     fn test_complex_multi_phase_dag() {
         // Simulates the web dashboard phases: 1 → (2 || 3) → 4 → 6
-        let dag = Dag::from_nodes(&vec![
+        let dag = Dag::from_nodes(&[
             make_node("1a", "p1", &[]),
             make_node("1b", "p1", &[]),
             make_node("2a", "p2", &["1a", "1b"]),
@@ -805,11 +798,8 @@ mod tests {
 
     #[test]
     fn test_serialization_round_trip() {
-        let dag = Dag::from_nodes(&vec![
-            make_node("a", "p1", &[]),
-            make_node("b", "p1", &["a"]),
-        ])
-        .unwrap();
+        let dag =
+            Dag::from_nodes(&[make_node("a", "p1", &[]), make_node("b", "p1", &["a"])]).unwrap();
 
         let json = serde_json::to_string_pretty(&dag).unwrap();
         let restored: Dag = serde_json::from_str(&json).unwrap();
@@ -821,7 +811,7 @@ mod tests {
 
     #[test]
     fn test_three_node_cycle_detection() {
-        let result = Dag::from_nodes(&vec![
+        let result = Dag::from_nodes(&[
             make_node("a", "p1", &["c"]),
             make_node("b", "p1", &["a"]),
             make_node("c", "p1", &["b"]),
@@ -831,14 +821,14 @@ mod tests {
 
     #[test]
     fn test_self_loop_detection() {
-        let result = Dag::from_nodes(&vec![make_node("a", "p1", &["a"])]);
+        let result = Dag::from_nodes(&[make_node("a", "p1", &["a"])]);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_no_false_cycle_on_diamond() {
         // Diamond is NOT a cycle
-        let dag = Dag::from_nodes(&vec![
+        let dag = Dag::from_nodes(&[
             make_node("a", "p1", &[]),
             make_node("b", "p1", &["a"]),
             make_node("c", "p1", &["a"]),
@@ -851,7 +841,7 @@ mod tests {
     #[test]
     fn test_many_independent_nodes_all_ready() {
         let nodes: Vec<DagNode> = (0..10)
-            .map(|i| make_node(&format!("n{}", i), "p1", &[]))
+            .map(|i| make_node(&format!("n{i}"), "p1", &[]))
             .collect();
         let dag = Dag::from_nodes(&nodes).unwrap();
         assert_eq!(dag.ready_nodes().len(), 10);
@@ -866,19 +856,19 @@ mod tests {
 
     #[test]
     fn test_is_empty_false_with_nodes() {
-        let dag = Dag::from_nodes(&vec![make_node("a", "p1", &[])]).unwrap();
+        let dag = Dag::from_nodes(&[make_node("a", "p1", &[])]).unwrap();
         assert!(!dag.is_empty());
     }
 
     #[test]
     fn test_has_failures_false_when_clean() {
-        let dag = Dag::from_nodes(&vec![make_node("a", "p1", &[])]).unwrap();
+        let dag = Dag::from_nodes(&[make_node("a", "p1", &[])]).unwrap();
         assert!(!dag.has_failures());
     }
 
     #[test]
     fn test_nodes_with_status() {
-        let mut dag = Dag::from_nodes(&vec![
+        let mut dag = Dag::from_nodes(&[
             make_node("a", "p1", &[]),
             make_node("b", "p1", &[]),
             make_node("c", "p1", &[]),
@@ -906,7 +896,7 @@ mod tests {
 
     #[test]
     fn test_mark_running_nonexistent_node() {
-        let mut dag = Dag::from_nodes(&vec![make_node("a", "p1", &[])]).unwrap();
+        let mut dag = Dag::from_nodes(&[make_node("a", "p1", &[])]).unwrap();
         let result = dag.mark_running("nonexistent", "agent-1");
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("not found"));
@@ -914,7 +904,7 @@ mod tests {
 
     #[test]
     fn test_mark_done_nonexistent_node() {
-        let mut dag = Dag::from_nodes(&vec![make_node("a", "p1", &[])]).unwrap();
+        let mut dag = Dag::from_nodes(&[make_node("a", "p1", &[])]).unwrap();
         let result = dag.mark_done("nonexistent");
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("not found"));
@@ -922,7 +912,7 @@ mod tests {
 
     #[test]
     fn test_mark_failed_nonexistent_node() {
-        let mut dag = Dag::from_nodes(&vec![make_node("a", "p1", &[])]).unwrap();
+        let mut dag = Dag::from_nodes(&[make_node("a", "p1", &[])]).unwrap();
         let result = dag.mark_failed("nonexistent");
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("not found"));
@@ -930,7 +920,7 @@ mod tests {
 
     #[test]
     fn test_mark_skipped_nonexistent_node() {
-        let mut dag = Dag::from_nodes(&vec![make_node("a", "p1", &[])]).unwrap();
+        let mut dag = Dag::from_nodes(&[make_node("a", "p1", &[])]).unwrap();
         let result = dag.mark_skipped("nonexistent");
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("not found"));
@@ -938,7 +928,7 @@ mod tests {
 
     #[test]
     fn test_set_issue_id_nonexistent_node() {
-        let mut dag = Dag::from_nodes(&vec![make_node("a", "p1", &[])]).unwrap();
+        let mut dag = Dag::from_nodes(&[make_node("a", "p1", &[])]).unwrap();
         let result = dag.set_issue_id("nonexistent", 42);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("not found"));
@@ -946,40 +936,40 @@ mod tests {
 
     #[test]
     fn test_dependents_nonexistent_node() {
-        let dag = Dag::from_nodes(&vec![make_node("a", "p1", &[])]).unwrap();
+        let dag = Dag::from_nodes(&[make_node("a", "p1", &[])]).unwrap();
         assert!(dag.dependents("nonexistent").is_empty());
     }
 
     #[test]
     fn test_dependencies_nonexistent_node() {
-        let dag = Dag::from_nodes(&vec![make_node("a", "p1", &[])]).unwrap();
+        let dag = Dag::from_nodes(&[make_node("a", "p1", &[])]).unwrap();
         assert!(dag.dependencies("nonexistent").is_empty());
     }
 
     #[test]
     fn test_get_returns_none_for_missing() {
-        let dag = Dag::from_nodes(&vec![make_node("a", "p1", &[])]).unwrap();
+        let dag = Dag::from_nodes(&[make_node("a", "p1", &[])]).unwrap();
         assert!(dag.get("nonexistent").is_none());
         assert!(dag.get("a").is_some());
     }
 
     #[test]
     fn test_get_mut_returns_none_for_missing() {
-        let mut dag = Dag::from_nodes(&vec![make_node("a", "p1", &[])]).unwrap();
+        let mut dag = Dag::from_nodes(&[make_node("a", "p1", &[])]).unwrap();
         assert!(dag.get_mut("nonexistent").is_none());
         assert!(dag.get_mut("a").is_some());
     }
 
     #[test]
     fn test_get_mut_modifies_node() {
-        let mut dag = Dag::from_nodes(&vec![make_node("a", "p1", &[])]).unwrap();
+        let mut dag = Dag::from_nodes(&[make_node("a", "p1", &[])]).unwrap();
         dag.get_mut("a").unwrap().title = "Modified".to_string();
         assert_eq!(dag.get("a").unwrap().title, "Modified");
     }
 
     #[test]
     fn test_node_ids_returns_all_ids() {
-        let dag = Dag::from_nodes(&vec![
+        let dag = Dag::from_nodes(&[
             make_node("x", "p1", &[]),
             make_node("y", "p1", &[]),
             make_node("z", "p1", &[]),
@@ -992,8 +982,7 @@ mod tests {
 
     #[test]
     fn test_nodes_returns_all_nodes() {
-        let dag =
-            Dag::from_nodes(&vec![make_node("a", "p1", &[]), make_node("b", "p1", &[])]).unwrap();
+        let dag = Dag::from_nodes(&[make_node("a", "p1", &[]), make_node("b", "p1", &[])]).unwrap();
         let nodes = dag.nodes();
         assert_eq!(nodes.len(), 2);
         assert!(nodes.contains_key("a"));
@@ -1002,17 +991,14 @@ mod tests {
 
     #[test]
     fn test_running_nodes_empty_when_none_running() {
-        let dag = Dag::from_nodes(&vec![make_node("a", "p1", &[])]).unwrap();
+        let dag = Dag::from_nodes(&[make_node("a", "p1", &[])]).unwrap();
         assert!(dag.running_nodes().is_empty());
     }
 
     #[test]
     fn test_ready_nodes_blocked_by_running_dep() {
-        let mut dag = Dag::from_nodes(&vec![
-            make_node("a", "p1", &[]),
-            make_node("b", "p1", &["a"]),
-        ])
-        .unwrap();
+        let mut dag =
+            Dag::from_nodes(&[make_node("a", "p1", &[]), make_node("b", "p1", &["a"])]).unwrap();
 
         dag.mark_running("a", "agent-1").unwrap();
         // b should NOT be ready since a is running, not done
@@ -1021,11 +1007,8 @@ mod tests {
 
     #[test]
     fn test_ready_nodes_blocked_by_failed_dep() {
-        let mut dag = Dag::from_nodes(&vec![
-            make_node("a", "p1", &[]),
-            make_node("b", "p1", &["a"]),
-        ])
-        .unwrap();
+        let mut dag =
+            Dag::from_nodes(&[make_node("a", "p1", &[]), make_node("b", "p1", &["a"])]).unwrap();
 
         dag.mark_failed("a").unwrap();
         // b should NOT be ready since a is failed, not done
@@ -1034,7 +1017,7 @@ mod tests {
 
     #[test]
     fn test_mark_done_no_dependents_returns_empty() {
-        let mut dag = Dag::from_nodes(&vec![make_node("a", "p1", &[])]).unwrap();
+        let mut dag = Dag::from_nodes(&[make_node("a", "p1", &[])]).unwrap();
         dag.mark_running("a", "agent-1").unwrap();
         let unblocked = dag.mark_done("a").unwrap();
         assert!(unblocked.is_empty());
@@ -1042,11 +1025,8 @@ mod tests {
 
     #[test]
     fn test_mark_done_dependent_not_pending_not_unblocked() {
-        let mut dag = Dag::from_nodes(&vec![
-            make_node("a", "p1", &[]),
-            make_node("b", "p1", &["a"]),
-        ])
-        .unwrap();
+        let mut dag =
+            Dag::from_nodes(&[make_node("a", "p1", &[]), make_node("b", "p1", &["a"])]).unwrap();
 
         // Mark b as failed before a completes
         dag.mark_failed("b").unwrap();
@@ -1059,7 +1039,7 @@ mod tests {
 
     #[test]
     fn test_progress_with_mixed_terminal_states() {
-        let mut dag = Dag::from_nodes(&vec![
+        let mut dag = Dag::from_nodes(&[
             make_node("a", "p1", &[]),
             make_node("b", "p1", &[]),
             make_node("c", "p1", &[]),
@@ -1076,7 +1056,7 @@ mod tests {
 
     #[test]
     fn test_is_complete_with_all_terminal_states() {
-        let mut dag = Dag::from_nodes(&vec![
+        let mut dag = Dag::from_nodes(&[
             make_node("a", "p1", &[]),
             make_node("b", "p1", &[]),
             make_node("c", "p1", &[]),
@@ -1093,7 +1073,7 @@ mod tests {
 
     #[test]
     fn test_is_complete_false_with_running() {
-        let mut dag = Dag::from_nodes(&vec![make_node("a", "p1", &[])]).unwrap();
+        let mut dag = Dag::from_nodes(&[make_node("a", "p1", &[])]).unwrap();
         dag.mark_running("a", "agent-1").unwrap();
         assert!(!dag.is_complete());
     }
@@ -1113,7 +1093,7 @@ mod tests {
 
     #[test]
     fn test_stages_by_phase_multiple_phases() {
-        let dag = Dag::from_nodes(&vec![
+        let dag = Dag::from_nodes(&[
             make_node("a", "phase-1", &[]),
             make_node("b", "phase-1", &["a"]),
             make_node("c", "phase-2", &[]),
@@ -1136,7 +1116,7 @@ mod tests {
 
     #[test]
     fn test_agent_map_only_includes_agents() {
-        let mut dag = Dag::from_nodes(&vec![
+        let mut dag = Dag::from_nodes(&[
             make_node("a", "p1", &[]),
             make_node("b", "p1", &[]),
             make_node("c", "p1", &[]),
@@ -1153,7 +1133,7 @@ mod tests {
     #[test]
     fn test_status_map_all_nodes() {
         let mut dag =
-            Dag::from_nodes(&vec![make_node("a", "p1", &[]), make_node("b", "p1", &[])]).unwrap();
+            Dag::from_nodes(&[make_node("a", "p1", &[]), make_node("b", "p1", &[])]).unwrap();
 
         dag.mark_running("a", "agent-1").unwrap();
         dag.mark_done("a").unwrap();
@@ -1167,7 +1147,7 @@ mod tests {
     #[test]
     fn test_mark_done_diamond_partial_unblock() {
         // d depends on both b and c. Completing b should NOT unblock d.
-        let mut dag = Dag::from_nodes(&vec![
+        let mut dag = Dag::from_nodes(&[
             make_node("a", "p1", &[]),
             make_node("b", "p1", &["a"]),
             make_node("c", "p1", &["a"]),

--- a/crosslink/src/orchestrator/decompose.rs
+++ b/crosslink/src/orchestrator/decompose.rs
@@ -470,7 +470,7 @@ mod tests {
         let plan = transform_to_plan(response, "test-doc");
         assert_eq!(plan.document_slug, "test-doc");
         assert_eq!(plan.total_stages, 1);
-        assert_eq!(plan.estimated_hours, 2.0);
+        assert!((plan.estimated_hours - 2.0).abs() < f64::EPSILON);
         assert_eq!(plan.phases.len(), 1);
         assert_eq!(plan.phases[0].stages.len(), 1);
         assert_eq!(plan.phases[0].stages[0].tasks.len(), 1);
@@ -722,7 +722,7 @@ mod tests {
         assert_eq!(resp.phases.len(), 1);
         assert_eq!(resp.phases[0].stages[0].tasks.len(), 1);
         assert_eq!(resp.phases[0].stages[0].agent_count, 2);
-        assert_eq!(resp.estimated_hours, 3.0);
+        assert!((resp.estimated_hours - 3.0).abs() < f64::EPSILON);
     }
 
     #[test]
@@ -771,9 +771,9 @@ mod tests {
         assert_eq!(stage.tasks.len(), 2);
         assert_eq!(stage.tasks[0].title, "Task A");
         assert_eq!(stage.tasks[0].description, "Do A");
-        assert_eq!(stage.tasks[0].complexity_hours, 1.0);
+        assert!((stage.tasks[0].complexity_hours - 1.0).abs() < f64::EPSILON);
         assert_eq!(stage.tasks[1].title, "Task B");
-        assert_eq!(stage.tasks[1].complexity_hours, 2.5);
+        assert!((stage.tasks[1].complexity_hours - 2.5).abs() < f64::EPSILON);
         // Check task IDs are sequential
         assert!(stage.tasks[0].id.contains("-t0"));
         assert!(stage.tasks[1].id.contains("-t1"));

--- a/crosslink/src/orchestrator/executor.rs
+++ b/crosslink/src/orchestrator/executor.rs
@@ -1013,7 +1013,7 @@ mod tests {
         let status = executor.status();
         assert_eq!(status.plan_id, "test-plan-1");
         assert_eq!(status.state, ExecutionState::Running);
-        assert_eq!(status.progress_percent, 0.0);
+        assert!(status.progress_percent < f64::EPSILON);
         assert_eq!(status.stage_statuses.len(), 4);
         assert!(status.stage_agents.is_empty());
     }

--- a/crosslink/src/orchestrator/models.rs
+++ b/crosslink/src/orchestrator/models.rs
@@ -203,7 +203,7 @@ mod tests {
             "estimated_hours": 5.0
         }"#;
         let resp: LlmDecomposeResponse = serde_json::from_str(json).unwrap();
-        assert_eq!(resp.estimated_hours, 5.0);
+        assert!((resp.estimated_hours - 5.0).abs() < f64::EPSILON);
         assert_eq!(resp.phases[0].stages[0].agent_count, 2);
         assert_eq!(resp.phases[0].stages[1].depends_on, vec!["Stage A"]);
         assert_eq!(

--- a/crosslink/src/pipeline.rs
+++ b/crosslink/src/pipeline.rs
@@ -479,8 +479,7 @@ mod tests {
         let err = p.advance().unwrap_err();
         assert!(
             err.to_string().contains("human checkpoint"),
-            "Expected checkpoint error, got: {}",
-            err
+            "Expected checkpoint error, got: {err}"
         );
     }
 
@@ -495,8 +494,7 @@ mod tests {
         let err = p.advance().unwrap_err();
         assert!(
             err.to_string().contains("terminal"),
-            "Expected terminal error, got: {}",
-            err
+            "Expected terminal error, got: {err}"
         );
     }
 
@@ -509,8 +507,7 @@ mod tests {
         let err = p.advance().unwrap_err();
         assert!(
             err.to_string().contains("terminal"),
-            "Expected terminal error, got: {}",
-            err
+            "Expected terminal error, got: {err}"
         );
     }
 
@@ -541,8 +538,7 @@ mod tests {
         let err = p.confirm_checkpoint().unwrap_err();
         assert!(
             err.to_string().contains("not at a human checkpoint"),
-            "Expected non-checkpoint error, got: {}",
-            err
+            "Expected non-checkpoint error, got: {err}"
         );
     }
 
@@ -564,7 +560,7 @@ mod tests {
         p.advance().unwrap(); // Review
         let summary = p.summary();
         assert!(summary.contains("Pipeline:"));
-        assert!(summary.contains("Stage:    review"), "Summary: {}", summary);
+        assert!(summary.contains("Stage:    review"), "Summary: {summary}");
         assert!(summary.contains("Agents:   4"));
         assert!(summary.contains("Mandate:  security review"));
         assert!(summary.contains("History:"));
@@ -604,8 +600,7 @@ mod tests {
             assert_eq!(
                 stage.to_string(),
                 serde_name,
-                "Display and serde mismatch for {:?}",
-                stage
+                "Display and serde mismatch for {stage:?}"
             );
         }
     }
@@ -785,7 +780,7 @@ mod tests {
         let summary = p.summary();
         assert!(summary.contains("History:"));
         assert!(summary.contains("partition -> review"));
-        assert!(!summary.contains("("));
+        assert!(!summary.contains('('));
     }
 
     #[test]
@@ -942,8 +937,7 @@ mod tests {
         let parsed = chrono::DateTime::parse_from_rfc3339(json.trim_matches('"'));
         assert!(
             parsed.is_ok(),
-            "created_at should serialize to valid RFC3339: {}",
-            json
+            "created_at should serialize to valid RFC3339: {json}"
         );
     }
 
@@ -1090,8 +1084,7 @@ mod tests {
         let err_msg = result.unwrap_err().to_string();
         assert!(
             err_msg.contains("Failed to write"),
-            "Expected write error, got: {}",
-            err_msg
+            "Expected write error, got: {err_msg}"
         );
     }
 
@@ -1126,9 +1119,7 @@ mod tests {
             let err = p.confirm_checkpoint().unwrap_err();
             assert!(
                 err.to_string().contains("not at a human checkpoint"),
-                "Stage {:?} should reject confirm_checkpoint, got: {}",
-                stage,
-                err
+                "Stage {stage:?} should reject confirm_checkpoint, got: {err}"
             );
         }
     }
@@ -1172,8 +1163,7 @@ mod tests {
             assert_eq!(
                 p.current_stage,
                 PipelineStage::Failed,
-                "fail() should set Failed from {:?}",
-                stage
+                "fail() should set Failed from {stage:?}"
             );
             let last = p.history.last().unwrap();
             assert_eq!(last.from, stage);
@@ -1222,9 +1212,7 @@ mod tests {
             let parsed = chrono::DateTime::parse_from_rfc3339(json.trim_matches('"'));
             assert!(
                 parsed.is_ok(),
-                "history[{}] timestamp should serialize to valid RFC3339: {}",
-                i,
-                json
+                "history[{i}] timestamp should serialize to valid RFC3339: {json}"
             );
         }
     }
@@ -1292,8 +1280,7 @@ mod tests {
             let v = Pipeline::valid_transitions(stage);
             assert!(
                 v.contains(&PipelineStage::Failed),
-                "{:?} should have Failed as valid transition",
-                stage
+                "{stage:?} should have Failed as valid transition"
             );
             assert!(
                 v.len() == 2,
@@ -1318,8 +1305,7 @@ mod tests {
         let created_str = p.created_at.to_rfc3339();
         assert!(
             summary.contains(&created_str),
-            "Summary should include the actual created_at value: {}",
-            summary
+            "Summary should include the actual created_at value: {summary}"
         );
     }
 
@@ -1343,8 +1329,7 @@ mod tests {
             let result = p.advance().unwrap();
             assert_eq!(
                 result, expected_to,
-                "advance from {:?} should go to {:?}",
-                from, expected_to
+                "advance from {from:?} should go to {expected_to:?}"
             );
             assert_eq!(p.current_stage, expected_to);
         }

--- a/crosslink/src/seam.rs
+++ b/crosslink/src/seam.rs
@@ -855,7 +855,7 @@ mod tests {
 
     #[test]
     fn test_parse_mod_declarations() {
-        let src = r#"
+        let src = r"
 mod foo;
 pub mod bar;
 pub(crate) mod baz;
@@ -864,7 +864,7 @@ mod qux;
 mod inline_mod {
     fn something() {}
 }
-"#;
+";
         let mods = parse_mod_declarations(src);
         assert_eq!(mods, vec!["foo", "bar", "baz", "qux"]);
     }
@@ -979,8 +979,7 @@ mod inline_mod {
             for f in &part.files {
                 assert!(
                     seen.insert(f.clone()),
-                    "file {:?} appears in multiple partitions",
-                    f
+                    "file {f:?} appears in multiple partitions"
                 );
             }
         }
@@ -990,8 +989,8 @@ mod inline_mod {
     fn test_max_partitions_respected() {
         let mut files = Vec::new();
         for i in 0..20 {
-            let dir = format!("dir{}", i);
-            files.push((format!("{}/file.rs", dir), "fn foo() {}\n".repeat(100)));
+            let dir = format!("dir{i}");
+            files.push((format!("{dir}/file.rs"), "fn foo() {}\n".repeat(100)));
         }
         let file_refs: Vec<(&str, &str)> = files
             .iter()
@@ -1037,8 +1036,7 @@ mod inline_mod {
         let total_big_lines: usize = big_parts.iter().map(|p| p.line_count).sum();
         assert!(
             total_big_lines > 2000,
-            "big module lines = {}",
-            total_big_lines
+            "big module lines = {total_big_lines}"
         );
     }
 
@@ -1139,7 +1137,7 @@ mod inline_mod {
     // Additional coverage tests
     // -----------------------------------------------------------------------
 
-    /// Line 174: count_lines returns 0 for a missing file.
+    /// Line 174: `count_lines` returns 0 for a missing file.
     #[test]
     fn test_count_lines_missing_file() {
         let dir = tempfile::tempdir().unwrap();
@@ -1173,13 +1171,13 @@ mod inline_mod {
         );
     }
 
-    /// Line 324: extract_mod_name returns None for "pub(crate" (no closing paren).
+    /// Line 324: `extract_mod_name` returns None for "pub(crate" (no closing paren).
     #[test]
     fn test_extract_mod_name_unclosed_pub_paren() {
         assert_eq!(extract_mod_name("pub(crate mod foo;"), None);
     }
 
-    /// Line 336: extract_mod_name returns None for identifiers containing
+    /// Line 336: `extract_mod_name` returns None for identifiers containing
     /// non-alphanumeric / non-underscore characters (e.g. a hyphen).
     #[test]
     fn test_extract_mod_name_invalid_identifier() {
@@ -1188,7 +1186,7 @@ mod inline_mod {
         assert_eq!(extract_mod_name("mod foo bar;"), None);
     }
 
-    /// Lines 384-388: directory_based_partitions groups files that sit directly
+    /// Lines 384-388: `directory_based_partitions` groups files that sit directly
     /// in the root (single path component) under the "_root" label.
     #[test]
     fn test_directory_based_partitions_root_files() {
@@ -1202,17 +1200,16 @@ mod inline_mod {
         let labels: Vec<&str> = parts.iter().map(|p| p.label.as_str()).collect();
         assert!(
             labels.contains(&"_root"),
-            "expected a '_root' partition for root-level files, got {:?}",
-            labels
+            "expected a '_root' partition for root-level files, got {labels:?}"
         );
         let root_part = parts.iter().find(|p| p.label == "_root").unwrap();
         // Both root-level .rs files should be in this partition.
         assert_eq!(root_part.files.len(), 2);
     }
 
-    /// Lines 499-500: git_coupling_inner builds the coupling map when pairs
-    /// exceed COUPLING_THRESHOLD.  We exercise this by calling the public
-    /// detect_seams on a real git repo where multiple commits touch the same
+    /// Lines 499-500: `git_coupling_inner` builds the coupling map when pairs
+    /// exceed `COUPLING_THRESHOLD`.  We exercise this by calling the public
+    /// `detect_seams` on a real git repo where multiple commits touch the same
     /// pair of files.
     #[test]
     fn test_git_coupling_builds_map() {
@@ -1243,9 +1240,9 @@ mod inline_mod {
         // Commit src/a.rs and src/b.rs together COUPLING_THRESHOLD times so
         // they get coupled.
         for i in 0..COUPLING_THRESHOLD {
-            let msg = format!("change {}", i);
-            let content_a = format!("fn a() {{ {} }}\n", i);
-            let content_b = format!("fn b() {{ {} }}\n", i);
+            let msg = format!("change {i}");
+            let content_a = format!("fn a() {{ {i} }}\n");
+            let content_b = format!("fn b() {{ {i} }}\n");
             fs::write(root.join("src/a.rs"), &content_a).unwrap();
             fs::write(root.join("src/b.rs"), &content_b).unwrap();
             git(&["add", "src/a.rs", "src/b.rs"]);
@@ -1256,13 +1253,12 @@ mod inline_mod {
         // After COUPLING_THRESHOLD co-commits the map should be non-empty.
         assert!(
             !coupling.is_empty(),
-            "expected non-empty coupling map after {} co-commits",
-            COUPLING_THRESHOLD
+            "expected non-empty coupling map after {COUPLING_THRESHOLD} co-commits"
         );
     }
 
-    /// Line 640: split_partition returns the original partition when line_count
-    /// is 0 (or files.len() <= 1).
+    /// Line 640: `split_partition` returns the original partition when `line_count`
+    /// is 0 (or `files.len()` <= 1).
     #[test]
     fn test_split_partition_zero_lines() {
         let part = Partition {
@@ -1287,7 +1283,7 @@ mod inline_mod {
         assert_eq!(result[0].label, "single");
     }
 
-    /// Lines 693-695: merge_small_partitions early-returns for 0 or 1 partition.
+    /// Lines 693-695: `merge_small_partitions` early-returns for 0 or 1 partition.
     #[test]
     fn test_merge_small_partitions_single() {
         let partitions = vec![Partition {
@@ -1306,7 +1302,7 @@ mod inline_mod {
         assert!(result.is_empty());
     }
 
-    /// Lines 734-738: merge_small_partitions else-branch — prev is big enough
+    /// Lines 734-738: `merge_small_partitions` else-branch — prev is big enough
     /// that it is emitted and part (also big) is pushed directly.
     #[test]
     fn test_merge_small_partitions_both_big() {
@@ -1488,13 +1484,13 @@ mod inline_mod {
     }
 
     /// Lines 748-750: leftover absorbed into last merged partition.
-    /// We achieve this by calling merge_small_partitions on a list that,
+    /// We achieve this by calling `merge_small_partitions` on a list that,
     /// after sorting, leaves a carry at the end but merged is already non-empty.
     /// We construct it manually: big(300) then small(50) — but sorted they
     /// become small(50), big(300).  With carry logic:
     ///   small(50) → carry.
     ///   big(300): prev(50) < MIN → merge → 350 >= MIN → pushed. carry=None.
-    /// No leftover. We need a different approach: call adjust_sizes with a
+    /// No leftover. We need a different approach: call `adjust_sizes` with a
     /// large partition containing a single file (so it won't be split) and
     /// two small ones that accumulate.
     #[test]
@@ -1551,7 +1547,7 @@ mod inline_mod {
         assert_eq!(result[0].files.len(), 3);
     }
 
-    /// Lines 764-765: merge_smallest_pair early-returns for single partition.
+    /// Lines 764-765: `merge_smallest_pair` early-returns for single partition.
     #[test]
     fn test_merge_smallest_pair_single() {
         let part = Partition {
@@ -1570,7 +1566,7 @@ mod inline_mod {
         assert!(result.is_empty());
     }
 
-    /// Line 793: merge_smallest_pair when partner_idx < min_idx (lo/hi swap).
+    /// Line 793: `merge_smallest_pair` when `partner_idx` < `min_idx` (lo/hi swap).
     #[test]
     fn test_merge_smallest_pair_partner_before_min() {
         // min_idx will be 2 (line_count=5), partner_idx will be 0 (line_count=10).
@@ -1604,16 +1600,16 @@ mod inline_mod {
         assert!(merged.label.contains("min"));
     }
 
-    /// Test apply_coupling with non-empty coupling data — exercises the full
+    /// Test `apply_coupling` with non-empty coupling data — exercises the full
     /// union-find merge path (lines 529-615).
     ///
     /// `apply_coupling` counts cross-partition edges by iterating every entry
-    /// in the coupling map: for each (file, coupled_set), for each coupled file
-    /// in the set it increments merge_votes by 1.  With two files a and b, the
+    /// in the coupling map: for each (file, `coupled_set`), for each coupled file
+    /// in the set it increments `merge_votes` by 1.  With two files a and b, the
     /// coupling map contributes 2 edges (a→b and b→a), which is 2 votes — still
-    /// below COUPLING_THRESHOLD(3).  We therefore add a third file c that is in
-    /// partition p_a and is also coupled with b, which drives the vote count for
-    /// the (p_a, p_b) pair above the threshold.
+    /// below `COUPLING_THRESHOLD(3)`.  We therefore add a third file c that is in
+    /// partition `p_a` and is also coupled with b, which drives the vote count for
+    /// the (`p_a`, `p_b`) pair above the threshold.
     #[test]
     fn test_apply_coupling_merges_coupled_partitions() {
         // p_a: a.rs, c.rs; p_b: b.rs.
@@ -1663,8 +1659,8 @@ mod inline_mod {
         assert_eq!(result[0].line_count, 200);
     }
 
-    /// Test apply_coupling when coupling exists but cross-partition vote count
-    /// is below COUPLING_THRESHOLD — partitions are NOT merged.
+    /// Test `apply_coupling` when coupling exists but cross-partition vote count
+    /// is below `COUPLING_THRESHOLD` — partitions are NOT merged.
     #[test]
     fn test_apply_coupling_below_threshold_not_merged() {
         // Each file appears in a separate partition.  Coupling map has the pair
@@ -1706,7 +1702,7 @@ mod inline_mod {
         assert_eq!(result.len(), 2);
     }
 
-    /// Test apply_coupling with an empty coupling map — early return path (line 524-525).
+    /// Test `apply_coupling` with an empty coupling map — early return path (line 524-525).
     #[test]
     fn test_apply_coupling_empty_coupling() {
         let partitions = vec![
@@ -1726,7 +1722,7 @@ mod inline_mod {
         assert_eq!(result.len(), 2);
     }
 
-    /// Test apply_coupling when coupling refers to files not in any partition —
+    /// Test `apply_coupling` when coupling refers to files not in any partition —
     /// those entries are simply skipped.
     #[test]
     fn test_apply_coupling_unknown_files_ignored() {
@@ -1746,7 +1742,7 @@ mod inline_mod {
         assert_eq!(result[0].label, "solo");
     }
 
-    /// Test the git_coupling_inner failure path: non-existent directory makes
+    /// Test the `git_coupling_inner` failure path: non-existent directory makes
     /// `git log` fail, which should return an empty map (not an error).
     #[test]
     fn test_git_coupling_non_git_dir() {
@@ -1756,7 +1752,7 @@ mod inline_mod {
         assert!(coupling.is_empty());
     }
 
-    /// Test ensure_complete_coverage adds _uncategorized for missing files and
+    /// Test `ensure_complete_coverage` adds _uncategorized for missing files and
     /// de-duplicates when files appear in multiple partitions.
     #[test]
     fn test_ensure_complete_coverage_adds_uncategorized() {
@@ -1768,8 +1764,7 @@ mod inline_mod {
         }];
         let all_files = vec![PathBuf::from("a.rs"), PathBuf::from("missing.rs")];
         let result = ensure_complete_coverage(partitions, &all_files, tmp.path());
-        let labels: Vec<&str> = result.iter().map(|p| p.label.as_str()).collect();
-        assert!(labels.contains(&"_uncategorized"));
+        assert!(result.iter().any(|p| p.label == "_uncategorized"));
         let uncat = result.iter().find(|p| p.label == "_uncategorized").unwrap();
         assert_eq!(uncat.files, vec![PathBuf::from("missing.rs")]);
     }
@@ -1829,7 +1824,7 @@ mod inline_mod {
         assert_eq!(result[0].label, "first");
     }
 
-    /// find_mod_files: file is directly under src as a .rs file.
+    /// `find_mod_files`: file is directly under src as a .rs file.
     #[test]
     fn test_find_mod_files_single_file() {
         let root = Path::new("/repo");
@@ -1843,7 +1838,7 @@ mod inline_mod {
         assert_eq!(result, vec![PathBuf::from("src/foo.rs")]);
     }
 
-    /// find_mod_files: module is a directory (src/<mod>/).
+    /// `find_mod_files`: module is a directory (src/<mod>/).
     #[test]
     fn test_find_mod_files_directory_module() {
         let root = Path::new("/repo");
@@ -1859,7 +1854,7 @@ mod inline_mod {
         assert!(result.contains(&PathBuf::from("src/mymod/helper.rs")));
     }
 
-    /// find_mod_files: no matching files returns empty vec.
+    /// `find_mod_files`: no matching files returns empty vec.
     #[test]
     fn test_find_mod_files_no_match() {
         let root = Path::new("/repo");
@@ -1869,7 +1864,7 @@ mod inline_mod {
         assert!(result.is_empty());
     }
 
-    /// record_pairs: single file — should not record any pair.
+    /// `record_pairs`: single file — should not record any pair.
     #[test]
     fn test_record_pairs_single_file() {
         let files = vec![PathBuf::from("a.rs")];
@@ -1878,7 +1873,7 @@ mod inline_mod {
         assert!(counts.is_empty());
     }
 
-    /// record_pairs: empty slice — should not record any pair.
+    /// `record_pairs`: empty slice — should not record any pair.
     #[test]
     fn test_record_pairs_empty() {
         let files: Vec<PathBuf> = vec![];
@@ -1887,7 +1882,7 @@ mod inline_mod {
         assert!(counts.is_empty());
     }
 
-    /// record_pairs: key normalisation — (b, a) and (a, b) map to the same key.
+    /// `record_pairs`: key normalisation — (b, a) and (a, b) map to the same key.
     #[test]
     fn test_record_pairs_key_order() {
         // b > a alphabetically, so the key should be (a, b) for both orderings.
@@ -1901,7 +1896,7 @@ mod inline_mod {
         assert_eq!(*counts.values().next().unwrap(), 2);
     }
 
-    /// detect_seams with max_partitions == 0 should clamp to 1.
+    /// `detect_seams` with `max_partitions` == 0 should clamp to 1.
     #[test]
     fn test_detect_seams_max_partitions_zero() {
         let repo = setup_repo(&[("dir_a/a.rs", "fn a() {}\n"), ("dir_b/b.rs", "fn b() {}\n")]);
@@ -1914,7 +1909,7 @@ mod inline_mod {
         );
     }
 
-    /// detect_seams on a non-Rust repo should fall back to directory partitions.
+    /// `detect_seams` on a non-Rust repo should fall back to directory partitions.
     #[test]
     fn test_detect_seams_non_rust_fallback() {
         // Use enough content per file to exceed MIN_PARTITION_LINES so the
@@ -1934,13 +1929,11 @@ mod inline_mod {
         assert!(!partitions.is_empty());
     }
 
-    /// Test adjust_sizes directly: a partition above MAX_PARTITION_LINES with
+    /// Test `adjust_sizes` directly: a partition above `MAX_PARTITION_LINES` with
     /// multiple files gets split.
     #[test]
     fn test_adjust_sizes_splits_large_partition() {
-        let files: Vec<PathBuf> = (0..10)
-            .map(|i| PathBuf::from(format!("f{}.rs", i)))
-            .collect();
+        let files: Vec<PathBuf> = (0..10).map(|i| PathBuf::from(format!("f{i}.rs"))).collect();
         let part = Partition {
             label: "big".to_string(),
             files,
@@ -1957,7 +1950,7 @@ mod inline_mod {
         assert!(result.iter().all(|p| p.label.starts_with("big")));
     }
 
-    /// Test adjust_sizes: a partition that does not exceed MAX is left alone.
+    /// Test `adjust_sizes`: a partition that does not exceed MAX is left alone.
     #[test]
     fn test_adjust_sizes_small_partition_unchanged() {
         let part = Partition {
@@ -1970,7 +1963,7 @@ mod inline_mod {
         assert_eq!(result[0].label, "small");
     }
 
-    /// Test merge_small_partitions: prev is big (>= MIN), part is big — both pushed separately.
+    /// Test `merge_small_partitions`: prev is big (>= MIN), part is big — both pushed separately.
     #[test]
     fn test_merge_small_partitions_big_prev_big_part() {
         // Three partitions: one small (< MIN_PARTITION_LINES), one that makes carry big, one big.
@@ -1999,7 +1992,7 @@ mod inline_mod {
         assert_eq!(result.len(), 2);
     }
 
-    /// Test merge_small_partitions: prev (carry) >= MIN_PARTITION_LINES, new part also >= MIN.
+    /// Test `merge_small_partitions`: prev (carry) >= `MIN_PARTITION_LINES`, new part also >= MIN.
     /// This exercises the else branch (line 733) where both are pushed separately.
     #[test]
     fn test_merge_small_partitions_carry_becomes_big_then_big_part() {
@@ -2035,7 +2028,7 @@ mod inline_mod {
         assert_eq!(result.len(), 2);
     }
 
-    /// Test merge_small_partitions: leftover carry absorbed into last merged partition.
+    /// Test `merge_small_partitions`: leftover carry absorbed into last merged partition.
     #[test]
     fn test_merge_small_partitions_leftover_carry_absorbed() {
         // Two partitions: one big, one small. After sort: small(50), big(300).

--- a/crosslink/src/server/handlers/agents.rs
+++ b/crosslink/src/server/handlers/agents.rs
@@ -762,7 +762,7 @@ mod tests {
             "machine_id": "test-machine"
         });
         std::fs::write(
-            heartbeats_dir.join(format!("{}.json", agent_id)),
+            heartbeats_dir.join(format!("{agent_id}.json")),
             serde_json::to_string(&hb).unwrap(),
         )
         .unwrap();
@@ -839,8 +839,7 @@ mod tests {
         let status = resp.status();
         assert!(
             status == StatusCode::OK || status == StatusCode::INTERNAL_SERVER_ERROR,
-            "Expected 200 or 500, got {}",
-            status
+            "Expected 200 or 500, got {status}"
         );
         if status == StatusCode::OK {
             let body = body_json(resp).await;
@@ -1092,7 +1091,7 @@ mod tests {
     }
 
     /// Test app with a seeded heartbeat AND a worktree directory that contains
-    /// a .kickoff-status file, so get_agent returns kickoff_status.
+    /// a .kickoff-status file, so `get_agent` returns `kickoff_status`.
     fn test_app_with_heartbeat_and_kickoff(
         agent_id: &str,
         kickoff_status: &str,
@@ -1113,7 +1112,7 @@ mod tests {
             "machine_id": "test-machine"
         });
         std::fs::write(
-            heartbeats_dir.join(format!("{}.json", agent_id)),
+            heartbeats_dir.join(format!("{agent_id}.json")),
             serde_json::to_string(&hb).unwrap(),
         )
         .unwrap();
@@ -1123,7 +1122,7 @@ mod tests {
         std::fs::create_dir_all(&worktrees_dir).unwrap();
         std::fs::write(
             worktrees_dir.join(".kickoff-status"),
-            format!("{}\n", kickoff_status),
+            format!("{kickoff_status}\n"),
         )
         .unwrap();
 
@@ -1231,7 +1230,7 @@ mod tests {
         std::fs::write(
             hub_cache
                 .join("heartbeats")
-                .join(format!("{}.json", agent_id)),
+                .join(format!("{agent_id}.json")),
             serde_json::to_string(&hb).unwrap(),
         )
         .unwrap();
@@ -1278,11 +1277,7 @@ mod tests {
         let body = body_json(resp).await;
         // There should be at least one stale lock entry
         let total = body["total"].as_u64().unwrap_or(0);
-        assert!(
-            total >= 1,
-            "expected at least one stale lock, got {}",
-            total
-        );
+        assert!(total >= 1, "expected at least one stale lock, got {total}");
         let items = body["items"].as_array().unwrap();
         let entry = &items[0];
         assert_eq!(entry["issue_id"], 77);

--- a/crosslink/src/server/handlers/issues.rs
+++ b/crosslink/src/server/handlers/issues.rs
@@ -706,7 +706,7 @@ mod tests {
     use tempfile::tempdir;
     use tower::util::ServiceExt;
 
-    /// Create a temporary AppState backed by a temp dir database.
+    /// Create a temporary `AppState` backed by a temp dir database.
     fn test_state() -> (AppState, tempfile::TempDir) {
         let dir = tempdir().unwrap();
         let db_path = dir.path().join("test.db");
@@ -1008,13 +1008,12 @@ mod tests {
             .await
             .unwrap();
         let detail: serde_json::Value = serde_json::from_slice(&resp_body).unwrap();
-        let subissue_ids: Vec<i64> = detail["subissues"]
+        let has_child = detail["subissues"]
             .as_array()
             .unwrap()
             .iter()
-            .map(|s| s["id"].as_i64().unwrap())
-            .collect();
-        assert!(subissue_ids.contains(&child_id));
+            .any(|s| s["id"].as_i64() == Some(child_id));
+        assert!(has_child);
     }
 
     #[tokio::test]
@@ -1309,8 +1308,7 @@ mod tests {
 
         let app = build_router(state);
         let body = format!(
-            r#"{{"title": "Child via create", "priority": "low", "parent_id": {}}}"#,
-            parent_id
+            r#"{{"title": "Child via create", "priority": "low", "parent_id": {parent_id}}}"#
         );
         let response = app
             .oneshot(
@@ -1551,7 +1549,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method("DELETE")
-                    .uri(format!("/issues/{}/labels/nonexistent", id))
+                    .uri(format!("/issues/{id}/labels/nonexistent"))
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -1590,7 +1588,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method("POST")
-                    .uri(format!("/issues/{}/block", id))
+                    .uri(format!("/issues/{id}/block"))
                     .header("content-type", "application/json")
                     .body(Body::from(r#"{"blocker_id": 9999}"#))
                     .unwrap(),
@@ -1614,7 +1612,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method("DELETE")
-                    .uri(format!("/issues/{}/block/{}", id, other_id))
+                    .uri(format!("/issues/{id}/block/{other_id}"))
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -1691,7 +1689,7 @@ mod tests {
         let response = app
             .oneshot(
                 Request::builder()
-                    .uri(format!("/issues?parent_id={}", parent_id))
+                    .uri(format!("/issues?parent_id={parent_id}"))
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -1780,7 +1778,7 @@ mod tests {
         let response = app
             .oneshot(
                 Request::builder()
-                    .uri(format!("/issues?search=Gizmo&parent_id={}", parent_id))
+                    .uri(format!("/issues?search=Gizmo&parent_id={parent_id}"))
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -1845,7 +1843,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method("POST")
-                    .uri(format!("/issues/{}/comments", id))
+                    .uri(format!("/issues/{id}/comments"))
                     .header("content-type", "application/json")
                     .body(Body::from(body.to_string()))
                     .unwrap(),
@@ -1927,7 +1925,7 @@ mod tests {
         let response = app
             .oneshot(
                 Request::builder()
-                    .uri(format!("/issues/{}", issue_id))
+                    .uri(format!("/issues/{issue_id}"))
                     .body(Body::empty())
                     .unwrap(),
             )

--- a/crosslink/src/server/handlers/milestones.rs
+++ b/crosslink/src/server/handlers/milestones.rs
@@ -315,7 +315,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method(Method::GET)
-                    .uri(format!("/api/v1/milestones/{}", id))
+                    .uri(format!("/api/v1/milestones/{id}"))
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -366,7 +366,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method(Method::POST)
-                    .uri(format!("/api/v1/milestones/{}/close", id))
+                    .uri(format!("/api/v1/milestones/{id}/close"))
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -417,7 +417,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method(Method::POST)
-                    .uri(format!("/api/v1/milestones/{}/close", id))
+                    .uri(format!("/api/v1/milestones/{id}/close"))
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -494,7 +494,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method(Method::POST)
-                    .uri(format!("/api/v1/milestones/{}/close", id2))
+                    .uri(format!("/api/v1/milestones/{id2}/close"))
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -556,7 +556,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method(Method::POST)
-                    .uri(format!("/api/v1/milestones/{}/assign", milestone_id))
+                    .uri(format!("/api/v1/milestones/{milestone_id}/assign"))
                     .header("content-type", "application/json")
                     .body(Body::from(json!({"issue_id": issue_id}).to_string()))
                     .unwrap(),
@@ -593,7 +593,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method(Method::POST)
-                    .uri(format!("/api/v1/milestones/{}/assign", milestone_id))
+                    .uri(format!("/api/v1/milestones/{milestone_id}/assign"))
                     .header("content-type", "application/json")
                     .body(Body::from(json!({"issue_id": 9999}).to_string()))
                     .unwrap(),
@@ -637,7 +637,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method(Method::GET)
-                    .uri(format!("/api/v1/milestones/{}", milestone_id))
+                    .uri(format!("/api/v1/milestones/{milestone_id}"))
                     .body(Body::empty())
                     .unwrap(),
             )

--- a/crosslink/src/server/handlers/sessions.rs
+++ b/crosslink/src/server/handlers/sessions.rs
@@ -358,7 +358,7 @@ mod tests {
         assert_eq!(body["ok"], true);
     }
 
-    /// Helper that returns (Router, TempDir) with an active session and a created issue.
+    /// Helper that returns (Router, `TempDir`) with an active session and a created issue.
     fn test_app_with_session_and_issue() -> (Router, tempfile::TempDir, i64) {
         let dir = tempfile::tempdir().expect("tempdir");
         let db_path = dir.path().join("test.db");
@@ -379,7 +379,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method(Method::POST)
-                    .uri(format!("/api/v1/sessions/work/{}", issue_id))
+                    .uri(format!("/api/v1/sessions/work/{issue_id}"))
                     .body(Body::empty())
                     .unwrap(),
             )

--- a/crosslink/src/server/types.rs
+++ b/crosslink/src/server/types.rs
@@ -764,7 +764,7 @@ mod tests {
 
     #[test]
     fn test_update_issue_request_all_optional() {
-        let json = r#"{}"#;
+        let json = r"{}";
         let req: UpdateIssueRequest = serde_json::from_str(json).unwrap();
         assert!(req.title.is_none());
         assert!(req.description.is_none());

--- a/crosslink/src/server/watcher.rs
+++ b/crosslink/src/server/watcher.rs
@@ -499,7 +499,7 @@ mod tests {
 
         let hb = make_heartbeat("worker-1", 1);
         let mut current: HashMap<String, Heartbeat> = HashMap::new();
-        current.insert("worker-1".to_string(), hb.clone());
+        current.insert("worker-1".to_string(), hb);
 
         // Simulate diff logic directly.
         for (agent_id, hb) in &current {
@@ -537,11 +537,9 @@ mod tests {
     fn test_diff_no_broadcast_on_unchanged() {
         let (tx, mut rx) = broadcast::channel::<WsEvent>(16);
         let mut last_state: HashMap<String, Heartbeat> = HashMap::new();
-        let mut last_statuses: HashMap<String, AgentStatus> = HashMap::new();
 
         let hb = make_heartbeat("worker-1", 1);
         last_state.insert("worker-1".to_string(), hb.clone());
-        last_statuses.insert("worker-1".to_string(), AgentStatus::Active);
 
         let mut current: HashMap<String, Heartbeat> = HashMap::new();
         current.insert("worker-1".to_string(), hb); // same timestamp
@@ -550,8 +548,7 @@ mod tests {
         for (agent_id, hb) in &current {
             let is_new_or_updated = last_state
                 .get(agent_id)
-                .map(|prev| prev.last_heartbeat != hb.last_heartbeat)
-                .unwrap_or(true);
+                .is_none_or(|prev| prev.last_heartbeat != hb.last_heartbeat);
             if is_new_or_updated {
                 let _ = tx.send(WsEvent::Heartbeat(WsHeartbeatEvent {
                     event_type: crate::server::types::WsEventType::Heartbeat,

--- a/crosslink/src/shared_writer/tests.rs
+++ b/crosslink/src/shared_writer/tests.rs
@@ -198,7 +198,7 @@ fn test_replace_local_refs_start_end() {
     assert_eq!(result, Some("#5".to_string()));
 }
 
-/// Helper for tests: scan issues dir for a display_id (mirrors SharedWriter logic).
+/// Helper for tests: scan issues dir for a `display_id` (mirrors `SharedWriter` logic).
 fn scan_for_display_id(issues_dir: &Path, display_id: i64) -> Result<IssueFile> {
     for entry in std::fs::read_dir(issues_dir)? {
         let entry = entry?;
@@ -212,20 +212,20 @@ fn scan_for_display_id(issues_dir: &Path, display_id: i64) -> Result<IssueFile> 
             }
         }
     }
-    bail!("Issue #{} not found", display_id)
+    bail!("Issue #{display_id} not found")
 }
 
 #[test]
 fn test_v1_issue_path_format() {
     let uuid = Uuid::parse_str("a1b2c3d4-e5f6-7890-abcd-ef1234567890").unwrap();
-    let path = format!("issues/{}.json", uuid);
+    let path = format!("issues/{uuid}.json");
     assert_eq!(path, "issues/a1b2c3d4-e5f6-7890-abcd-ef1234567890.json");
 }
 
 #[test]
 fn test_v2_issue_path_format() {
     let uuid = Uuid::parse_str("a1b2c3d4-e5f6-7890-abcd-ef1234567890").unwrap();
-    let path = format!("issues/{}/issue.json", uuid);
+    let path = format!("issues/{uuid}/issue.json");
     assert_eq!(
         path,
         "issues/a1b2c3d4-e5f6-7890-abcd-ef1234567890/issue.json"
@@ -236,7 +236,7 @@ fn test_v2_issue_path_format() {
 fn test_v2_comment_path_format() {
     let issue_uuid = Uuid::parse_str("a1b2c3d4-e5f6-7890-abcd-ef1234567890").unwrap();
     let comment_uuid = Uuid::parse_str("11111111-2222-3333-4444-555555555555").unwrap();
-    let path = format!("issues/{}/comments/{}.json", issue_uuid, comment_uuid);
+    let path = format!("issues/{issue_uuid}/comments/{comment_uuid}.json");
     assert_eq!(
         path,
         "issues/a1b2c3d4-e5f6-7890-abcd-ef1234567890/comments/11111111-2222-3333-4444-555555555555.json"
@@ -356,7 +356,7 @@ mod lock_v2_tests {
         assert_eq!(claimed, LockClaimResult::Claimed);
         assert_eq!(already, LockClaimResult::AlreadyHeld);
         assert_ne!(claimed, already);
-        assert_ne!(claimed, contended.clone());
+        assert_ne!(claimed, contended);
         assert_eq!(
             contended,
             LockClaimResult::Contended {
@@ -364,8 +364,8 @@ mod lock_v2_tests {
             }
         );
         // Verify Debug
-        let _ = format!("{:?}", claimed);
-        let _ = format!("{:?}", contended);
+        let _ = format!("{claimed:?}");
+        let _ = format!("{contended:?}");
     }
 
     #[test]
@@ -837,8 +837,7 @@ mod lock_v2_tests {
             let state = read_checkpoint(cache).unwrap();
             assert_eq!(
                 state.locks[&1].agent_id, "agent-a",
-                "Winner should be agent-a regardless of who runs compaction (compactor={})",
-                compactor
+                "Winner should be agent-a regardless of who runs compaction (compactor={compactor})"
             );
         }
     }
@@ -853,10 +852,10 @@ mod integration {
     use std::process::Command;
     use tempfile::TempDir;
 
-    /// Set up a minimal git environment for SharedWriter tests.
+    /// Set up a minimal git environment for `SharedWriter` tests.
     ///
-    /// Returns (work_dir, remote_dir). The hub cache (`crosslink/hub` branch)
-    /// is initialized directly inside the work_dir so SharedWriter::new() works.
+    /// Returns (`work_dir`, `remote_dir`). The hub cache (`crosslink/hub` branch)
+    /// is initialized directly inside the `work_dir` so `SharedWriter::new()` works.
     fn setup_shared_writer_env() -> (TempDir, TempDir, std::path::PathBuf) {
         let remote_dir = tempfile::tempdir().unwrap();
         let work_dir = tempfile::tempdir().unwrap();
@@ -1068,7 +1067,7 @@ mod integration {
         let cache_dir = crosslink_dir.join(".hub-cache").join("issues");
         let entries: Vec<_> = std::fs::read_dir(&cache_dir)
             .unwrap()
-            .filter_map(|e| e.ok())
+            .filter_map(std::result::Result::ok)
             .collect();
         assert!(
             !entries.is_empty(),
@@ -1395,7 +1394,7 @@ mod integration {
         let kinds = ["plan", "decision", "observation", "blocker", "resolution"];
         for kind in &kinds {
             writer
-                .add_comment(&db, issue_id, &format!("Comment: {}", kind), kind)
+                .add_comment(&db, issue_id, &format!("Comment: {kind}"), kind)
                 .unwrap();
         }
 
@@ -1966,7 +1965,7 @@ mod integration {
             milestone_uuid: None,
             time_entries: vec![],
         };
-        crate::issue_file::write_issue_file(&issues_dir.join(format!("{}.json", uuid)), &issue)
+        crate::issue_file::write_issue_file(&issues_dir.join(format!("{uuid}.json")), &issue)
             .unwrap();
 
         // promote_offline_issues should skip this one (UUID in promoted set)
@@ -2449,7 +2448,7 @@ mod integration {
 
     /// Create a V1-layout environment by deleting `meta/version.json` from the hub
     /// cache after normal V2 setup. `layout_version()` returns 1 when this file
-    /// is absent, routing add_comment / add_intervention_comment through the V1
+    /// is absent, routing `add_comment` / `add_intervention_comment` through the V1
     /// inline-append code paths (lines 679-701, 762-785).
     fn setup_shared_writer_env_v1() -> (TempDir, TempDir, std::path::PathBuf) {
         let (work_dir, remote_dir, crosslink_dir) = setup_shared_writer_env();
@@ -2824,9 +2823,8 @@ mod integration {
                 .description
                 .as_deref()
                 .unwrap()
-                .contains(&format!("#{}", id)),
-            "L1 should be rewritten to #{}",
-            id
+                .contains(&format!("#{id}")),
+            "L1 should be rewritten to #{id}"
         );
         drop(work_dir);
     }
@@ -2927,7 +2925,7 @@ mod integration {
 
         // Also git add + commit so the cache is clean
         writer
-            .git_in_cache(&["add", &format!("issues/{}/issue.json", uuid)])
+            .git_in_cache(&["add", &format!("issues/{uuid}/issue.json")])
             .unwrap();
         let _ = writer.git_in_cache(&["commit", "-m", "add offline issue", "--no-gpg-sign"]);
 
@@ -2940,7 +2938,7 @@ mod integration {
 
         // write_commit_push writes the promoted file in V1 format
         // (issues/{uuid}.json) regardless of layout version
-        let v1_file = cache_dir.join("issues").join(format!("{}.json", uuid));
+        let v1_file = cache_dir.join("issues").join(format!("{uuid}.json"));
         if v1_file.exists() {
             let content = std::fs::read_to_string(&v1_file).unwrap();
             let updated: crate::issue_file::IssueFile = serde_json::from_str(&content).unwrap();

--- a/crosslink/src/signing.rs
+++ b/crosslink/src/signing.rs
@@ -1651,8 +1651,7 @@ mod tests {
         let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
         assert!(
             value.contains("allowed_signers"),
-            "should contain allowed_signers path, got: {}",
-            value
+            "should contain allowed_signers path, got: {value}"
         );
     }
 
@@ -1911,25 +1910,25 @@ f@host sk-ecdsa-sha2-nistp256 FFFF\n";
             fingerprint: Some("SHA256:abc".to_string()),
             principal: Some("user@host".to_string()),
         };
-        let debug_str = format!("{:?}", valid);
+        let debug_str = format!("{valid:?}");
         assert!(debug_str.contains("Valid"));
         assert!(debug_str.contains("abc123"));
 
         let unsigned = SignatureVerification::Unsigned {
             commit: "def456".to_string(),
         };
-        let debug_str = format!("{:?}", unsigned);
+        let debug_str = format!("{unsigned:?}");
         assert!(debug_str.contains("Unsigned"));
 
         let invalid = SignatureVerification::Invalid {
             commit: "ghi789".to_string(),
             reason: "bad sig".to_string(),
         };
-        let debug_str = format!("{:?}", invalid);
+        let debug_str = format!("{invalid:?}");
         assert!(debug_str.contains("Invalid"));
 
         let no_commits = SignatureVerification::NoCommits;
-        let debug_str = format!("{:?}", no_commits);
+        let debug_str = format!("{no_commits:?}");
         assert!(debug_str.contains("NoCommits"));
     }
 
@@ -1940,7 +1939,7 @@ f@host sk-ecdsa-sha2-nistp256 FFFF\n";
             fingerprint: None,
             principal: None,
         };
-        let debug = format!("{:?}", v);
+        let debug = format!("{v:?}");
         assert!(debug.contains("None"));
     }
 
@@ -2078,7 +2077,7 @@ f@host sk-ecdsa-sha2-nistp256 FFFF\n";
         let mut signers = AllowedSigners::default();
         signers.add_entry(AllowedSignerEntry {
             principal: "canon-test@crosslink".to_string(),
-            public_key: keypair.public_key.clone(),
+            public_key: keypair.public_key,
             metadata_comment: None,
         });
         signers.save(&signers_path).unwrap();
@@ -2312,7 +2311,7 @@ f@host sk-ecdsa-sha2-nistp256 FFFF\n";
         let mut signers = AllowedSigners::default();
         signers.add_entry(AllowedSignerEntry {
             principal: "ns-test@crosslink".to_string(),
-            public_key: keypair.public_key.clone(),
+            public_key: keypair.public_key,
             metadata_comment: None,
         });
         signers.save(&signers_path).unwrap();

--- a/crosslink/src/sync/tests.rs
+++ b/crosslink/src/sync/tests.rs
@@ -1189,7 +1189,7 @@ fn test_find_stale_locks_with_age_stale_lock_no_heartbeat() {
             agent_id: "stale-agent".to_string(),
             branch: None,
             claimed_at: old_time,
-            signed_by: "".to_string(),
+            signed_by: String::new(),
         },
     );
     let locks = LocksFile {
@@ -1225,7 +1225,7 @@ fn test_find_stale_locks_with_age_fresh_heartbeat_not_stale() {
             agent_id: "fresh-agent".to_string(),
             branch: None,
             claimed_at: Utc::now(),
-            signed_by: "".to_string(),
+            signed_by: String::new(),
         },
     );
     let locks = LocksFile {
@@ -2187,7 +2187,7 @@ fn test_init_cache_with_existing_local_hub_branch() {
             "checkout",
             "-b",
             HUB_BRANCH,
-            &format!("origin/{}", HUB_BRANCH),
+            &format!("origin/{HUB_BRANCH}"),
         ])
         .output()
         .unwrap();
@@ -2275,17 +2275,17 @@ fn test_check_divergence_with_many_commits_fails() {
         .unwrap();
 
     // Create MAX_DIVERGENCE + 1 local commits without pushing
-    for i in 0..(MAX_DIVERGENCE + 1) {
+    for i in 0..=MAX_DIVERGENCE {
         std::fs::write(
-            manager.cache_dir.join(format!("diverge-{}.txt", i)),
-            format!("content {}", i),
+            manager.cache_dir.join(format!("diverge-{i}.txt")),
+            format!("content {i}"),
         )
         .unwrap();
         manager
-            .git_in_cache(&["add", &format!("diverge-{}.txt", i)])
+            .git_in_cache(&["add", &format!("diverge-{i}.txt")])
             .unwrap();
         manager
-            .git_in_cache(&["commit", "-m", &format!("diverge commit {}", i)])
+            .git_in_cache(&["commit", "-m", &format!("diverge commit {i}")])
             .unwrap();
     }
 
@@ -2338,7 +2338,7 @@ fn test_migrate_from_locks_branch_with_old_remote_branch() {
     // Push as crosslink/locks to the remote
     Command::new("git")
         .current_dir(work_dir.path())
-        .args(["push", "origin", &format!("HEAD:{}", OLD_BRANCH)])
+        .args(["push", "origin", &format!("HEAD:{OLD_BRANCH}")])
         .output()
         .unwrap();
     // Switch back to main

--- a/crosslink/src/trust_model.rs
+++ b/crosslink/src/trust_model.rs
@@ -356,7 +356,7 @@ internal = ["db"]
             TriageResult::ByDesign { reason } => {
                 assert_eq!(reason, "Local-only tool with no network exposure");
             }
-            other => panic!("Expected ByDesign, got {:?}", other),
+            other => panic!("Expected ByDesign, got {other:?}"),
         }
     }
 
@@ -375,7 +375,7 @@ internal = ["db"]
                 assert!(reason.contains("matched ignore pattern"));
                 assert!(reason.contains("auth"));
             }
-            other => panic!("Expected ByDesign, got {:?}", other),
+            other => panic!("Expected ByDesign, got {other:?}"),
         }
     }
 
@@ -441,7 +441,7 @@ internal = ["db"]
                 assert!(reason.contains("internal-db"));
                 assert!(reason.contains("implicit trust"));
             }
-            other => panic!("Expected Downgraded, got {:?}", other),
+            other => panic!("Expected Downgraded, got {other:?}"),
         }
     }
 
@@ -458,7 +458,7 @@ internal = ["db"]
         let result = triage_finding(&config, "Unvalidated input", "goes through message-bus");
         match result {
             TriageResult::Downgraded { .. } => {}
-            other => panic!("Expected Downgraded, got {:?}", other),
+            other => panic!("Expected Downgraded, got {other:?}"),
         }
     }
 

--- a/crosslink/src/tui/knowledge_tab.rs
+++ b/crosslink/src/tui/knowledge_tab.rs
@@ -1037,7 +1037,7 @@ mod tests {
             slug: slug.to_string(),
             frontmatter: PageFrontmatter {
                 title: title.to_string(),
-                tags: tags.iter().map(|s| s.to_string()).collect(),
+                tags: tags.iter().map(std::string::ToString::to_string).collect(),
                 sources: Vec::new(),
                 contributors: vec!["worker-1".to_string()],
                 created: "2026-01-01".to_string(),

--- a/crosslink/src/tui/mod.rs
+++ b/crosslink/src/tui/mod.rs
@@ -83,7 +83,7 @@ impl StatusFilter {
 
 /// Create a `KeyEvent` for testing purposes. Shared across TUI tab test modules.
 #[cfg(test)]
-pub fn make_test_key(code: crossterm::event::KeyCode) -> crossterm::event::KeyEvent {
+pub const fn make_test_key(code: crossterm::event::KeyCode) -> crossterm::event::KeyEvent {
     use crossterm::event::{KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
     KeyEvent {
         code,

--- a/crosslink/src/utils.rs
+++ b/crosslink/src/utils.rs
@@ -359,11 +359,7 @@ mod tests {
     #[test]
     fn test_windows_reserved_names_rejected() {
         for name in &["CON", "PRN", "AUX", "NUL", "COM1", "COM9", "LPT1", "LPT9"] {
-            assert!(
-                is_windows_reserved_name(name),
-                "{} should be reserved",
-                name
-            );
+            assert!(is_windows_reserved_name(name), "{name} should be reserved");
         }
     }
 
@@ -449,13 +445,13 @@ mod tests {
 
     #[test]
     fn test_base62_encode_4_deterministic() {
-        assert_eq!(base62_encode_4(999999), base62_encode_4(999999));
+        assert_eq!(base62_encode_4(999_999), base62_encode_4(999_999));
     }
 
     #[test]
     fn test_base62_encode_4_all_valid_chars() {
-        let result = base62_encode_4(0xDEADBEEF);
-        assert!(result.chars().all(|c| c.is_alphanumeric()));
+        let result = base62_encode_4(0xDEAD_BEEF);
+        assert!(result.chars().all(char::is_alphanumeric));
     }
 
     #[test]

--- a/crosslink/tests/cli_integration.rs
+++ b/crosslink/tests/cli_integration.rs
@@ -3742,3 +3742,132 @@ fn test_dry_run_flag_accepted() {
         stderr
     );
 }
+
+// ===== Sentinel tests =====
+
+#[test]
+fn test_sentinel_run_disabled() {
+    let dir = test_dir();
+    init_crosslink(dir.path());
+
+    // Write sentinel config with enabled: false
+    let config_path = dir.path().join(".crosslink").join("hook-config.json");
+    let config = serde_json::json!({
+        "sentinel": { "enabled": false }
+    });
+    std::fs::write(&config_path, serde_json::to_string_pretty(&config).unwrap()).unwrap();
+
+    let (success, stdout, _) = run_crosslink(dir.path(), &["sentinel", "run"]);
+    assert!(success);
+    assert!(
+        stdout.contains("sentinel is disabled"),
+        "Expected 'sentinel is disabled', got: {stdout}"
+    );
+}
+
+#[test]
+fn test_sentinel_run_dry_run() {
+    let dir = test_dir();
+    init_crosslink(dir.path());
+
+    // Enable sentinel (default template has it disabled)
+    let config_path = dir.path().join(".crosslink").join("hook-config.json");
+    let config = serde_json::json!({
+        "sentinel": { "enabled": true }
+    });
+    std::fs::write(&config_path, serde_json::to_string_pretty(&config).unwrap()).unwrap();
+
+    let (success, stdout, _) = run_crosslink(dir.path(), &["sentinel", "run", "--dry-run"]);
+    assert!(success);
+    assert!(
+        stdout.contains("sentinel dry-run"),
+        "Expected dry-run output, got: {stdout}"
+    );
+    assert!(stdout.contains("github-labels"));
+    assert!(stdout.contains("max concurrent agents"));
+    assert!(stdout.contains("default model"));
+}
+
+#[test]
+fn test_sentinel_history_empty() {
+    let dir = test_dir();
+    init_crosslink(dir.path());
+
+    let (success, stdout, _) = run_crosslink(dir.path(), &["sentinel", "history"]);
+    assert!(success);
+    assert!(
+        stdout.contains("No sentinel runs recorded"),
+        "Expected empty history message, got: {stdout}"
+    );
+}
+
+#[test]
+fn test_sentinel_history_json_empty() {
+    let dir = test_dir();
+    init_crosslink(dir.path());
+
+    let (success, stdout, _) = run_crosslink(dir.path(), &["sentinel", "history", "--json"]);
+    assert!(success);
+    assert_eq!(stdout.trim(), "[]");
+}
+
+#[test]
+fn test_sentinel_status_not_running() {
+    let dir = test_dir();
+    init_crosslink(dir.path());
+
+    let (success, stdout, _) = run_crosslink(dir.path(), &["sentinel", "status"]);
+    assert!(success);
+    assert!(
+        stdout.contains("Sentinel not running"),
+        "Expected not running status, got: {stdout}"
+    );
+    assert!(stdout.contains("In-flight: 0"));
+}
+
+#[test]
+fn test_sentinel_stop_not_running() {
+    let dir = test_dir();
+    init_crosslink(dir.path());
+
+    let (success, stdout, _) = run_crosslink(dir.path(), &["sentinel", "stop"]);
+    assert!(success);
+    assert!(
+        stdout.contains("not running"),
+        "Expected not running, got: {stdout}"
+    );
+}
+
+#[test]
+fn test_sentinel_schema_migration() {
+    let dir = test_dir();
+    init_crosslink(dir.path());
+
+    // Verify sentinel tables exist after init (triggers migration)
+    let db_path = dir.path().join(".crosslink").join("issues.db");
+    let db = rusqlite::Connection::open(&db_path).unwrap();
+
+    let has_runs: bool = db
+        .query_row(
+            "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='sentinel_runs'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap_or(false);
+    assert!(has_runs, "sentinel_runs table should exist");
+
+    let has_dispatches: bool = db
+        .query_row(
+            "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='sentinel_dispatches'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap_or(false);
+    assert!(has_dispatches, "sentinel_dispatches table should exist");
+
+    // Verify schema version is 16
+    let version: i32 = db
+        .query_row("PRAGMA user_version", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(version, 16, "Schema version should be 16");
+}

--- a/crosslink/tests/cli_integration.rs
+++ b/crosslink/tests/cli_integration.rs
@@ -64,13 +64,13 @@ fn test_dir() -> tempfile::TempDir {
 
 /// Check if text contains an issue ref in either #N or LN format.
 fn contains_issue_ref(text: &str, id: u32) -> bool {
-    text.contains(&format!("#{}", id)) || text.contains(&format!("L{}", id))
+    text.contains(&format!("#{id}")) || text.contains(&format!("L{id}"))
 }
 
 /// Initialize crosslink in a temp directory
 fn init_crosslink(dir: &std::path::Path) {
     let (success, _, stderr) = run_crosslink(dir, &["init"]);
-    assert!(success, "Failed to init: {}", stderr);
+    assert!(success, "Failed to init: {stderr}");
 }
 
 // ==================== Init Tests ====================
@@ -109,8 +109,7 @@ fn test_create_issue() {
     assert!(success);
     assert!(
         stdout.contains("Created issue") && contains_issue_ref(&stdout, 1),
-        "Expected 'Created issue #1' in output, got: {}",
-        stdout
+        "Expected 'Created issue #1' in output, got: {stdout}"
     );
 }
 
@@ -162,8 +161,7 @@ fn test_create_subissue() {
     assert!(success);
     assert!(
         stdout.contains("Created subissue") && contains_issue_ref(&stdout, 2),
-        "Expected 'Created subissue #2' in output, got: {}",
-        stdout
+        "Expected 'Created subissue #2' in output, got: {stdout}"
     );
 
     // Verify parent-child relationship in show
@@ -183,8 +181,7 @@ fn test_list_empty() {
     assert!(success);
     assert!(
         stdout.contains("No issues found."),
-        "Expected 'No issues found.' in output, got: {}",
-        stdout
+        "Expected 'No issues found.' in output, got: {stdout}"
     );
 }
 
@@ -303,7 +300,7 @@ fn test_close_issue() {
     run_crosslink(dir.path(), &["create", "Test issue"]);
     let (success, stdout, stderr) = run_crosslink(dir.path(), &["close", "1"]);
 
-    assert!(success, "close failed: stdout={} stderr={}", stdout, stderr);
+    assert!(success, "close failed: stdout={stdout} stderr={stderr}");
     assert!(stdout.contains("Closed") || stdout.contains("closed"));
 
     let (_, show_out, _) = run_crosslink(dir.path(), &["show", "1"]);
@@ -336,11 +333,7 @@ fn test_delete_issue() {
     let (_, create_out, _) = run_crosslink(dir.path(), &["create", "To delete"]);
     let (success, del_out, del_err) = run_crosslink(dir.path(), &["issue", "delete", "1", "-f"]);
 
-    assert!(
-        success,
-        "delete failed: stdout={} stderr={}",
-        del_out, del_err
-    );
+    assert!(success, "delete failed: stdout={del_out} stderr={del_err}");
 
     let (_, list_out, list_err) = run_crosslink(dir.path(), &["list"]);
     assert!(
@@ -536,15 +529,13 @@ fn test_command_without_init() {
     if !success {
         assert!(
             stderr.contains("Not a crosslink repository") || stderr.contains("crosslink init"),
-            "Error should mention missing repo, got stderr: {}",
-            stderr
+            "Error should mention missing repo, got stderr: {stderr}"
         );
     } else {
         // Found a parent .crosslink - list should work normally
         assert!(
             stdout.contains("No issues") || stdout.contains("#"),
-            "Should show valid list output, got: {}",
-            stdout
+            "Should show valid list output, got: {stdout}"
         );
     }
 }
@@ -559,8 +550,7 @@ fn test_invalid_priority() {
     assert!(!success, "Creating issue with invalid priority should fail");
     assert!(
         stderr.contains("Invalid") || stderr.contains("priority"),
-        "Error should mention invalid priority, got stderr: {}",
-        stderr
+        "Error should mention invalid priority, got stderr: {stderr}"
     );
 }
 
@@ -834,8 +824,7 @@ fn test_timer_status_no_timer() {
     assert!(success);
     assert!(
         stdout.contains("No timer running"),
-        "Expected 'No timer running' message, got: {}",
-        stdout
+        "Expected 'No timer running' message, got: {stdout}"
     );
 }
 
@@ -955,8 +944,7 @@ fn test_next_no_issues() {
     assert!(success);
     assert!(
         stdout.contains("No issues ready to work on"),
-        "Expected 'No issues ready to work on' message, got: {}",
-        stdout
+        "Expected 'No issues ready to work on' message, got: {stdout}"
     );
 }
 
@@ -1053,8 +1041,7 @@ fn test_tested_command() {
     assert!(success);
     assert!(
         stdout.contains("Marked tests as run"),
-        "Expected 'Marked tests as run' in output, got: {}",
-        stdout
+        "Expected 'Marked tests as run' in output, got: {stdout}"
     );
 }
 
@@ -1081,9 +1068,9 @@ fn test_create_all_priorities() {
     for priority in &["low", "medium", "high", "critical"] {
         let (success, _, _) = run_crosslink(
             dir.path(),
-            &["create", &format!("{} issue", priority), "-p", priority],
+            &["create", &format!("{priority} issue"), "-p", priority],
         );
-        assert!(success, "Failed to create {} priority issue", priority);
+        assert!(success, "Failed to create {priority} priority issue");
     }
 
     let (_, list_out, _) = run_crosslink(dir.path(), &["list"]);
@@ -1179,7 +1166,7 @@ fn test_session_end_without_start() {
     // Should fail or report no active session
     assert!(
         !success || stdout.contains("No active") || stderr.contains("No active"),
-        "Ending without starting should fail or report no active session, got stdout: {}, stderr: {}", stdout, stderr
+        "Ending without starting should fail or report no active session, got stdout: {stdout}, stderr: {stderr}"
     );
 }
 
@@ -1193,8 +1180,7 @@ fn test_session_status_without_session() {
     assert!(success);
     assert!(
         stdout.contains("No active session"),
-        "Expected 'No active session' message, got: {}",
-        stdout
+        "Expected 'No active session' message, got: {stdout}"
     );
 }
 
@@ -1228,8 +1214,7 @@ fn test_next_with_blocked_issues() {
     // Should suggest the blocker, not the blocked issue
     assert!(
         stdout.contains("Blocker issue"),
-        "Next should recommend the unblocked blocker, got: {}",
-        stdout
+        "Next should recommend the unblocked blocker, got: {stdout}"
     );
     assert!(
         !stdout.contains("Next: #1"),
@@ -1250,8 +1235,7 @@ fn test_next_all_closed() {
     assert!(success);
     assert!(
         stdout.contains("No issues ready to work on"),
-        "Expected 'No issues ready to work on' message, got: {}",
-        stdout
+        "Expected 'No issues ready to work on' message, got: {stdout}"
     );
 }
 
@@ -1286,9 +1270,7 @@ fn test_archive_already_archived() {
     // Should report already archived or fail
     assert!(
         stdout.contains("already") || stderr.contains("already") || !success,
-        "Archiving twice should indicate already archived, got stdout: {}, stderr: {}",
-        stdout,
-        stderr
+        "Archiving twice should indicate already archived, got stdout: {stdout}, stderr: {stderr}"
     );
 }
 
@@ -1465,8 +1447,7 @@ fn test_search_no_results() {
     assert!(success);
     assert!(
         stdout.contains("No issues found matching"),
-        "Expected 'No issues found matching' message, got: {}",
-        stdout
+        "Expected 'No issues found matching' message, got: {stdout}"
     );
 }
 
@@ -1903,8 +1884,7 @@ fn test_export_markdown_format() {
     assert!(success);
     assert!(
         stdout.contains("Exported"),
-        "Expected 'Exported' in stdout, got: {}",
-        stdout
+        "Expected 'Exported' in stdout, got: {stdout}"
     );
 
     // Verify file exists and has the issue content
@@ -1932,8 +1912,7 @@ fn test_archive_older_no_matches() {
     assert!(success);
     assert!(
         stdout.contains("No issues to archive") || stdout.contains("Archived 0"),
-        "Should report no issues to archive, got: {}",
-        stdout
+        "Should report no issues to archive, got: {stdout}"
     );
 }
 
@@ -1996,8 +1975,7 @@ fn test_unrelate_no_relation() {
     assert!(success);
     assert!(
         stdout.contains("No relation found"),
-        "Expected 'No relation found' message, got: {}",
-        stdout
+        "Expected 'No relation found' message, got: {stdout}"
     );
 }
 
@@ -2013,8 +1991,7 @@ fn test_related_no_relations() {
     assert!(success);
     assert!(
         stdout.contains("No related issues"),
-        "Expected 'No related issues' message, got: {}",
-        stdout
+        "Expected 'No related issues' message, got: {stdout}"
     );
 }
 
@@ -2079,8 +2056,7 @@ fn test_unlabel_nonexistent_label() {
     assert!(success);
     assert!(
         stdout.contains("not found"),
-        "Expected 'not found' message for non-existent label, got: {}",
-        stdout
+        "Expected 'not found' message for non-existent label, got: {stdout}"
     );
 }
 
@@ -2125,8 +2101,7 @@ fn test_block_self() {
     assert!(!success, "Blocking an issue by itself should fail");
     assert!(
         stderr.contains("cannot block itself"),
-        "Error should mention self-blocking, got stderr: {}",
-        stderr
+        "Error should mention self-blocking, got stderr: {stderr}"
     );
 }
 
@@ -2274,9 +2249,9 @@ fn test_stress_many_issues() {
 
     // Create 100 issues
     for i in 0..100 {
-        let title = format!("Issue number {}", i);
+        let title = format!("Issue number {i}");
         let (success, _, _) = run_crosslink(dir.path(), &["create", &title]);
-        assert!(success, "Failed to create issue {}", i);
+        assert!(success, "Failed to create issue {i}");
     }
 
     // Verify list works
@@ -2302,9 +2277,9 @@ fn test_stress_deep_nesting() {
     // Create 20 levels of nesting
     for i in 1..=20 {
         let parent_id = i.to_string();
-        let title = format!("Level {}", i);
+        let title = format!("Level {i}");
         let (success, _, _) = run_crosslink(dir.path(), &["subissue", &parent_id, &title]);
-        assert!(success, "Failed to create subissue at level {}", i);
+        assert!(success, "Failed to create subissue at level {i}");
     }
 
     // Verify tree command handles deep nesting
@@ -2329,7 +2304,7 @@ fn test_security_sql_injection_title() {
 
     for title in malicious_titles {
         let (success, _, _) = run_crosslink(dir.path(), &["create", title]);
-        assert!(success, "Failed to create issue with title: {}", title);
+        assert!(success, "Failed to create issue with title: {title}");
     }
 
     // Verify all issues exist and DB is intact
@@ -2356,7 +2331,7 @@ fn test_security_sql_injection_search() {
     for query in malicious_searches {
         let (success, _, _) = run_crosslink(dir.path(), &["issue", "search", query]);
         // Should not crash, may or may not find results
-        assert!(success, "Search crashed with query: {}", query);
+        assert!(success, "Search crashed with query: {query}");
     }
 
     // DB should still be intact
@@ -2441,8 +2416,7 @@ fn test_edge_empty_strings() {
         // If it accepted empty title, verify the issue was created
         assert!(
             stdout.contains("Created issue"),
-            "If success, should show created message, got: {}",
-            stdout
+            "If success, should show created message, got: {stdout}"
         );
     }
 
@@ -2467,8 +2441,7 @@ fn test_edge_large_ids() {
     assert!(!success, "Show with non-existent large ID should fail");
     assert!(
         stderr.contains("not found"),
-        "Error should say not found, got: {}",
-        stderr
+        "Error should say not found, got: {stderr}"
     );
 
     // Overflow ID - should fail with parse error or not found
@@ -2488,7 +2461,7 @@ fn test_stress_rapid_operations() {
 
     // Rapid create/close/reopen cycle
     for i in 0..20 {
-        let title = format!("Rapid issue {}", i);
+        let title = format!("Rapid issue {i}");
         run_crosslink(dir.path(), &["create", &title]);
         let id = (i + 1).to_string();
         run_crosslink(dir.path(), &["close", &id]);
@@ -2592,7 +2565,7 @@ fn test_unicode_variety_in_titles() {
 
     for (i, title) in unicode_titles.iter().enumerate() {
         let (success, _, _) = run_crosslink(dir.path(), &["create", title]);
-        assert!(success, "Failed to create issue with title: {}", title);
+        assert!(success, "Failed to create issue with title: {title}");
 
         // Verify it can be shown without panic
         let id = (i + 1).to_string();
@@ -2640,8 +2613,7 @@ fn test_unicode_in_descriptions_and_comments() {
     assert!(success);
     assert!(
         stdout.contains("日本語"),
-        "Show output should contain the Unicode description text, got: {}",
-        stdout
+        "Show output should contain the Unicode description text, got: {stdout}"
     );
 }
 
@@ -2677,7 +2649,7 @@ fn test_unicode_long_string_truncation() {
     // Create title that's definitely longer than truncation limit
     // Using 3-byte UTF-8 chars (←) to maximize byte/char mismatch
     let long_arrows = "←".repeat(60);
-    let (success, _, _) = run_crosslink(dir.path(), &["create", &format!("Long: {}", long_arrows)]);
+    let (success, _, _) = run_crosslink(dir.path(), &["create", &format!("Long: {long_arrows}")]);
     assert!(success);
 
     // List must not panic on truncation
@@ -2879,13 +2851,12 @@ fn test_kickoff_dry_run_prints_prompt_and_metadata() {
         &["kickoff", "run", "--dry-run", "add batch retry logic"],
     );
 
-    assert!(success, "kickoff --dry-run failed: stderr={}", stderr);
+    assert!(success, "kickoff --dry-run failed: stderr={stderr}");
 
     // Prompt content
     assert!(
         stdout.contains("KICKOFF: add batch retry logic"),
-        "Missing KICKOFF header in output: {}",
-        stdout
+        "Missing KICKOFF header in output: {stdout}"
     );
     assert!(stdout.contains("Feature Description"));
     assert!(stdout.contains("add batch retry logic"));
@@ -3009,8 +2980,7 @@ fn test_knowledge_search_with_tag_filter() {
     assert!(success);
     assert!(
         stdout.contains("design-alpha") || stdout.contains("Alpha"),
-        "Tag-filtered search should find design-alpha, got: {}",
-        stdout
+        "Tag-filtered search should find design-alpha, got: {stdout}"
     );
     assert!(
         !stdout.contains("notes-beta"),
@@ -3042,13 +3012,11 @@ fn test_knowledge_import_dry_run() {
     // Dry run should list files that WOULD be imported
     assert!(
         stdout.contains("doc-one") || stdout.contains("import"),
-        "Dry run should list files: {}",
-        stdout
+        "Dry run should list files: {stdout}"
     );
     assert!(
         stdout.contains("doc-two") || stdout.contains("import"),
-        "Dry run should list both files: {}",
-        stdout
+        "Dry run should list both files: {stdout}"
     );
 
     // Verify nothing was actually imported
@@ -3178,14 +3146,13 @@ fn test_hub_sync_idempotent() {
 
     // First sync
     let (s1, out1, err1) = run_crosslink(work_dir.path(), &["sync"]);
-    assert!(s1, "First sync failed: stdout={} stderr={}", out1, err1);
+    assert!(s1, "First sync failed: stdout={out1} stderr={err1}");
 
     // Second sync — must also succeed (idempotent)
     let (s2, out2, err2) = run_crosslink(work_dir.path(), &["sync"]);
     assert!(
         s2,
-        "Second sync failed (not idempotent): stdout={} stderr={}",
-        out2, err2
+        "Second sync failed (not idempotent): stdout={out2} stderr={err2}"
     );
 }
 
@@ -3195,7 +3162,7 @@ fn test_hub_sync_recovery_from_dirty_cache() {
 
     // First sync to initialize cache
     let (s, _, err) = run_crosslink(work_dir.path(), &["sync"]);
-    assert!(s, "Initial sync failed: {}", err);
+    assert!(s, "Initial sync failed: {err}");
 
     // Dirty the cache by appending to a file in the hub cache dir
     let hub_cache = work_dir.path().join(".crosslink/.hub-cache");
@@ -3206,7 +3173,7 @@ fn test_hub_sync_recovery_from_dirty_cache() {
 
     // Sync again — should recover cleanly
     let (s2, _, err2) = run_crosslink(work_dir.path(), &["sync"]);
-    assert!(s2, "Sync after dirty cache should recover: stderr={}", err2);
+    assert!(s2, "Sync after dirty cache should recover: stderr={err2}");
 }
 
 #[test]
@@ -3215,7 +3182,7 @@ fn test_offline_sync_does_not_panic() {
 
     // First sync to initialize the hub cache properly
     let (s, _, err) = run_crosslink(work_dir.path(), &["sync"]);
-    assert!(s, "Initial sync failed: {}", err);
+    assert!(s, "Initial sync failed: {err}");
 
     // Now point origin at a nonexistent path so fetch/push will fail
     let _ = Command::new("git")
@@ -3231,13 +3198,12 @@ fn test_offline_sync_does_not_panic() {
     // Sync with unreachable remote — should not panic, and should either
     // fail gracefully or succeed with local-only state
     let (_, stdout, stderr) = run_crosslink(work_dir.path(), &["sync"]);
-    let combined = format!("{}{}", stdout, stderr);
+    let combined = format!("{stdout}{stderr}");
 
     // Must not contain panic output
     assert!(
         !combined.contains("panicked"),
-        "Sync with offline remote should not panic: {}",
-        combined
+        "Sync with offline remote should not panic: {combined}"
     );
 }
 
@@ -3253,17 +3219,15 @@ fn test_issue_create_canonical() {
     let (success, stdout, stderr) =
         run_crosslink(dir.path(), &["issue", "create", "Canonical test"]);
 
-    assert!(success, "issue create failed: {}", stderr);
+    assert!(success, "issue create failed: {stderr}");
     assert!(
         stdout.contains("Created issue") && contains_issue_ref(&stdout, 1),
-        "Expected 'Created issue #1', got: {}",
-        stdout
+        "Expected 'Created issue #1', got: {stdout}"
     );
     // Canonical path should NOT emit a hint
     assert!(
         !stderr.contains("hint:"),
-        "Canonical path should not emit hint, got stderr: {}",
-        stderr
+        "Canonical path should not emit hint, got stderr: {stderr}"
     );
 }
 
@@ -3276,11 +3240,10 @@ fn test_issue_create_with_parent() {
     let (success, stdout, stderr) =
         run_crosslink(dir.path(), &["issue", "create", "Child", "--parent", "1"]);
 
-    assert!(success, "issue create --parent failed: {}", stderr);
+    assert!(success, "issue create --parent failed: {stderr}");
     assert!(
         stdout.contains("Created subissue") && contains_issue_ref(&stdout, 2),
-        "Expected subissue creation, got: {}",
-        stdout
+        "Expected subissue creation, got: {stdout}"
     );
 }
 
@@ -3302,11 +3265,10 @@ fn test_issue_quick_canonical() {
         ],
     );
 
-    assert!(success, "issue quick failed: {}", stderr);
+    assert!(success, "issue quick failed: {stderr}");
     assert!(
         stdout.contains("Created issue") && contains_issue_ref(&stdout, 1),
-        "Expected issue creation, got: {}",
-        stdout
+        "Expected issue creation, got: {stdout}"
     );
 }
 
@@ -3318,7 +3280,7 @@ fn test_issue_list_canonical() {
     run_crosslink(dir.path(), &["issue", "create", "Test issue"]);
     let (success, stdout, stderr) = run_crosslink(dir.path(), &["issue", "list"]);
 
-    assert!(success, "issue list failed: {}", stderr);
+    assert!(success, "issue list failed: {stderr}");
     assert!(stdout.contains("Test issue"));
     assert!(!stderr.contains("hint:"));
 }
@@ -3331,7 +3293,7 @@ fn test_issue_show_canonical() {
     run_crosslink(dir.path(), &["issue", "create", "Show me"]);
     let (success, stdout, stderr) = run_crosslink(dir.path(), &["issue", "show", "1"]);
 
-    assert!(success, "issue show failed: {}", stderr);
+    assert!(success, "issue show failed: {stderr}");
     assert!(stdout.contains("Show me"));
     assert!(!stderr.contains("hint:"));
 }
@@ -3344,7 +3306,7 @@ fn test_issue_close_canonical() {
     run_crosslink(dir.path(), &["issue", "create", "Close me"]);
     let (success, stdout, stderr) = run_crosslink(dir.path(), &["issue", "close", "1"]);
 
-    assert!(success, "issue close failed: {}", stderr);
+    assert!(success, "issue close failed: {stderr}");
     assert!(stdout.contains("Closed") || stdout.contains("closed"));
     assert!(!stderr.contains("hint:"));
 }
@@ -3358,7 +3320,7 @@ fn test_issue_update_canonical() {
     let (success, _, stderr) =
         run_crosslink(dir.path(), &["issue", "update", "1", "--title", "Updated"]);
 
-    assert!(success, "issue update failed: {}", stderr);
+    assert!(success, "issue update failed: {stderr}");
 
     let (_, show_out, _) = run_crosslink(dir.path(), &["issue", "show", "1"]);
     assert!(show_out.contains("Updated"));
@@ -3373,7 +3335,7 @@ fn test_issue_reopen_canonical() {
     run_crosslink(dir.path(), &["issue", "close", "1"]);
     let (success, stdout, stderr) = run_crosslink(dir.path(), &["issue", "reopen", "1"]);
 
-    assert!(success, "issue reopen failed: {}", stderr);
+    assert!(success, "issue reopen failed: {stderr}");
     assert!(stdout.contains("Reopened") || stdout.contains("reopen"));
 }
 
@@ -3385,7 +3347,7 @@ fn test_issue_delete_canonical() {
     run_crosslink(dir.path(), &["issue", "create", "Delete me"]);
     let (success, _, stderr) = run_crosslink(dir.path(), &["issue", "delete", "1", "-f"]);
 
-    assert!(success, "issue delete failed: {}", stderr);
+    assert!(success, "issue delete failed: {stderr}");
 
     let (_, list_out, _) = run_crosslink(dir.path(), &["issue", "list"]);
     assert!(!list_out.contains("Delete me"));
@@ -3402,7 +3364,7 @@ fn test_issue_comment_canonical() {
         &["issue", "comment", "1", "A canonical comment"],
     );
 
-    assert!(success, "issue comment failed: {}", stderr);
+    assert!(success, "issue comment failed: {stderr}");
 
     let (_, show_out, _) = run_crosslink(dir.path(), &["issue", "show", "1"]);
     assert!(show_out.contains("A canonical comment"));
@@ -3416,7 +3378,7 @@ fn test_issue_label_canonical() {
     run_crosslink(dir.path(), &["issue", "create", "Label target"]);
     let (success, _, stderr) = run_crosslink(dir.path(), &["issue", "label", "1", "bugfix"]);
 
-    assert!(success, "issue label failed: {}", stderr);
+    assert!(success, "issue label failed: {stderr}");
 
     let (_, show_out, _) = run_crosslink(dir.path(), &["issue", "show", "1"]);
     assert!(show_out.contains("bugfix"));
@@ -3446,7 +3408,7 @@ fn test_issue_block_canonical() {
     run_crosslink(dir.path(), &["issue", "create", "Blocker"]);
     let (success, _, stderr) = run_crosslink(dir.path(), &["issue", "block", "1", "2"]);
 
-    assert!(success, "issue block failed: {}", stderr);
+    assert!(success, "issue block failed: {stderr}");
 
     let (_, blocked_out, _) = run_crosslink(dir.path(), &["issue", "blocked"]);
     assert!(blocked_out.contains("Blocked"));
@@ -3494,7 +3456,7 @@ fn test_timer_start_canonical() {
     run_crosslink(dir.path(), &["issue", "create", "Timed issue"]);
     let (success, stdout, stderr) = run_crosslink(dir.path(), &["timer", "start", "1"]);
 
-    assert!(success, "timer start failed: {}", stderr);
+    assert!(success, "timer start failed: {stderr}");
     assert!(
         stdout.contains("Started") || stdout.contains("timer") || contains_issue_ref(&stdout, 1)
     );
@@ -3510,7 +3472,7 @@ fn test_timer_stop_canonical() {
     run_crosslink(dir.path(), &["timer", "start", "1"]);
     let (success, stdout, stderr) = run_crosslink(dir.path(), &["timer", "stop"]);
 
-    assert!(success, "timer stop failed: {}", stderr);
+    assert!(success, "timer stop failed: {stderr}");
     assert!(stdout.contains("Stopped") || stdout.contains("stopped") || stdout.contains("timer"));
     assert!(!stderr.contains("hint:"));
 }
@@ -3543,12 +3505,11 @@ fn test_new_alias_emits_hint() {
 
     let (success, stdout, stderr) = run_crosslink_info(dir.path(), &["new", "Aliased issue"]);
 
-    assert!(success, "new alias failed: {}", stderr);
+    assert!(success, "new alias failed: {stderr}");
     assert!(stdout.contains("Created issue") && contains_issue_ref(&stdout, 1));
     assert!(
         stderr.contains("hint:") && stderr.contains("issue create"),
-        "Expected hint about 'issue create', got stderr: {}",
-        stderr
+        "Expected hint about 'issue create', got stderr: {stderr}"
     );
 }
 
@@ -3560,12 +3521,11 @@ fn test_issues_alias_emits_hint() {
     run_crosslink(dir.path(), &["issue", "create", "Visible issue"]);
     let (success, stdout, stderr) = run_crosslink_info(dir.path(), &["issues"]);
 
-    assert!(success, "issues alias failed: {}", stderr);
+    assert!(success, "issues alias failed: {stderr}");
     assert!(stdout.contains("Visible issue"));
     assert!(
         stderr.contains("hint:") && stderr.contains("issue list"),
-        "Expected hint about 'issue list', got stderr: {}",
-        stderr
+        "Expected hint about 'issue list', got stderr: {stderr}"
     );
 }
 
@@ -3578,12 +3538,11 @@ fn test_issues_list_alias_emits_hint() {
     let (success, stdout, stderr) =
         run_crosslink_info(dir.path(), &["issues", "list", "-s", "open"]);
 
-    assert!(success, "issues list alias failed: {}", stderr);
+    assert!(success, "issues list alias failed: {stderr}");
     assert!(stdout.contains("Listed issue"));
     assert!(
         stderr.contains("hint:"),
-        "Expected hint on stderr, got: {}",
-        stderr
+        "Expected hint on stderr, got: {stderr}"
     );
 }
 
@@ -3596,12 +3555,11 @@ fn test_subissue_alias_emits_hint() {
     let (success, stdout, stderr) =
         run_crosslink_info(dir.path(), &["subissue", "1", "Child via alias"]);
 
-    assert!(success, "subissue alias failed: {}", stderr);
+    assert!(success, "subissue alias failed: {stderr}");
     assert!(stdout.contains("Created subissue") && contains_issue_ref(&stdout, 2));
     assert!(
         stderr.contains("hint:") && stderr.contains("issue create --parent"),
-        "Expected hint about 'issue create --parent', got stderr: {}",
-        stderr
+        "Expected hint about 'issue create --parent', got stderr: {stderr}"
     );
 }
 
@@ -3613,14 +3571,13 @@ fn test_start_alias_emits_hint() {
     run_crosslink(dir.path(), &["issue", "create", "Timer target"]);
     let (success, stdout, stderr) = run_crosslink_info(dir.path(), &["start", "1"]);
 
-    assert!(success, "start alias failed: {}", stderr);
+    assert!(success, "start alias failed: {stderr}");
     assert!(
         stdout.contains("Started") || stdout.contains("timer") || contains_issue_ref(&stdout, 1)
     );
     assert!(
         stderr.contains("hint:") && stderr.contains("timer start"),
-        "Expected hint about 'timer start', got stderr: {}",
-        stderr
+        "Expected hint about 'timer start', got stderr: {stderr}"
     );
 }
 
@@ -3633,12 +3590,11 @@ fn test_stop_alias_emits_hint() {
     run_crosslink(dir.path(), &["timer", "start", "1"]);
     let (success, stdout, stderr) = run_crosslink_info(dir.path(), &["stop"]);
 
-    assert!(success, "stop alias failed: {}", stderr);
+    assert!(success, "stop alias failed: {stderr}");
     assert!(stdout.contains("Stopped") || stdout.contains("stopped") || stdout.contains("timer"));
     assert!(
         stderr.contains("hint:") && stderr.contains("timer stop"),
-        "Expected hint about 'timer stop', got stderr: {}",
-        stderr
+        "Expected hint about 'timer stop', got stderr: {stderr}"
     );
 }
 
@@ -3657,8 +3613,7 @@ fn test_top_level_create_no_hint() {
     assert!(stdout.contains("Created issue") && contains_issue_ref(&stdout, 1));
     assert!(
         !stderr.contains("hint:"),
-        "Top-level 'create' shortcut should not emit hint, got stderr: {}",
-        stderr
+        "Top-level 'create' shortcut should not emit hint, got stderr: {stderr}"
     );
 }
 
@@ -3672,8 +3627,7 @@ fn test_top_level_list_no_hint() {
 
     assert!(
         !stderr.contains("hint:"),
-        "Top-level 'list' shortcut should not emit hint, got stderr: {}",
-        stderr
+        "Top-level 'list' shortcut should not emit hint, got stderr: {stderr}"
     );
 }
 
@@ -3687,8 +3641,7 @@ fn test_top_level_show_no_hint() {
 
     assert!(
         !stderr.contains("hint:"),
-        "Top-level 'show' shortcut should not emit hint, got stderr: {}",
-        stderr
+        "Top-level 'show' shortcut should not emit hint, got stderr: {stderr}"
     );
 }
 
@@ -3702,8 +3655,7 @@ fn test_top_level_close_no_hint() {
 
     assert!(
         !stderr.contains("hint:"),
-        "Top-level 'close' shortcut should not emit hint, got stderr: {}",
-        stderr
+        "Top-level 'close' shortcut should not emit hint, got stderr: {stderr}"
     );
 }
 
@@ -3719,8 +3671,7 @@ fn test_top_level_quick_no_hint() {
     assert!(stdout.contains("Created issue") && contains_issue_ref(&stdout, 1));
     assert!(
         !stderr.contains("hint:"),
-        "Top-level 'quick' shortcut should not emit hint, got stderr: {}",
-        stderr
+        "Top-level 'quick' shortcut should not emit hint, got stderr: {stderr}"
     );
 }
 
@@ -3738,8 +3689,7 @@ fn test_dry_run_flag_accepted() {
     // The command may fail (no style source configured), but clap should accept the flag
     assert!(
         !stderr.contains("unexpected argument"),
-        "--dry-run flag should be accepted, got stderr: {}",
-        stderr
+        "--dry-run flag should be accepted, got stderr: {stderr}"
     );
 }
 

--- a/crosslink/tests/smoke/adversarial.rs
+++ b/crosslink/tests/smoke/adversarial.rs
@@ -439,7 +439,7 @@ fn test_concurrent_creates_5() {
             thread::spawn(move || {
                 let output = Command::new(&bin)
                     .current_dir(&dir)
-                    .args(["create", &format!("Concurrent issue {}", i)])
+                    .args(["create", &format!("Concurrent issue {i}")])
                     .output()
                     .expect("failed to execute crosslink");
                 output.status.success()
@@ -468,7 +468,6 @@ fn test_concurrent_creates_5() {
     let count = parsed.as_array().map(|a| a.len()).unwrap_or(0);
     assert!(
         count >= 1,
-        "DB should have at least 1 issue after concurrent creates, got {}",
-        count,
+        "DB should have at least 1 issue after concurrent creates, got {count}",
     );
 }

--- a/crosslink/tests/smoke/cli_data.rs
+++ b/crosslink/tests/smoke/cli_data.rs
@@ -235,7 +235,7 @@ fn test_import_boundary_over() {
   "uuid": "00000000-0000-0000-0000-000000000001",
   "display_id": 1,
   "title": "Too big",
-  "description": "{}",
+  "description": "{desc_padding}",
   "priority": "medium",
   "status": "open",
   "labels": [],
@@ -249,8 +249,7 @@ fn test_import_boundary_over() {
   "created_at": "2026-01-01T00:00:00Z",
   "updated_at": "2026-01-01T00:00:00Z",
   "closed_at": null
-}}]"#,
-        desc_padding
+}}]"#
     );
 
     let import_path = h.temp_dir.path().join("too_big.json");
@@ -345,7 +344,7 @@ fn test_import_export_roundtrip() {
 
     // Create 10 issues with labels and comments
     for i in 1..=10 {
-        h.run_ok(&["create", &format!("Roundtrip issue {}", i), "-p", "medium"]);
+        h.run_ok(&["create", &format!("Roundtrip issue {i}"), "-p", "medium"]);
     }
     // Add labels to some
     h.run_ok(&["issue", "label", "1", "bug"]);
@@ -558,7 +557,7 @@ fn test_archive_older() {
 
     // Create and close several issues
     for i in 1..=5 {
-        h.run_ok(&["create", &format!("Issue {}", i)]);
+        h.run_ok(&["create", &format!("Issue {i}")]);
     }
     for i in 1..=5 {
         h.run_ok(&["close", &i.to_string()]);
@@ -576,9 +575,8 @@ fn test_archive_older() {
     let archive_list = h.run_ok(&["archive", "list"]);
     for i in 1..=5 {
         assert!(
-            archive_list.stdout.contains(&format!("Issue {}", i)),
-            "Issue {} should be in archive list",
-            i
+            archive_list.stdout.contains(&format!("Issue {i}")),
+            "Issue {i} should be in archive list"
         );
     }
 

--- a/crosslink/tests/smoke/cli_infra.rs
+++ b/crosslink/tests/smoke/cli_infra.rs
@@ -158,8 +158,7 @@ fn test_integrity_counters_clean() {
     let combined = format!("{}{}", r.stdout, r.stderr);
     assert!(
         combined.contains("PASS") || combined.contains("SKIPPED"),
-        "Expected PASS or SKIPPED for counters on fresh install, got:\n{}",
-        combined,
+        "Expected PASS or SKIPPED for counters on fresh install, got:\n{combined}",
     );
 }
 
@@ -170,8 +169,7 @@ fn test_integrity_hydration_clean() {
     let combined = format!("{}{}", r.stdout, r.stderr);
     assert!(
         combined.contains("PASS") || combined.contains("SKIPPED"),
-        "Expected PASS or SKIPPED for hydration on fresh install, got:\n{}",
-        combined,
+        "Expected PASS or SKIPPED for hydration on fresh install, got:\n{combined}",
     );
 }
 
@@ -182,8 +180,7 @@ fn test_integrity_locks_clean() {
     let combined = format!("{}{}", r.stdout, r.stderr);
     assert!(
         combined.contains("PASS") || combined.contains("SKIPPED"),
-        "Expected PASS or SKIPPED for locks on fresh install, got:\n{}",
-        combined,
+        "Expected PASS or SKIPPED for locks on fresh install, got:\n{combined}",
     );
 }
 
@@ -227,8 +224,7 @@ fn test_integrity_counters_repair() {
         let combined = format!("{}{}", r.stdout, r.stderr);
         assert!(
             combined.contains("REPAIRED") || combined.contains("PASS"),
-            "Expected REPAIRED or PASS after repair, got:\n{}",
-            combined,
+            "Expected REPAIRED or PASS after repair, got:\n{combined}",
         );
 
         // Verify it passes now
@@ -243,8 +239,7 @@ fn test_integrity_counters_repair() {
         let combined = format!("{}{}", r.stdout, r.stderr);
         assert!(
             combined.contains("SKIPPED") || combined.contains("FAIL"),
-            "Expected SKIPPED or FAIL when counters not populated, got:\n{}",
-            combined,
+            "Expected SKIPPED or FAIL when counters not populated, got:\n{combined}",
         );
     }
 }
@@ -324,8 +319,7 @@ fn test_prune_dry_run() {
                 || combined.contains("Prune plan")
                 || combined.contains("commit(s)")
                 || combined.contains("nothing to prune"),
-            "Expected dry-run output, got:\n{}",
-            combined,
+            "Expected dry-run output, got:\n{combined}",
         );
     }
 }

--- a/crosslink/tests/smoke/cli_tooling.rs
+++ b/crosslink/tests/smoke/cli_tooling.rs
@@ -36,7 +36,7 @@ fn harness_local_only() -> SmokeHarness {
             .args(&args)
             .output()
             .expect("git config failed");
-        assert!(out.status.success(), "git config {:?} failed", args);
+        assert!(out.status.success(), "git config {args:?} failed");
     }
 
     // Initial commit (crosslink init needs a git repo with at least one commit)
@@ -86,7 +86,7 @@ fn extract_issue_id(stdout: &str) -> String {
             }
         }
     }
-    panic!("Could not extract issue ID from output:\n{}", stdout);
+    panic!("Could not extract issue ID from output:\n{stdout}");
 }
 
 // ===========================================================================

--- a/crosslink/tests/smoke/concurrency.rs
+++ b/crosslink/tests/smoke/concurrency.rs
@@ -33,7 +33,7 @@ fn http_request(
     auth_token: Option<&str>,
 ) -> (u16, String) {
     let mut stream =
-        TcpStream::connect(format!("127.0.0.1:{}", port)).expect("Failed to connect to server");
+        TcpStream::connect(format!("127.0.0.1:{port}")).expect("Failed to connect to server");
     stream.set_read_timeout(Some(Duration::from_secs(10))).ok();
     stream.set_write_timeout(Some(Duration::from_secs(5))).ok();
 
@@ -150,10 +150,8 @@ fn test_concurrent_api_creates_10() {
             let token = Arc::clone(&token);
             thread::spawn(move || {
                 barrier.wait();
-                let payload = format!(
-                    r#"{{"title": "Concurrent issue {}", "priority": "medium"}}"#,
-                    i
-                );
+                let payload =
+                    format!(r#"{{"title": "Concurrent issue {i}", "priority": "medium"}}"#);
                 http_request(port, "POST", "/api/v1/issues", Some(&payload), Some(&token))
             })
         })
@@ -172,22 +170,15 @@ fn test_concurrent_api_creates_10() {
         let json = parse_json(&body);
         let id = json["id"]
             .as_i64()
-            .unwrap_or_else(|| panic!("Thread {} response missing numeric id: {}", idx, body));
+            .unwrap_or_else(|| panic!("Thread {idx} response missing numeric id: {body}"));
         assert!(
             !ids.contains(&id),
-            "Duplicate issue id {} from thread {}",
-            id,
-            idx
+            "Duplicate issue id {id} from thread {idx}"
         );
         ids.push(id);
     }
 
-    assert_eq!(
-        ids.len(),
-        10,
-        "Expected 10 distinct issue ids, got {:?}",
-        ids
-    );
+    assert_eq!(ids.len(), 10, "Expected 10 distinct issue ids, got {ids:?}");
 
     // Verify all 10 issues are queryable through the list endpoint.
     let (status, body) = http_request(port, "GET", "/api/v1/issues", None, Some(&token));
@@ -196,8 +187,7 @@ fn test_concurrent_api_creates_10() {
     let total = json["total"].as_u64().unwrap_or(0);
     assert_eq!(
         total, 10,
-        "Expected 10 issues in list after concurrent creates, got {}",
-        total
+        "Expected 10 issues in list after concurrent creates, got {total}"
     );
 }
 
@@ -268,40 +258,26 @@ fn test_parallel_lock_claim_one_winner() {
     let code_b = out_b.status.code().unwrap_or(-1);
     assert!(
         code_a == 0 || code_a == 1,
-        "agent-a exited with unexpected code {}\nstdout: {}\nstderr: {}",
-        code_a,
-        stdout_a,
-        stderr_a,
+        "agent-a exited with unexpected code {code_a}\nstdout: {stdout_a}\nstderr: {stderr_a}",
     );
     assert!(
         code_b == 0 || code_b == 1,
-        "agent-b exited with unexpected code {}\nstdout: {}\nstderr: {}",
-        code_b,
-        stdout_b,
-        stderr_b,
+        "agent-b exited with unexpected code {code_b}\nstdout: {stdout_b}\nstderr: {stderr_b}",
     );
 
     // At most one agent wins.
     assert!(
         !(success_a && success_b),
         "Both agents claimed the same lock simultaneously — expected exactly one winner.\n\
-         agent-a stdout: {}\nagent-b stdout: {}",
-        stdout_a,
-        stdout_b,
+         agent-a stdout: {stdout_a}\nagent-b stdout: {stdout_b}",
     );
 
     // At least one agent wins (the lock must be claimable by somebody).
     assert!(
         success_a || success_b,
         "Neither agent was able to claim the lock.\n\
-         agent-a: code={} stdout={} stderr={}\n\
-         agent-b: code={} stdout={} stderr={}",
-        code_a,
-        stdout_a,
-        stderr_a,
-        code_b,
-        stdout_b,
-        stderr_b,
+         agent-a: code={code_a} stdout={stdout_a} stderr={stderr_a}\n\
+         agent-b: code={code_b} stdout={stdout_b} stderr={stderr_b}",
     );
 
     // The loser must not be killed by a signal (code must be Some).  We do
@@ -309,14 +285,14 @@ fn test_parallel_lock_claim_one_winner() {
     // the lock layer OR from the underlying git/SharedWriter layer, both of
     // which produce valid (non-empty) diagnostic output.
     if !success_a {
-        let combined_a = format!("{}{}", stdout_a, stderr_a);
+        let combined_a = format!("{stdout_a}{stderr_a}");
         assert!(
             !combined_a.is_empty(),
             "Losing agent-a produced no output at all",
         );
     }
     if !success_b {
-        let combined_b = format!("{}{}", stdout_b, stderr_b);
+        let combined_b = format!("{stdout_b}{stderr_b}");
         assert!(
             !combined_b.is_empty(),
             "Losing agent-b produced no output at all",
@@ -357,7 +333,7 @@ fn test_offline_local_operations_then_sync() {
             .args(&args)
             .output()
             .expect("git config failed");
-        assert!(out.status.success(), "git config {:?} failed", args);
+        assert!(out.status.success(), "git config {args:?} failed");
     }
 
     // Make an initial commit (crosslink init needs a git repo with at least
@@ -405,15 +381,13 @@ fn test_offline_local_operations_then_sync() {
     let (ok, stdout, stderr) = run(&["issue", "create", "Offline issue alpha"]);
     assert!(
         ok,
-        "create should succeed offline\nstdout: {}\nstderr: {}",
-        stdout, stderr
+        "create should succeed offline\nstdout: {stdout}\nstderr: {stderr}"
     );
 
     let (ok, stdout, stderr) = run(&["issue", "create", "Offline issue beta", "-p", "high"]);
     assert!(
         ok,
-        "create with priority should succeed offline\nstdout: {}\nstderr: {}",
-        stdout, stderr
+        "create with priority should succeed offline\nstdout: {stdout}\nstderr: {stderr}"
     );
 
     // --- Offline list ---
@@ -422,18 +396,15 @@ fn test_offline_local_operations_then_sync() {
     let (ok, list_stdout, stderr) = run(&["issue", "list", "-s", "all"]);
     assert!(
         ok,
-        "list should succeed offline\nstdout: {}\nstderr: {}",
-        list_stdout, stderr
+        "list should succeed offline\nstdout: {list_stdout}\nstderr: {stderr}"
     );
     assert!(
         list_stdout.contains("Offline issue alpha"),
-        "list should show alpha\nstdout: {}",
-        list_stdout
+        "list should show alpha\nstdout: {list_stdout}"
     );
     assert!(
         list_stdout.contains("Offline issue beta"),
-        "list should show beta\nstdout: {}",
-        list_stdout
+        "list should show beta\nstdout: {list_stdout}"
     );
 
     // --- Offline show ---
@@ -445,25 +416,23 @@ fn test_offline_local_operations_then_sync() {
         .find(|l| l.contains("Offline issue alpha"))
         .and_then(|l| l.split_whitespace().next())
         .map(|id| id.trim_start_matches('#').to_string())
-        .unwrap_or_else(|| panic!("Could not find alpha in list output: {}", list_stdout));
+        .unwrap_or_else(|| panic!("Could not find alpha in list output: {list_stdout}"));
 
     let beta_id = list_stdout
         .lines()
         .find(|l| l.contains("Offline issue beta"))
         .and_then(|l| l.split_whitespace().next())
         .map(|id| id.trim_start_matches('#').to_string())
-        .unwrap_or_else(|| panic!("Could not find beta in list output: {}", list_stdout));
+        .unwrap_or_else(|| panic!("Could not find beta in list output: {list_stdout}"));
 
     let (ok, stdout, stderr) = run(&["issue", "show", &alpha_id]);
     assert!(
         ok,
-        "show should succeed offline\nstdout: {}\nstderr: {}",
-        stdout, stderr
+        "show should succeed offline\nstdout: {stdout}\nstderr: {stderr}"
     );
     assert!(
         stdout.contains("Offline issue alpha"),
-        "show should display alpha\nstdout: {}",
-        stdout
+        "show should display alpha\nstdout: {stdout}"
     );
 
     // --- Offline update ---
@@ -476,16 +445,14 @@ fn test_offline_local_operations_then_sync() {
     ]);
     assert!(
         ok,
-        "update should succeed offline\nstdout: {}\nstderr: {}",
-        stdout, stderr
+        "update should succeed offline\nstdout: {stdout}\nstderr: {stderr}"
     );
 
     let (ok, stdout, _) = run(&["issue", "show", &beta_id]);
     assert!(ok, "show after offline update should succeed");
     assert!(
         stdout.contains("beta (updated)") || stdout.contains("Offline issue beta"),
-        "show should reflect the update\nstdout: {}",
-        stdout
+        "show should reflect the update\nstdout: {stdout}"
     );
 
     // --- Add a remote and sync ---
@@ -534,13 +501,11 @@ fn test_offline_local_operations_then_sync() {
     let (ok, stdout, stderr) = run(&["issue", "list", "-s", "all"]);
     assert!(
         ok,
-        "list should succeed after sync\nstdout: {}\nstderr: {}",
-        stdout, stderr
+        "list should succeed after sync\nstdout: {stdout}\nstderr: {stderr}"
     );
     assert!(
         stdout.contains("Offline issue alpha"),
-        "alpha should survive sync\nstdout: {}",
-        stdout
+        "alpha should survive sync\nstdout: {stdout}"
     );
 }
 
@@ -582,7 +547,7 @@ fn test_sqlite_busy_concurrent_writes() {
                 barrier.wait();
                 Command::new(&bin)
                     .current_dir(&dir)
-                    .args(["issue", "create", &format!("SQLITE_BUSY issue {}", i)])
+                    .args(["issue", "create", &format!("SQLITE_BUSY issue {i}")])
                     .output()
                     .expect("failed to execute crosslink")
             })
@@ -593,13 +558,12 @@ fn test_sqlite_busy_concurrent_writes() {
     for (i, handle) in handles.into_iter().enumerate() {
         let output = handle
             .join()
-            .unwrap_or_else(|_| panic!("thread {} panicked", i));
+            .unwrap_or_else(|_| panic!("thread {i} panicked"));
 
         // A signal-terminated process has no exit code — that is a bug.
         assert!(
             output.status.code().is_some(),
-            "thread {} process killed by signal (possible panic/abort)",
-            i
+            "thread {i} process killed by signal (possible panic/abort)"
         );
 
         if output.status.success() {
@@ -610,8 +574,7 @@ fn test_sqlite_busy_concurrent_writes() {
 
     assert!(
         successes >= 1,
-        "At least one concurrent create must succeed, but all {} failed",
-        THREADS,
+        "At least one concurrent create must succeed, but all {THREADS} failed",
     );
 
     // Count successfully queryable issues; must equal successes.
@@ -622,9 +585,7 @@ fn test_sqlite_busy_concurrent_writes() {
 
     assert!(
         db_count >= successes as usize,
-        "DB has {} issues but {} creates succeeded — some data was lost",
-        db_count,
-        successes,
+        "DB has {db_count} issues but {successes} creates succeeded — some data was lost",
     );
 }
 
@@ -723,12 +684,11 @@ fn test_split_brain_lock_detection() {
         assert!(
             !check_text.contains("agent-a") || !check_text.contains("agent-b"),
             "Both agents appear as lock holders simultaneously — split-brain not resolved.\n\
-             locks check output: {}",
-            check_text,
+             locks check output: {check_text}",
         );
     } else {
         // Sync failed — it should mention a lock or conflict in its output.
-        let combined = format!("{}{}", sync_stdout, sync_stderr);
+        let combined = format!("{sync_stdout}{sync_stderr}");
         assert!(
             combined.contains("lock")
                 || combined.contains("Lock")

--- a/crosslink/tests/smoke/harness.rs
+++ b/crosslink/tests/smoke/harness.rs
@@ -103,7 +103,7 @@ impl SmokeHarness {
                 .args(&args)
                 .output()
                 .expect("git config/remote failed to execute");
-            assert!(out.status.success(), "git {:?} failed", args);
+            assert!(out.status.success(), "git {args:?} failed");
         }
 
         // Initial commit + push so the remote has a main branch
@@ -339,7 +339,7 @@ impl SmokeHarness {
         assert!(out.status.success(), "git init for fork failed");
 
         for args in [
-            vec!["config", "user.email", &format!("{}@test.local", agent_id)],
+            vec!["config", "user.email", &format!("{agent_id}@test.local")],
             vec!["config", "user.name", agent_id],
             vec![
                 "remote",
@@ -353,7 +353,7 @@ impl SmokeHarness {
                 .args(&args)
                 .output()
                 .expect("git config/remote failed");
-            assert!(out.status.success(), "git {:?} failed for fork", args);
+            assert!(out.status.success(), "git {args:?} failed for fork");
         }
 
         // Fetch and checkout main from the shared remote

--- a/crosslink/tests/smoke/lifecycle.rs
+++ b/crosslink/tests/smoke/lifecycle.rs
@@ -55,7 +55,7 @@ fn extract_issue_id(stdout: &str) -> String {
             }
         }
     }
-    panic!("Could not extract issue ID from output:\n{}", stdout);
+    panic!("Could not extract issue ID from output:\n{stdout}");
 }
 
 // ===========================================================================

--- a/crosslink/tests/smoke/server_api.rs
+++ b/crosslink/tests/smoke/server_api.rs
@@ -27,7 +27,7 @@ fn http_request(
     auth_token: Option<&str>,
 ) -> (u16, String) {
     let mut stream =
-        TcpStream::connect(format!("127.0.0.1:{}", port)).expect("Failed to connect to server");
+        TcpStream::connect(format!("127.0.0.1:{port}")).expect("Failed to connect to server");
     stream.set_read_timeout(Some(Duration::from_secs(10))).ok();
     stream.set_write_timeout(Some(Duration::from_secs(5))).ok();
 
@@ -160,12 +160,8 @@ fn test_server_starts_and_stops() {
     let port = h.start_server();
 
     // Verify the port is listening by opening a TCP connection.
-    let stream = TcpStream::connect(format!("127.0.0.1:{}", port));
-    assert!(
-        stream.is_ok(),
-        "Server should be listening on port {}",
-        port
-    );
+    let stream = TcpStream::connect(format!("127.0.0.1:{port}"));
+    assert!(stream.is_ok(), "Server should be listening on port {port}");
     drop(stream);
 
     h.stop_server();
@@ -174,7 +170,7 @@ fn test_server_starts_and_stops() {
     // Give it a moment to fully shut down.
     std::thread::sleep(Duration::from_millis(200));
     let stream = TcpStream::connect_timeout(
-        &format!("127.0.0.1:{}", port).parse().unwrap(),
+        &format!("127.0.0.1:{port}").parse().unwrap(),
         Duration::from_millis(500),
     );
     assert!(
@@ -212,8 +208,7 @@ fn test_api_create_issue() {
     let (status, body) = authed_request(port, &token, "POST", "/api/v1/issues", Some(payload));
     assert!(
         status == 200 || status == 201,
-        "Create issue should return 200 or 201, got {}",
-        status
+        "Create issue should return 200 or 201, got {status}"
     );
 
     let json = parse_json(&body);
@@ -361,8 +356,7 @@ fn test_api_404_unknown() {
     let (status, _) = authed_request(port, &token, "GET", "/api/v1/nonexistent", None);
     assert_eq!(
         status, 404,
-        "Unknown API path should return 404, got {}",
-        status
+        "Unknown API path should return 404, got {status}"
     );
 }
 
@@ -393,8 +387,7 @@ fn test_api_invalid_json() {
     );
     assert!(
         status == 400 || status == 422,
-        "Invalid JSON should return 400 or 422, got {}",
-        status
+        "Invalid JSON should return 400 or 422, got {status}"
     );
 }
 
@@ -411,8 +404,7 @@ fn test_api_sessions() {
     let (status, _) = authed_request(port, &token, "GET", "/api/v1/sessions/current", None);
     assert_eq!(
         status, 404,
-        "No session should exist initially, got {}",
-        status
+        "No session should exist initially, got {status}"
     );
 
     // Start a session.
@@ -447,8 +439,7 @@ fn test_api_sessions() {
     let (status, _) = authed_request(port, &token, "GET", "/api/v1/sessions/current", None);
     assert_eq!(
         status, 404,
-        "After ending session, current should be 404, got {}",
-        status
+        "After ending session, current should be 404, got {status}"
     );
 }
 
@@ -487,7 +478,7 @@ fn test_api_milestones() {
         port,
         &token,
         "GET",
-        &format!("/api/v1/milestones/{}", ms_id),
+        &format!("/api/v1/milestones/{ms_id}"),
         None,
     );
     assert_eq!(status, 200);
@@ -520,8 +511,7 @@ fn test_api_search() {
     let total = json["total"].as_u64().unwrap_or(0);
     assert!(
         total >= 2,
-        "Search for 'authentication' should find at least 2 results, got {}",
-        total
+        "Search for 'authentication' should find at least 2 results, got {total}"
     );
 
     let items = json["items"].as_array().expect("items should be an array");
@@ -531,8 +521,7 @@ fn test_api_search() {
             let title = item["title"].as_str().unwrap_or("");
             assert!(
                 title.to_lowercase().contains("authentication"),
-                "Issue result should match query: {}",
-                title
+                "Issue result should match query: {title}"
             );
         }
     }
@@ -619,7 +608,7 @@ fn test_ws_connects() {
 
     // Perform a WebSocket upgrade handshake using raw TCP.
     // We just verify the server responds with 101 Switching Protocols.
-    let mut stream = TcpStream::connect(format!("127.0.0.1:{}", port))
+    let mut stream = TcpStream::connect(format!("127.0.0.1:{port}"))
         .expect("Failed to connect for WebSocket test");
     stream.set_read_timeout(Some(Duration::from_secs(5))).ok();
     stream.set_write_timeout(Some(Duration::from_secs(5))).ok();
@@ -750,8 +739,7 @@ fn test_api_issues_blocked_and_ready() {
     let total = json["total"].as_u64().unwrap_or(0);
     assert!(
         total >= 2,
-        "Should have at least 2 ready issues, got {}",
-        total
+        "Should have at least 2 ready issues, got {total}"
     );
 
     // Blocked list should be empty (no dependencies set).
@@ -782,8 +770,7 @@ fn test_api_search_empty_query() {
     let (status, _) = authed_request(port, &token, "GET", "/api/v1/search?q=", None);
     assert_eq!(
         status, 400,
-        "Empty search query should return 400, got {}",
-        status
+        "Empty search query should return 400, got {status}"
     );
 }
 

--- a/crosslink/tests/smoke/tui_proptest.rs
+++ b/crosslink/tests/smoke/tui_proptest.rs
@@ -23,8 +23,7 @@ fn assert_issue_count_flat(h: &SmokeHarness, status: &str, expected: usize) {
     let count = count_issues(h, status);
     assert_eq!(
         count, expected,
-        "expected {} issues with status {:?}, got {}",
-        expected, status, count
+        "expected {expected} issues with status {status:?}, got {count}"
     );
 }
 
@@ -70,7 +69,7 @@ fn test_roundtrip_label_list() {
     // Create issues with different labels
     let labels = ["bug", "feature", "docs", "ci", "refactor"];
     for (i, label) in labels.iter().enumerate() {
-        h.run_ok(&["create", &format!("Issue for label {}", label)]);
+        h.run_ok(&["create", &format!("Issue for label {label}")]);
         h.run_ok(&["issue", "label", &(i + 1).to_string(), label]);
     }
 
@@ -78,7 +77,7 @@ fn test_roundtrip_label_list() {
     for label in &labels {
         let result = h.run_ok(&["list", "-l", label]);
         assert!(
-            result.stdout_contains(&format!("Issue for label {}", label)),
+            result.stdout_contains(&format!("Issue for label {label}")),
             "list with -l {} didn't contain expected issue.\nGot: {}",
             label,
             result.stdout
@@ -123,7 +122,7 @@ fn test_roundtrip_comment_trail() {
             result.stdout
         );
         assert!(
-            result.stdout_contains(&format!("[{}]", kind)),
+            result.stdout_contains(&format!("[{kind}]")),
             "trail missing kind tag [{}].\nGot: {}",
             kind,
             result.stdout
@@ -136,13 +135,13 @@ fn test_roundtrip_export_import() {
     let h = SmokeHarness::new();
     // Create issues with labels and comments
     for i in 1..=5 {
-        h.run_ok(&["create", &format!("Export issue {}", i), "-p", "medium"]);
+        h.run_ok(&["create", &format!("Export issue {i}"), "-p", "medium"]);
         h.run_ok(&["issue", "label", &i.to_string(), "test-label"]);
         h.run_ok(&[
             "issue",
             "comment",
             &i.to_string(),
-            &format!("Comment on {}", i),
+            &format!("Comment on {i}"),
         ]);
     }
 
@@ -154,7 +153,7 @@ fn test_roundtrip_export_import() {
     assert!(export_path.exists(), "export file was not created");
     let content = std::fs::read_to_string(&export_path).unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&content)
-        .unwrap_or_else(|e| panic!("export JSON is invalid: {}\ncontent: {}", e, content));
+        .unwrap_or_else(|e| panic!("export JSON is invalid: {e}\ncontent: {content}"));
     assert_eq!(
         parsed.as_array().map(|a| a.len()),
         Some(5),
@@ -174,7 +173,7 @@ fn test_roundtrip_export_import() {
     let list_result = h2.run_ok(&["list", "-s", "all"]);
     for i in 1..=5 {
         assert!(
-            list_result.stdout_contains(&format!("Export issue {}", i)),
+            list_result.stdout_contains(&format!("Export issue {i}")),
             "imported issue {} missing from list.\nGot: {}",
             i,
             list_result.stdout
@@ -320,7 +319,7 @@ fn test_regression_subissue_chain() {
 fn test_scale_50_issues() {
     let h = SmokeHarness::new();
     for i in 1..=50 {
-        h.run_ok(&["create", &format!("Scale test issue {}", i)]);
+        h.run_ok(&["create", &format!("Scale test issue {i}")]);
     }
     assert_issue_count_flat(&h, "all", 50);
 
@@ -337,7 +336,7 @@ fn test_scale_many_labels() {
     h.run_ok(&["create", "Many labels issue"]);
 
     // Add 20 different labels
-    let labels: Vec<String> = (1..=20).map(|i| format!("label-{}", i)).collect();
+    let labels: Vec<String> = (1..=20).map(|i| format!("label-{i}")).collect();
     for label in &labels {
         h.run_ok(&["issue", "label", "1", label]);
     }
@@ -364,7 +363,7 @@ fn test_scale_deep_subissues_10() {
         h.run_ok(&[
             "issue",
             "create",
-            &format!("Depth level {}", depth),
+            &format!("Depth level {depth}"),
             "--parent",
             &(depth - 1).to_string(),
         ]);
@@ -374,7 +373,7 @@ fn test_scale_deep_subissues_10() {
     let result = h.run_ok(&["issue", "tree"]);
     for depth in 1..=10 {
         assert!(
-            result.stdout_contains(&format!("Depth level {}", depth)),
+            result.stdout_contains(&format!("Depth level {depth}")),
             "tree missing depth level {}.\nGot: {}",
             depth,
             result.stdout
@@ -426,12 +425,12 @@ fn test_scale_comments_20() {
     ];
     for i in 1..=20 {
         let kind = kinds[(i - 1) % kinds.len()];
-        h.run_ok(&["create", &format!("Issue for comment {}", i)]);
+        h.run_ok(&["create", &format!("Issue for comment {i}")]);
         h.run_ok(&[
             "issue",
             "comment",
             &i.to_string(),
-            &format!("Comment number {} of twenty", i),
+            &format!("Comment number {i} of twenty"),
             "--kind",
             kind,
         ]);
@@ -440,7 +439,7 @@ fn test_scale_comments_20() {
     for i in 1..=20 {
         let result = h.run_ok(&["workflow", "trail", &i.to_string()]);
         assert!(
-            result.stdout_contains(&format!("Comment number {} of twenty", i)),
+            result.stdout_contains(&format!("Comment number {i} of twenty")),
             "trail for issue {} missing comment.\nGot: {}",
             i,
             result.stdout


### PR DESCRIPTION
## Summary

Implements `crosslink sentinel` from the design doc in `.design/patrol-autonomous-maintenance.md` (origin: forecast-bio/crosslink#504). A persistent command that monitors external sources and autonomously dispatches scoped maintenance tasks via the existing kickoff infrastructure.

24 commits, 4540 lines, 28 files. 19 sentinel-specific tests (12 SeenSet unit + 7 CLI integration). All 4643 tests pass, zero warnings, zero `#[allow(dead_code)]` annotations.

## Milestones (all complete on this branch)

**V0 — Foundation**
- Module skeleton + CLI dispatch (#650)
- Schema v16: `sentinel_runs` + `sentinel_dispatches` tables (#651)
- Config registry + hook-config.json template (#658)
- `GitHubLabelSource` polling `agent-todo:*` issues (#652)
- 4-layer dedup: source filter, SeenSet, DB constraint, GH comment marker (#653)
- Dispatch engine: triage + kickoff integration (#654)
- Result collection + structured GH comment templates (#655)
- `sentinel history` command (#656)
- Sonnet→Opus automatic escalation with cooldown (#657)

**V1 — Daemon Mode + Fix Rule**
- `sentinel watch` daemon (separate process, PID file, signals) (#659)
- `agent-todo: fix` rule with `VerifyLevel::Ci` + draft PR (#660)
- Per-agent in-flight details in `sentinel status` (#661)
- Closed V0/V1 design-doc gaps: Test File/Output, GH_TOKEN, PR link, integration tests (#662)

**V2 — Multi-Source + Policy**
- `InternalHygieneSource`: stale issues, orphans, unlabeled (#663)
- `GitHubCISource`: failed workflow runs (#664)
- `sentinel metrics` command: success rates per model/rule (#665)

**V3 — Proactive + Real-Time**
- `MaintenanceSweepSource`: lint drift + test regression (#666)
- Webhook receiver: axum HTTP server with HMAC-SHA256 verification (#667)
- Slack/webhook outbound notifications for dispatch results (#668)
- `sentinel patterns`: historical pattern detection (#669)
- Self-tuning model selection from success rates (#670)

**Quality**
- QA audit pass: removed all but one `allow(dead_code)`, fixed 11-param function, label filter substring bug, git diff crash on fresh repos, missing stderr logging (#671)
- Full async refactor: watch loop now uses tokio + select! to multiplex polling timer, webhook events, and shutdown signals. Webhook module fully wired end-to-end. Zero `allow(dead_code)` remaining (#672)

## Architecture highlights

- **Two-tier human filter**: `agent-todo:*` label is the human approval gate. `replicate` runs `VerifyLevel::Local` (tests only). `fix` runs `VerifyLevel::Ci` and opens a draft PR.
- **Multi-layer dedup**: source-level → in-memory SeenSet → DB constraint → GH comment marker. Same issue can have separate `replicate` and `fix` dispatches in flight.
- **Sonnet→Opus escalation**: first attempt uses Sonnet, retries with Opus after configurable cooldown (default 30min). Max 2 attempts → outcome `exhausted`.
- **Self-tuning**: when Sonnet success rate drops below 40% for a label (≥5 completions), tuning auto-promotes that label to Opus on first attempt.
- **Async daemon**: tokio multi-thread runtime, sync engine wrapped via `spawn_blocking`. Webhook events processed in real-time via dedicated `process_signal_batch` path (mode `webhook` distinguishes from polling cycles in history).
- **Path enforcement**: `AgentScope.allowed_paths` injected into agent prompt as a Path Enforcement section so each rule's scope is contract-bound.

## Test plan

- [x] `cargo test` — full suite passes (4643 tests)
- [x] `cargo clippy --all-targets -- -D warnings` — zero warnings
- [x] `cargo fmt --check` — clean
- [x] `crosslink sentinel run --dry-run` shows polling config
- [x] `crosslink sentinel run` with `enabled: false` exits cleanly
- [x] `crosslink sentinel history` displays empty + populated states
- [x] `crosslink sentinel history --detail` shows per-dispatch breakdown
- [x] `crosslink sentinel metrics` shows success rates after dispatch data
- [x] `crosslink sentinel patterns` detects repeat-failures, low-success, escalation-heavy
- [x] `crosslink sentinel status` reports daemon state + in-flight agents
- [x] Schema migration v15 → v16 creates sentinel tables on existing DBs
- [x] Manual test: label a GH issue with `agent-todo: replicate`, run `sentinel run`, verify agent dispatched + result posted back
- [x] Manual test: enable `sentinel.webhook.enabled`, configure secret, point GH webhook at the port, label an issue, verify real-time dispatch

## Out of scope (deferred to future work)

- `sentinel.toml` declarative policy file (V2 design — current implementation uses hardcoded triage rules in dispatch.rs which is sufficient until 3+ rule patterns emerge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)