### PR TITLE
test(init): cover all three MCP servers in deploy/manifest assertions (GH#554)

### DIFF
--- a/crosslink/src/commands/init/mod.rs
+++ b/crosslink/src/commands/init/mod.rs
@@ -1491,7 +1491,10 @@ mod tests {
         assert!(!PRE_WEB_CHECK_PY.is_empty());
         assert!(!WORK_CHECK_PY.is_empty());
         assert!(!CROSSLINK_CONFIG_PY.is_empty());
+        assert!(!HEARTBEAT_PY.is_empty());
         assert!(!SAFE_FETCH_SERVER_PY.is_empty());
+        assert!(!KNOWLEDGE_SERVER_PY.is_empty());
+        assert!(!AGENT_PROMPT_SERVER_PY.is_empty());
         assert!(!MCP_JSON.is_empty());
         // All auto-discovered command files should be non-empty
         assert!(
@@ -2119,17 +2122,32 @@ mod tests {
     }
 
     #[test]
-    fn test_init_deploys_mcp_knowledge_server() {
+    fn test_init_deploys_mcp_servers() {
         let dir = test_dir();
         run(dir.path(), &test_opts(false)).unwrap();
 
-        // knowledge-server.py must exist
+        // All three server scripts must be deployed. Previously only
+        // safe-fetch and knowledge were checked, which masked #554 — init
+        // registered crosslink-agent-prompt in .mcp.json but never wrote
+        // the script to disk, so every Claude Code session logged a
+        // server-launch failure.
+        let mcp_dir = dir.path().join(".claude/mcp");
         assert!(
-            dir.path().join(".claude/mcp/knowledge-server.py").exists(),
+            mcp_dir.join("safe-fetch-server.py").exists(),
+            "safe-fetch-server.py not deployed"
+        );
+        assert!(
+            mcp_dir.join("knowledge-server.py").exists(),
             "knowledge-server.py not deployed"
         );
+        assert!(
+            mcp_dir.join("agent-prompt-server.py").exists(),
+            "agent-prompt-server.py not deployed"
+        );
 
-        // .mcp.json must reference both MCP servers
+        // .mcp.json must reference all three MCP servers. If a server is
+        // registered here without the matching script being deployed,
+        // Claude Code will fail to launch it on startup (#554).
         let mcp_content = fs::read_to_string(dir.path().join(".mcp.json")).unwrap();
         let mcp: serde_json::Value = serde_json::from_str(&mcp_content).unwrap();
         let servers = mcp["mcpServers"].as_object().unwrap();
@@ -2140,6 +2158,10 @@ mod tests {
         assert!(
             servers.contains_key("crosslink-knowledge"),
             ".mcp.json missing crosslink-knowledge"
+        );
+        assert!(
+            servers.contains_key("crosslink-agent-prompt"),
+            ".mcp.json missing crosslink-agent-prompt"
         );
     }
 
@@ -2213,6 +2235,14 @@ mod tests {
         assert!(
             files.contains_key(".claude/mcp/safe-fetch-server.py"),
             "Manifest should track MCP servers"
+        );
+        assert!(
+            files.contains_key(".claude/mcp/knowledge-server.py"),
+            "Manifest should track knowledge MCP server"
+        );
+        assert!(
+            files.contains_key(".claude/mcp/agent-prompt-server.py"),
+            "Manifest should track agent-prompt MCP server"
         );
     }
 


### PR DESCRIPTION
## Summary

- Closes forecast-bio/crosslink#554 — but with a caveat: the **production fix** for this bug already landed in commit `e9e5bc52` via PR #550 (filed against issue #549, which is effectively a duplicate of #554). The `AGENT_PROMPT_SERVER_PY` `include_str!` and matching `fs::write` are already in `crosslink/src/commands/init/mod.rs` on `develop`.
- What was still missing: **test coverage**. The init test suite still only referenced `safe-fetch` + `knowledge`, so a future regression that re-dropped `agent-prompt-server.py` from the scaffold would slip through the same way #554 did the first time. This PR closes that gap.

## Changes (all in `crosslink/src/commands/init/mod.rs`)

| Test | Before | After |
|---|---|---|
| `test_init_deploys_mcp_knowledge_server` | Asserted `knowledge-server.py` existed; `.mcp.json` referenced safe-fetch + knowledge | Renamed to `test_init_deploys_mcp_servers`; asserts **all 3** scripts on disk (`safe-fetch`, `knowledge`, `agent-prompt`) and **all 3** entries in `.mcp.json` |
| `test_embedded_constants_not_empty` | Only `SAFE_FETCH_SERVER_PY` validated | Now also covers `KNOWLEDGE_SERVER_PY`, `AGENT_PROMPT_SERVER_PY`, and `HEARTBEAT_PY` — a broken `include_str!` path compiles as an empty const and fails silently at runtime; the assert catches it at test time instead |
| `test_init_writes_manifest` | Only `safe-fetch-server.py` checked in manifest | All 3 MCP scripts required in manifest |

No production code change — the runtime fix was already in place.

## Test plan

- [x] `cargo test commands::init` — 83/83 pass
- [x] `cargo test test_init_deploys_mcp_servers` — 1/1 pass (renamed test)
- [x] `cargo fmt --all --check` — clean
- [x] Manual smoke: `mkdir /tmp/xl-repro && cd /tmp/xl-repro && git init -q && crosslink init && ls .claude/mcp/` should list all three `.py` files; `jq '.mcpServers | keys' .mcp.json` should show `crosslink-safe-fetch`, `crosslink-knowledge`, `crosslink-agent-prompt`.

## Scope notes

- This PR is intentionally test-only. The production fix is already on `develop`; reopening the scaffolding change would conflict with #550's merge.
- The `test_init_deploys_mcp_knowledge_server` → `test_init_deploys_mcp_servers` rename matches the test's actual scope now that it covers all three servers. No callers of the old name exist outside the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)