### PR TITLE
fix(design): pass prompt as positional arg to claude CLI (#568)

### DIFF
--- a/crosslink/src/commands/design_cmd.rs
+++ b/crosslink/src/commands/design_cmd.rs
@@ -63,9 +63,10 @@ pub fn run(
         format!("ARGUMENTS: {arguments}\n\n{prompt_body}")
     };
 
-    // 6. Launch foreground Claude session
+    // 6. Launch foreground Claude session.
+    // The `claude` CLI accepts the initial prompt as a positional argument;
+    // there is no `--prompt` flag (see issue #568).
     let status = Command::new("claude")
-        .arg("--prompt")
         .arg(&full_prompt)
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())


### PR DESCRIPTION
## Summary
- `crosslink design` was invoking `claude --prompt <text>`, but the `claude` CLI has no `--prompt` flag — the resulting error bubbled up from the child process and read as if it came from `crosslink design` itself, which did not advertise `--prompt` in its own `--help`.
- Fix: pass the full prompt as a positional argument to `claude`, matching the CLI's actual interface for launching an interactive session with seed text.
- Added a short comment referencing #568 so the flag does not get re-introduced.

Fixes #568.

## Test plan
- [x] `cargo build -p crosslink` — clean
- [x] `cargo test -p crosslink design_cmd` — 3/3 passing
- [x] Manual: run `crosslink design` and `crosslink design "some description"` outside Claude Code and confirm the foreground `claude` session launches with the design prompt as its seed

🤖 Generated with [Claude Code](https://claude.com/claude-code)