### PR TITLE
fix(serve): wire dashboard to bearer-token auth (GH#556)

### DIFF
--- a/crosslink/src/server/mod.rs
+++ b/crosslink/src/server/mod.rs
@@ -91,6 +91,10 @@ pub async fn run(
             axum::http::header::ACCEPT,
         ]);
 
+    // Remember whether a dashboard is being served so we can print a
+    // clickable URL (with the bearer token baked in) at startup.
+    let has_dashboard = dashboard_dir.is_some();
+
     let app = routes::build_router(state.clone(), dashboard_dir)
         .layer(middleware::from_fn_with_state(
             state.clone(),
@@ -101,6 +105,13 @@ pub async fn run(
 
     let addr = SocketAddr::from(([127, 0, 0, 1], port));
     println!("crosslink serve: listening on http://{addr}");
+    if has_dashboard {
+        // The dashboard reads `?token=<value>` on first load, persists it to
+        // sessionStorage, and strips it from the URL (see
+        // `dashboard/src/auth/bootstrap.ts`). Subsequent reloads in the same
+        // tab reuse the stored token.
+        println!("  Dashboard: http://{addr}/?token={}", state.auth_token);
+    }
     println!("  API:       http://{addr}/api/v1/health");
     println!("  WebSocket: ws://{addr}/ws");
     println!("  Auth:      Bearer {}", state.auth_token);

--- a/dashboard/src/auth/__tests__/bootstrap.test.ts
+++ b/dashboard/src/auth/__tests__/bootstrap.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { bootstrapAuth, TOKEN_STORAGE_KEY } from "../bootstrap";
+import { configureApiClient } from "@/api/client";
+
+// Observe `configureApiClient` without touching the real module singleton.
+vi.mock("@/api/client", () => ({
+  configureApiClient: vi.fn(),
+}));
+
+const mockedConfigure = configureApiClient as unknown as ReturnType<typeof vi.fn>;
+
+describe("bootstrapAuth", () => {
+  const originalFetch = globalThis.fetch;
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.sessionStorage.clear();
+    window.history.replaceState({}, "", "/");
+    fetchSpy = vi.fn(() =>
+      Promise.resolve(new Response("{}", { status: 200 })),
+    );
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("returns null and does not configure the client when no token is present", () => {
+    const result = bootstrapAuth();
+
+    expect(result).toBeNull();
+    expect(mockedConfigure).not.toHaveBeenCalled();
+  });
+
+  it("extracts a token from ?token=, persists it, scrubs the URL, and configures the client", () => {
+    window.history.replaceState({}, "", "/?token=secret123&foo=bar");
+
+    const result = bootstrapAuth();
+
+    expect(result).toBe("secret123");
+    expect(window.sessionStorage.getItem(TOKEN_STORAGE_KEY)).toBe("secret123");
+    expect(window.location.search).toBe("?foo=bar");
+    expect(mockedConfigure).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses a token stored by a previous load when ?token= is absent", () => {
+    window.sessionStorage.setItem(TOKEN_STORAGE_KEY, "persisted456");
+
+    const result = bootstrapAuth();
+
+    expect(result).toBe("persisted456");
+    expect(mockedConfigure).toHaveBeenCalledTimes(1);
+  });
+
+  it("prefers the URL token over the stored token to support re-auth", () => {
+    window.sessionStorage.setItem(TOKEN_STORAGE_KEY, "oldtoken");
+    window.history.replaceState({}, "", "/?token=newtoken");
+
+    const result = bootstrapAuth();
+
+    expect(result).toBe("newtoken");
+    expect(window.sessionStorage.getItem(TOKEN_STORAGE_KEY)).toBe("newtoken");
+  });
+
+  it("installs a fetch wrapper that attaches Authorization: Bearer <token>", async () => {
+    window.history.replaceState({}, "", "/?token=abc");
+
+    bootstrapAuth();
+
+    const call = mockedConfigure.mock.calls[0]?.[0] as
+      | { fetchFn?: typeof globalThis.fetch }
+      | undefined;
+    expect(call?.fetchFn).toBeDefined();
+
+    await call!.fetchFn!("/api/v1/agents", { method: "GET" });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [, init] = fetchSpy.mock.calls[0] as [unknown, RequestInit];
+    const headers = new Headers(init.headers);
+    expect(headers.get("Authorization")).toBe("Bearer abc");
+  });
+
+  it("preserves caller-supplied headers when attaching Authorization", async () => {
+    window.history.replaceState({}, "", "/?token=xyz");
+
+    bootstrapAuth();
+
+    const call = mockedConfigure.mock.calls[0]?.[0] as
+      | { fetchFn?: typeof globalThis.fetch }
+      | undefined;
+    expect(call?.fetchFn).toBeDefined();
+
+    await call!.fetchFn!("/api/v1/x", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "X-Foo": "bar" },
+      body: "{}",
+    });
+
+    const [, init] = fetchSpy.mock.calls[0] as [unknown, RequestInit];
+    const headers = new Headers(init.headers);
+    expect(headers.get("Authorization")).toBe("Bearer xyz");
+    expect(headers.get("Content-Type")).toBe("application/json");
+    expect(headers.get("X-Foo")).toBe("bar");
+  });
+
+  it("gracefully degrades when sessionStorage.setItem throws", () => {
+    const spy = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new Error("QuotaExceededError");
+      });
+    window.history.replaceState({}, "", "/?token=abc");
+
+    const result = bootstrapAuth();
+
+    // The token still works for this load; persistence just failed.
+    expect(result).toBe("abc");
+    expect(window.location.search).toBe("");
+    expect(mockedConfigure).toHaveBeenCalledTimes(1);
+
+    spy.mockRestore();
+  });
+});

--- a/dashboard/src/auth/bootstrap.ts
+++ b/dashboard/src/auth/bootstrap.ts
@@ -1,0 +1,72 @@
+import { configureApiClient } from "@/api/client";
+
+/**
+ * sessionStorage key used to persist the bearer token across reloads in the
+ * same browser tab. The key is tab-scoped on purpose — closing the tab
+ * forgets the token and the user must paste the `?token=` URL again.
+ */
+export const TOKEN_STORAGE_KEY = "crosslink_api_token";
+
+/**
+ * Bootstrap API auth for the dashboard.
+ *
+ * `crosslink serve` protects every `/api/*` route (except `/api/v1/health`
+ * and `/ws`) with a randomly-generated bearer token that it prints at
+ * startup. The dashboard needs that token for its `fetch` calls to succeed.
+ *
+ * This function runs once, synchronously, before React mounts (stores
+ * hydrate on the first render, so the client must be configured first):
+ *
+ * 1. If `?token=<value>` is present on the current URL, store it in
+ *    `sessionStorage` and strip it from the URL via `history.replaceState`
+ *    so it doesn't leak into the browser history.
+ * 2. Otherwise, try to read a previously-persisted token from sessionStorage.
+ * 3. If a token is available, wrap `globalThis.fetch` with a function that
+ *    attaches `Authorization: Bearer <token>` to every request, and install
+ *    it via `configureApiClient`. If no token is available, leave the
+ *    client unconfigured — requests will 401 and the user will see the
+ *    empty-state placeholders, matching the pre-fix behaviour.
+ *
+ * @returns the bearer token that was installed, or `null` if none was found.
+ */
+export function bootstrapAuth(): string | null {
+  let token: string | null = null;
+
+  try {
+    const url = new URL(window.location.href);
+    const urlToken = url.searchParams.get("token");
+    if (urlToken) {
+      token = urlToken;
+      try {
+        window.sessionStorage.setItem(TOKEN_STORAGE_KEY, urlToken);
+      } catch {
+        // sessionStorage may be unavailable (sandboxed iframes, some private
+        // browsing modes). Fall through — the token still works for this load.
+      }
+      url.searchParams.delete("token");
+      window.history.replaceState({}, "", url.toString());
+    } else {
+      try {
+        token = window.sessionStorage.getItem(TOKEN_STORAGE_KEY);
+      } catch {
+        token = null;
+      }
+    }
+  } catch {
+    // Unknown failure resolving the current URL; skip auth setup.
+    return null;
+  }
+
+  if (!token) return null;
+
+  const nativeFetch = globalThis.fetch.bind(globalThis);
+  const capturedToken = token;
+  const authedFetch: typeof globalThis.fetch = (input, init) => {
+    const headers = new Headers(init?.headers);
+    headers.set("Authorization", `Bearer ${capturedToken}`);
+    return nativeFetch(input, { ...init, headers });
+  };
+  configureApiClient({ fetchFn: authedFetch });
+
+  return token;
+}

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -2,6 +2,13 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import { App } from "./App";
+import { bootstrapAuth } from "./auth/bootstrap";
+
+// Wire the API client to attach `Authorization: Bearer <token>` before
+// React mounts — stores hydrate from the API on the first render, so the
+// fetch wrapper must be installed first. See auth/bootstrap.ts for the
+// `?token=...` → sessionStorage flow.
+bootstrapAuth();
 
 const root = document.getElementById("root");
 if (!root) throw new Error("Root element not found");


### PR DESCRIPTION
## Summary

- Fixes forecast-bio/crosslink#556 — the React dashboard never attached `Authorization: Bearer <token>`, so every `/api/*` call against the auth-protected `crosslink serve` returned 401 and the UI permanently showed empty-state placeholders.
- Root cause: the server's `auth_middleware` enforced bearer tokens, but the client's `configureApiClient` was exported and never called. Two halves of a feature shipped without the connecting wire.
- Fix wires them together: new `dashboard/src/auth/bootstrap.ts` reads `?token=` from the URL, persists to `sessionStorage`, scrubs the URL via `history.replaceState`, and installs a fetch wrapper via `configureApiClient` that attaches the header on every request. Subsequent reloads in the same tab reuse the stored token.
- `main.tsx` calls `bootstrapAuth()` before `createRoot` so stores are configured before first render.
- `crosslink serve` startup banner now prints a clickable `Dashboard: http://addr/?token=<token>` line when `--dashboard-dir` is set. Existing `Auth: Bearer <token>` line is kept for curl/script users.

## Test plan

- [x] `npm test` in `dashboard/` — 26/26 pass (7 new vitest cases: URL-token extract/scrub/store, sessionStorage reuse, URL-over-storage precedence for re-auth, header injection, header preservation, graceful degradation when `sessionStorage.setItem` throws)
- [x] `npx vite build` in `dashboard/` — clean bundle
- [x] `cargo test --lib server::` — 271/271 pass
- [x] `cargo test --test smoke` — 159/159 pass (includes `test_api_*` that exercise the authed routes)
- [x] Manual smoke: `crosslink serve --port 3100 --dashboard-dir ./dashboard/dist`, open the printed `Dashboard:` URL, confirm summary cards populate instead of `…` placeholders; reload and confirm sessionStorage reuse; open a fresh tab without the query param and confirm it falls back to the empty-state (no crash).

## Scope notes

- Left `/ws` alone — server exempts it from auth and the bug report confirms WS works as-is.
- The two adjacent issues the bug report called out (pre-existing `tsc -b` errors in `UsageChart.tsx`/`AgentCard.tsx`/`stores/agents.ts`, and the `serve` 404 when `--dashboard-dir` is omitted) were explicitly scoped to separate tickets and are not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)