### PR TITLE
fix(shared_writer): reconcile display/milestone counter against on-disk state

### DIFF
--- a/crosslink/src/shared_writer/core.rs
+++ b/crosslink/src/shared_writer/core.rs
@@ -459,8 +459,19 @@ impl SharedWriter {
     /// Claim N sequential display IDs from `meta/counters.json`.
     ///
     /// Returns `(first_claimed_id, updated_counters)`.
+    ///
+    /// Before claiming, the counter is reconciled against the highest
+    /// `display_id` actually present in the hub-cache issue files. This
+    /// prevents a class of collision bugs where `counters.json` falls out
+    /// of sync with the real state — e.g. a freshly-cloned repo whose
+    /// `counters.json` defaults to 1 but whose `issues/` directory
+    /// already contains closed issues with larger IDs; or a local cache
+    /// whose counter was decremented by a previous offline rollback
+    /// without observing that other agents had meanwhile pushed issues
+    /// with higher IDs. See `reconcile_display_counter`.
     pub(super) fn claim_display_id(&self, count: i64) -> Result<(i64, Counters)> {
         let mut counters = self.read_counters()?;
+        self.reconcile_display_counter(&mut counters)?;
         let first = counters.next_display_id;
         counters.next_display_id += count;
         Ok((first, counters))
@@ -469,11 +480,78 @@ impl SharedWriter {
     /// Claim a milestone display ID from `meta/counters.json`.
     ///
     /// Returns `(claimed_id, updated_counters)`.
+    ///
+    /// As with `claim_display_id`, the counter is reconciled against the
+    /// highest `display_id` present in the on-disk milestone files
+    /// before assignment so that stale `counters.json` does not produce
+    /// colliding IDs.
     pub(super) fn claim_milestone_id(&self) -> Result<(i64, Counters)> {
         let mut counters = self.read_counters()?;
+        self.reconcile_milestone_counter(&mut counters)?;
         let id = counters.next_milestone_id;
         counters.next_milestone_id += 1;
         Ok((id, counters))
+    }
+
+    /// Reconcile `counters.next_display_id` with the actual maximum
+    /// `display_id` present in the hub-cache issue files (open OR
+    /// closed). If the counter is behind, advance it past the max so
+    /// the next claim cannot collide with an existing file.
+    ///
+    /// Typical scenarios where the counter falls behind:
+    /// - Fresh clone: `meta/counters.json` does not yet exist so
+    ///   `read_counters` returns `Counters::default()` with
+    ///   `next_display_id = 1`, but the hub branch already has issues
+    ///   with much higher IDs.
+    /// - Offline rollback: `rewrite_as_offline` decrements the counter
+    ///   on local push failure. If another agent meanwhile pushed a
+    ///   new issue that reuses the same slot, the next online sync
+    ///   pulls it in but the local counter still points at the freed
+    ///   slot.
+    /// - Mixed hub/local state: merges and fast-forwards can leave
+    ///   `counters.json` lagging behind the issues directory.
+    ///
+    /// This is O(N) over issues-in-cache. That cost is paid only when
+    /// minting a new `display_id` (typically a handful of times per
+    /// command), not on every read.
+    pub(super) fn reconcile_display_counter(&self, counters: &mut Counters) -> Result<()> {
+        let max_existing = self
+            .scan_issues(|_| true)?
+            .iter()
+            .filter_map(|i| i.display_id)
+            .max()
+            .unwrap_or(0);
+        if counters.next_display_id <= max_existing {
+            counters.next_display_id = max_existing + 1;
+        }
+        Ok(())
+    }
+
+    /// Reconcile `counters.next_milestone_id` with the actual maximum
+    /// `display_id` present in the on-disk milestone files. See
+    /// [`reconcile_display_counter`] for the full rationale; the same
+    /// failure modes apply to milestones.
+    pub(super) fn reconcile_milestone_counter(&self, counters: &mut Counters) -> Result<()> {
+        let milestones_dir = self.cache_dir.join("meta").join("milestones");
+        let mut max_existing = 0i64;
+        if milestones_dir.exists() {
+            for entry in std::fs::read_dir(&milestones_dir)? {
+                let entry = entry?;
+                let path = entry.path();
+                if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                    continue;
+                }
+                if let Ok(ms) = read_milestone_file(&path) {
+                    if ms.display_id > max_existing {
+                        max_existing = ms.display_id;
+                    }
+                }
+            }
+        }
+        if counters.next_milestone_id <= max_existing {
+            counters.next_milestone_id = max_existing + 1;
+        }
+        Ok(())
     }
 
     /// Load a milestone entry by `display_id` from per-file storage.

--- a/crosslink/src/shared_writer/tests.rs
+++ b/crosslink/src/shared_writer/tests.rs
@@ -2393,6 +2393,126 @@ mod integration {
         drop(work_dir);
     }
 
+    /// Regression: `claim_display_id` must not hand out an ID that
+    /// already belongs to an existing issue file, even when
+    /// `counters.json` is stale. Simulates a freshly-cloned repo
+    /// whose hub branch contains closed issues but whose local
+    /// `counters.json` still reports `next_display_id = 1`.
+    #[test]
+    fn test_claim_display_id_reconciles_against_stale_counter() {
+        let (work_dir, _remote, crosslink_dir) = setup_shared_writer_env();
+        let writer = SharedWriter::new(&crosslink_dir).unwrap().unwrap();
+
+        // Simulate: issues directory already contains higher-ID files
+        // (from a hub branch that was synced but whose counters.json
+        // was never updated — e.g., a closed issue preserved from a
+        // prior session).
+        let issues_dir = writer.sync.cache_path().join("issues");
+        std::fs::create_dir_all(&issues_dir).unwrap();
+        let stale = make_issue(100, "closed-from-hub");
+        write_issue_file(&issues_dir.join(format!("{}.json", stale.uuid)), &stale).unwrap();
+
+        // counters.json still at the default (next_display_id = 1).
+        let counters = writer.read_counters().unwrap();
+        assert_eq!(
+            counters.next_display_id, 1,
+            "precondition: counter is stale"
+        );
+
+        // Claim — the reconciler should jump ahead past the existing
+        // max so the new ID does not collide.
+        let (first, updated) = writer.claim_display_id(1).unwrap();
+        assert_eq!(first, 101, "first claim must be past the max existing ID");
+        assert_eq!(updated.next_display_id, 102);
+        drop(work_dir);
+    }
+
+    /// Regression: the reconciler must walk both V1 and V2 layouts.
+    #[test]
+    fn test_claim_display_id_reconciles_across_v1_and_v2_layouts() {
+        let (work_dir, _remote, crosslink_dir) = setup_shared_writer_env();
+        let writer = SharedWriter::new(&crosslink_dir).unwrap().unwrap();
+
+        let issues_dir = writer.sync.cache_path().join("issues");
+        std::fs::create_dir_all(&issues_dir).unwrap();
+
+        // V1 layout: issues/{uuid}.json
+        let v1 = make_issue(50, "v1-issue");
+        write_issue_file(&issues_dir.join(format!("{}.json", v1.uuid)), &v1).unwrap();
+
+        // V2 layout: issues/{uuid}/issue.json with a HIGHER display_id
+        let v2 = make_issue(200, "v2-issue");
+        let v2_dir = issues_dir.join(v2.uuid.to_string());
+        std::fs::create_dir_all(&v2_dir).unwrap();
+        write_issue_file(&v2_dir.join("issue.json"), &v2).unwrap();
+
+        let (first, _) = writer.claim_display_id(1).unwrap();
+        assert_eq!(
+            first, 201,
+            "reconciler must see the highest ID across both layouts"
+        );
+        drop(work_dir);
+    }
+
+    /// When the counter is already ahead of the cache (the normal
+    /// steady-state case), reconciliation must NOT decrease it.
+    /// Otherwise a successful push that bumped the counter could be
+    /// silently undone on the next claim.
+    #[test]
+    fn test_claim_display_id_does_not_regress_advanced_counter() {
+        let (work_dir, _remote, crosslink_dir) = setup_shared_writer_env();
+        let writer = SharedWriter::new(&crosslink_dir).unwrap().unwrap();
+
+        // Advance the counter well beyond any files on disk.
+        let mut counters = writer.read_counters().unwrap();
+        counters.next_display_id = 500;
+        writer.write_counters_to_cache(&counters).unwrap();
+
+        // Add a few issue files with much lower IDs.
+        let issues_dir = writer.sync.cache_path().join("issues");
+        std::fs::create_dir_all(&issues_dir).unwrap();
+        let low = make_issue(5, "low");
+        write_issue_file(&issues_dir.join(format!("{}.json", low.uuid)), &low).unwrap();
+
+        let (first, updated) = writer.claim_display_id(1).unwrap();
+        assert_eq!(first, 500, "counter must not be regressed by older files");
+        assert_eq!(updated.next_display_id, 501);
+        drop(work_dir);
+    }
+
+    /// Regression: `claim_milestone_id` has the same potential
+    /// collision; verify the parallel reconciler fixes it.
+    #[test]
+    fn test_claim_milestone_id_reconciles_against_stale_counter() {
+        let (work_dir, _remote, crosslink_dir) = setup_shared_writer_env();
+        let writer = SharedWriter::new(&crosslink_dir).unwrap().unwrap();
+
+        // Seed meta/milestones/ with a pre-existing milestone file.
+        let milestones_dir = writer.sync.cache_path().join("meta").join("milestones");
+        std::fs::create_dir_all(&milestones_dir).unwrap();
+        let ms_uuid = Uuid::new_v4();
+        let milestone = crate::issue_file::MilestoneEntry {
+            uuid: ms_uuid,
+            display_id: 42,
+            name: "Q1".to_string(),
+            description: None,
+            status: IssueStatus::Open,
+            created_at: Utc::now(),
+            closed_at: None,
+        };
+        let path = milestones_dir.join(format!("{ms_uuid}.json"));
+        std::fs::write(&path, serde_json::to_string_pretty(&milestone).unwrap()).unwrap();
+
+        // counters.json default says next_milestone_id = 1.
+        let counters = writer.read_counters().unwrap();
+        assert_eq!(counters.next_milestone_id, 1, "precondition: counter stale");
+
+        let (id, updated) = writer.claim_milestone_id().unwrap();
+        assert_eq!(id, 43, "milestone id must skip past the existing max");
+        assert_eq!(updated.next_milestone_id, 44);
+        drop(work_dir);
+    }
+
     #[test]
     fn test_read_max_event_seq_returns_zero_when_no_log() {
         let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

- `claim_display_id` / `claim_milestone_id` now reconcile `meta/counters.json` against the actual maximum ID present in the hub-cache issue files before minting. Prevents collisions when the counter falls behind on-disk state.
- Counter was previously trusted as the source of truth even when a fresh clone, offline rollback, or hub fast-forward left it out of sync.
- Reconciler never regresses an advanced counter — the fix is monotonic.

## Repro of the bug

1. A repo has issues #1…#1090 on the hub, many closed
2. `meta/counters.json` reports `next_display_id = 1045` (stale — last pushed by an agent that hadn't seen the more recent pushes yet)
3. A new session creates an issue → `claim_display_id` hands out 1046
4. That `display_id` already belongs to a (closed) issue
5. On next `hydrate`, one of the two files with `display_id=1046` is silently skipped based on `updated_at`:
   ```
   WARN duplicate issue file(s) skipped during hydration (same display_id)
   WARN   skipped: <title> (display_id Some(1046), uuid <uuid>)
   ```
6. The "winner" replaces the loser in SQLite — either the new issue takes over the closed slot, or the new issue vanishes from `crosslink issue list`.

Hit during a batch issue-filing session against sigil: ~22 of 45 newly-created security issues collided with long-closed QA issues and disappeared from the list view even though they exist on disk.

## Fix

Add `reconcile_display_counter` and `reconcile_milestone_counter` on `SharedWriter`:

- Scan all issue files (both V1 `issues/{uuid}.json` and V2 `issues/{uuid}/issue.json`) for the max `display_id`, take `max + 1` if the counter is behind. Milestone variant walks `meta/milestones/*.json`.
- Called from `claim_display_id` and `claim_milestone_id` before each mint.
- O(N) over issues-in-cache; only runs when minting a new ID, not on reads. For hot-path optimization later, the SQLite `get_max_display_id()` query already caches the same info and can be plumbed through.

## Test plan

- [x] `cargo build --lib` — clean
- [x] `cargo test --lib shared_writer::tests` — 129/129 pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --lib --tests` — no new warnings from this change
- [x] 4 new regression tests:
  - `test_claim_display_id_reconciles_against_stale_counter` — stale counters.json + existing issue #100 → next claim returns 101
  - `test_claim_display_id_reconciles_across_v1_and_v2_layouts` — max is found across both file layouts
  - `test_claim_display_id_does_not_regress_advanced_counter` — counter already at 500 stays at 500 even when on-disk max is 5
  - `test_claim_milestone_id_reconciles_against_stale_counter` — parallel check for milestones

## Notes

- Potentially-overlapping work: `fix/681-hydration-comment-id-collision` is addressing a related hydration-dedup class of bug but for comments. This PR is strictly about `display_id` / `milestone_id` mint-time collisions. The two are complementary; merging this first or last both work — no conflict expected since they touch different code paths.
- `next_comment_id` has the same class of bug in principle but comments are UUID-addressed in most paths; deferring until the comment-id collision fix lands to avoid duplicate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)