### PR TITLE
fix(sentinel): keep watch daemon alive + stop premature dispatch harvest (GH#561)

### DIFF
--- a/crosslink/src/commands/sentinel/collect.rs
+++ b/crosslink/src/commands/sentinel/collect.rs
@@ -68,12 +68,9 @@ pub fn collect_completed(
             continue;
         };
 
-        let outcome = if status_content.trim().starts_with("DONE") {
-            "success"
-        } else if dispatch.attempt_number >= 2 {
-            "exhausted"
-        } else {
-            "failure"
+        let Some(outcome) = classify_status(&status_content, dispatch.attempt_number) else {
+            stats.still_running += 1;
+            continue;
         };
 
         // Read agent findings from crosslink comments on the linked issue
@@ -311,6 +308,40 @@ fn repo_root(crosslink_dir: &Path) -> Result<std::path::PathBuf> {
     Ok(std::path::PathBuf::from(root))
 }
 
+/// Classify a `.kickoff-status` file body into a dispatch outcome.
+///
+/// Returns `Some(outcome_code)` for a terminal state, or `None` if the
+/// agent is still working (in which case the collect loop should leave
+/// the dispatch pending and try again on the next cycle).
+///
+/// Agent states (per `crosslink/src/commands/kickoff/launch.rs`):
+/// - `LAUNCHING` — tmux session being created
+/// - `RUNNING`   — agent executing in tmux
+/// - `FAILED`    — launch couldn't hand off to tmux
+/// - `DONE`      — agent finished cleanly (written by the agent itself)
+/// - `TIMEOUT`   — accepted as a future-compatible terminal state
+///
+/// Previously the collect loop treated every non-`DONE` value as a
+/// terminal `failure`, which caused it to harvest dispatches within
+/// seconds of their creation — producing `Duration | 0s` and
+/// `No findings recorded` in the posted GitHub comment because the
+/// agent hadn't yet written any observations (GH#561 defects 2 & 3).
+fn classify_status(status_content: &str, attempt_number: i32) -> Option<&'static str> {
+    let trimmed = status_content.trim();
+    if trimmed.starts_with("DONE") {
+        Some("success")
+    } else if trimmed.starts_with("FAILED") || trimmed.starts_with("TIMEOUT") {
+        if attempt_number >= 2 {
+            Some("exhausted")
+        } else {
+            Some("failure")
+        }
+    } else {
+        // RUNNING / LAUNCHING / empty / any other value — not terminal.
+        None
+    }
+}
+
 /// Read observation and resolution comments from a crosslink issue.
 fn read_agent_findings(db: &Database, issue_id: i64) -> String {
     let Ok(comments) = db.get_comments(issue_id) else {
@@ -474,6 +505,54 @@ fn build_fix_template(ctx: &TemplateContext<'_>) -> String {
 ---
 *Posted by crosslink sentinel | sentinel #{dispatch_id}*"
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_status_done_is_success() {
+        assert_eq!(classify_status("DONE", 1), Some("success"));
+        assert_eq!(classify_status("DONE\n", 1), Some("success"));
+        assert_eq!(classify_status("  DONE  ", 2), Some("success"));
+        assert_eq!(classify_status("DONE with extra info", 1), Some("success"));
+    }
+
+    #[test]
+    fn classify_status_failed_is_failure_then_exhausted() {
+        assert_eq!(classify_status("FAILED\n", 1), Some("failure"));
+        assert_eq!(classify_status("FAILED\n", 2), Some("exhausted"));
+        assert_eq!(
+            classify_status("FAILED: tmux send-keys", 1),
+            Some("failure")
+        );
+    }
+
+    #[test]
+    fn classify_status_timeout_is_terminal() {
+        assert_eq!(classify_status("TIMEOUT\n", 1), Some("failure"));
+        assert_eq!(classify_status("TIMEOUT\n", 2), Some("exhausted"));
+    }
+
+    #[test]
+    fn classify_status_running_leaves_pending() {
+        // This is the GH#561 regression: RUNNING must not be treated as
+        // a terminal outcome, otherwise the harvest runs while the agent
+        // is still working and posts a premature "0s / no findings" comment.
+        assert_eq!(classify_status("RUNNING\n", 1), None);
+        assert_eq!(classify_status("LAUNCHING\n", 1), None);
+        assert_eq!(classify_status("RUNNING", 2), None);
+    }
+
+    #[test]
+    fn classify_status_unknown_leaves_pending() {
+        // Defensive: anything we don't recognise should also be treated
+        // as "agent is still working" rather than silently terminal.
+        assert_eq!(classify_status("", 1), None);
+        assert_eq!(classify_status("partial-write", 1), None);
+        assert_eq!(classify_status("  ", 1), None);
+    }
 }
 
 /// Post a comment to a GitHub issue via `gh`.

--- a/crosslink/src/commands/sentinel/watch.rs
+++ b/crosslink/src/commands/sentinel/watch.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use std::fs;
-use std::io::Read;
+use std::io::{IsTerminal, Read};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -229,22 +229,40 @@ async fn async_watch_loop(
     let mut sigint = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())
         .context("Failed to register SIGINT handler")?;
 
-    // Zombie prevention: spawn a blocking thread to detect stdin closure
-    let stdin_flag = Arc::clone(&should_exit);
-    thread::spawn(move || {
-        let mut stdin = std::io::stdin();
-        let mut buf = [0u8; 1];
-        loop {
-            match stdin.read(&mut buf) {
-                Ok(0) | Err(_) => {
-                    tracing::info!("Stdin closed, sentinel shutting down");
-                    stdin_flag.store(true, Ordering::SeqCst);
-                    break;
+    // Zombie prevention: spawn a blocking thread to detect stdin closure.
+    //
+    // Only active when stdin is a TTY. When `sentinel watch` spawns this
+    // daemon it passes `Stdio::null()` for the child's stdin — `/dev/null`
+    // returns `Ok(0)` on the first read, which would immediately set the
+    // shutdown flag and kill the daemon right after startup (GH#561). In
+    // that non-interactive case, SIGTERM from `sentinel stop` (or from the
+    // parent process exiting) is the correct shutdown channel; we don't
+    // need an additional stdin-EOF signal.
+    //
+    // The check remains useful when a human runs `sentinel run-daemon`
+    // directly in a terminal — ctrl+D then still cleanly shuts it down.
+    if std::io::stdin().is_terminal() {
+        let stdin_flag = Arc::clone(&should_exit);
+        thread::spawn(move || {
+            let mut stdin = std::io::stdin();
+            let mut buf = [0u8; 1];
+            loop {
+                match stdin.read(&mut buf) {
+                    Ok(0) | Err(_) => {
+                        tracing::info!("Stdin closed, sentinel shutting down");
+                        stdin_flag.store(true, Ordering::SeqCst);
+                        break;
+                    }
+                    Ok(_) => {}
                 }
-                Ok(_) => {}
             }
-        }
-    });
+        });
+    } else {
+        tracing::debug!(
+            "stdin is not a TTY; skipping stdin-close zombie-prevention check \
+             (SIGTERM/SIGINT remain active)"
+        );
+    }
 
     // Run an initial cycle immediately so the first poll doesn't wait `interval_minutes`
     let mut next_poll_at = tokio::time::Instant::now();


### PR DESCRIPTION
## Summary

Fixes all three defects reported in forecast-bio/crosslink#561, found while running the two manual-test items from the PR #553 sentinel QA.

Two logical fixes in two focused commits:

### 1. `9a715ad0` — watch daemon exits at startup
`sentinel watch` spawned its `run-daemon` child with `Stdio::null()` for stdin. The daemon's zombie-prevention thread read from stdin and treated `Ok(0)` (EOF) as "parent died, shut down." `/dev/null` is EOF-on-first-read, so the daemon shut itself down within milliseconds of startup — after the webhook server had bound its port but before any request could be served.

Gated the stdin-close thread on `std::io::stdin().is_terminal()`. Interactive `run-daemon` in a TTY still gets ctrl+D semantics; the daemon-spawned case falls back to SIGTERM/SIGINT (already wired via tokio's unix signal handlers and feeding the same `should_exit` flag).

### 2. `872f64e8` — collect step prematurely harvested running agents
`run_oneshot` calls `collect::collect_completed` in the same cycle as dispatch. The collect loop treated every non-`DONE` `.kickoff-status` value as a terminal `failure`:

```rust
let outcome = if content.starts_with("DONE") { "success" }
              else if attempt >= 2           { "exhausted" }
              else                           { "failure" };
```

`launch_local` writes `LAUNCHING` → `RUNNING` → `DONE` during an agent's lifetime, so the newly-spawned agent's status was `RUNNING` when collect scanned it seconds later. The dispatch got marked `failure`, a premature `Sentinel: Reproduction Report` comment was posted with `Duration | 0s` and `No findings recorded`, and because `outcome != 'pending'` after that, subsequent collect passes skipped the dispatch even after the agent actually finished.

Extracted the mapping into `classify_status(status, attempt) -> Option<&'static str>`:
- `DONE` → `Some("success")`
- `FAILED` / `TIMEOUT` → `Some("failure")` on attempt 1, `Some("exhausted")` on ≥2
- `RUNNING` / `LAUNCHING` / empty / anything else → `None` (leave pending, retry next cycle)

The collect loop now skips `None` (increments `still_running` as it already did for a missing status file).

Both defects #2 ("Duration 0s") and #3 ("No findings recorded") from GH#561 were downstream symptoms of this single bug.

## Test plan

- [x] `cargo test classify_status` — 5 new unit cases pass (DONE/FAILED/TIMEOUT/RUNNING/unknown)
- [x] `cargo build --release` on the new branch — clean compile
- [x] Live smoke test of the watch daemon fix: `crosslink sentinel watch` with webhook enabled on port 9877, confirmed daemon stays alive, `/health` responds, `sentinel stop` terminates cleanly
- [x] Manual re-run of the original sentinel replicate flow from GH#561 (create labeled issue → `sentinel run` dispatches → wait for agent DONE → `sentinel run` again collects → verify posted comment has non-zero Duration and agent's `--kind resolution` comment in Findings)

## Non-blocking follow-ups (not in this PR)

- Timeout detection: if an agent hangs or gets killed by `timeout` without writing `DONE`, the dispatch stays `pending` forever. Worth adding a `max_age` check in collect (e.g. `created_at + 2 * default_agent.timeout_minutes` → force `exhausted`). Happy to file as a separate issue.
- Claude Code first-run "Accept bypass permissions" prompt hangs fresh agent worktrees. Not a sentinel/crosslink bug but worth a sentence in the sentinel docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)