### PR TITLE
fix(sync): auto-repair stale user.signingkey in hub-cache worktree (#565)

### DIFF
--- a/crosslink/src/sync/core.rs
+++ b/crosslink/src/sync/core.rs
@@ -136,10 +136,22 @@ impl SyncManager {
     /// was only inherited from the user's global git config, bypass it to avoid
     /// failures when the global key isn't usable in the cache context.
     ///
+    /// Before committing, self-heals a stale `user.signingkey` left over from
+    /// a deleted agent worktree (GH #565) — a repair failure is logged but
+    /// doesn't abort the commit, so the existing signing error still surfaces
+    /// to the caller if auto-repair can't fix things.
+    ///
     /// # Errors
     ///
     /// Returns an error if the git commit command fails.
     pub(super) fn git_commit_in_cache(&self, args: &[&str]) -> Result<std::process::Output> {
+        // Best-effort self-heal for stale signingkey configs (GH #565).
+        // If this fails, let the commit proceed — it may still succeed, or
+        // the real signing error will surface below with full context.
+        if let Err(e) = self.repair_stale_signingkey() {
+            tracing::warn!("signingkey self-heal failed (non-fatal): {e}");
+        }
+
         let local_configured = Command::new("git")
             .current_dir(&self.cache_dir)
             .args(["config", "--local", "commit.gpgsign"])

--- a/crosslink/src/sync/tests.rs
+++ b/crosslink/src/sync/tests.rs
@@ -2925,3 +2925,190 @@ fn test_lock_mode_enum_in_claim_and_release() {
     // Steal release should succeed
     assert!(manager.release_lock(&agent1, 100, LockMode::Steal).unwrap());
 }
+
+// ------------------------------------------------------------------
+// repair_stale_signingkey — GH #565
+// ------------------------------------------------------------------
+
+/// Write `user.signingkey` into the cache worktree's config at whatever scope
+/// `configure_git_ssh_signing` would choose (worktree-scoped for linked worktrees).
+fn write_cache_signingkey(manager: &SyncManager, value: &str) {
+    let use_worktree = crate::signing::is_linked_worktree(&manager.cache_dir);
+    if use_worktree {
+        // Replicate enable_worktree_config side-effect: flip extensions.worktreeConfig.
+        Command::new("git")
+            .current_dir(&manager.cache_dir)
+            .args(["config", "--local", "extensions.worktreeConfig", "true"])
+            .output()
+            .unwrap();
+    }
+    let scope = if use_worktree {
+        "--worktree"
+    } else {
+        "--local"
+    };
+    Command::new("git")
+        .current_dir(&manager.cache_dir)
+        .args(["config", scope, "user.signingkey", value])
+        .output()
+        .unwrap();
+}
+
+fn read_cache_signingkey(manager: &SyncManager) -> Option<String> {
+    let out = Command::new("git")
+        .current_dir(&manager.cache_dir)
+        .args(["config", "user.signingkey"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let v = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if v.is_empty() {
+        None
+    } else {
+        Some(v)
+    }
+}
+
+#[test]
+fn test_repair_stale_signingkey_missing_path_is_repaired() {
+    let (work_dir, _remote_dir) = setup_sync_env();
+    let crosslink_dir = work_dir.path().join(".crosslink");
+    let manager = SyncManager::new(&crosslink_dir).unwrap();
+    manager.init_cache().unwrap();
+
+    // Simulate the #565 state: an agent worktree wrote its key path into the
+    // hub-cache's config.worktree, then the agent worktree was deleted.
+    let stale_path = work_dir
+        .path()
+        .join("gone-agent-worktree")
+        .join("keys")
+        .join("jus4_ed25519");
+    write_cache_signingkey(&manager, stale_path.to_str().unwrap());
+    assert!(
+        !stale_path.exists(),
+        "precondition: stale path must not exist"
+    );
+
+    let repaired = manager.repair_stale_signingkey().unwrap();
+    assert!(repaired, "stale path should trigger a repair");
+
+    // After repair, the cache signingkey is either unset (no driver key) or
+    // points at an existing path (driver key). Either way, the stale path
+    // that was there before must no longer be effective.
+    let post = read_cache_signingkey(&manager);
+    if let Some(ref new_value) = post {
+        assert_ne!(
+            new_value.as_str(),
+            stale_path.to_str().unwrap(),
+            "stale signingkey must not survive a repair"
+        );
+    }
+}
+
+#[test]
+fn test_repair_stale_signingkey_valid_path_is_noop() {
+    let (work_dir, _remote_dir) = setup_sync_env();
+    let crosslink_dir = work_dir.path().join(".crosslink");
+    let manager = SyncManager::new(&crosslink_dir).unwrap();
+    manager.init_cache().unwrap();
+
+    // Create a key file that actually exists.
+    let keys_dir = crosslink_dir.join("keys");
+    std::fs::create_dir_all(&keys_dir).unwrap();
+    let key_path = keys_dir.join("real_ed25519");
+    std::fs::write(&key_path, "-----BEGIN OPENSSH PRIVATE KEY-----\nfake\n").unwrap();
+
+    let abs = key_path.to_str().unwrap().to_string();
+    write_cache_signingkey(&manager, &abs);
+
+    let repaired = manager.repair_stale_signingkey().unwrap();
+    assert!(!repaired, "valid path must not trigger a repair");
+
+    let post = read_cache_signingkey(&manager);
+    assert_eq!(post.as_deref(), Some(abs.as_str()), "signingkey unchanged");
+}
+
+#[test]
+fn test_repair_stale_signingkey_literal_key_is_skipped() {
+    let (work_dir, _remote_dir) = setup_sync_env();
+    let crosslink_dir = work_dir.path().join(".crosslink");
+    let manager = SyncManager::new(&crosslink_dir).unwrap();
+    manager.init_cache().unwrap();
+
+    // Literal key material, not a path. Git accepts these inline.
+    let literal = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAfake literal-test";
+    write_cache_signingkey(&manager, literal);
+
+    let repaired = manager.repair_stale_signingkey().unwrap();
+    assert!(!repaired, "literal key material must not trigger a repair");
+
+    let post = read_cache_signingkey(&manager);
+    assert_eq!(
+        post.as_deref(),
+        Some(literal),
+        "literal signingkey unchanged"
+    );
+}
+
+#[test]
+fn test_repair_stale_signingkey_no_worktree_override_is_noop() {
+    // When the cache worktree has no `user.signingkey` override, repair must
+    // be a no-op. The effective value may surface from the user's global
+    // git config (which this test cannot control), but as long as nothing
+    // crosslink wrote is stale, repair returns Ok(false).
+    let (work_dir, _remote_dir) = setup_sync_env();
+    let crosslink_dir = work_dir.path().join(".crosslink");
+    let manager = SyncManager::new(&crosslink_dir).unwrap();
+    manager.init_cache().unwrap();
+
+    // Explicitly unset any local/worktree-scoped signingkey.
+    let _ = Command::new("git")
+        .current_dir(&manager.cache_dir)
+        .args(["config", "--local", "--unset-all", "user.signingkey"])
+        .output();
+    let _ = Command::new("git")
+        .current_dir(&manager.cache_dir)
+        .args(["config", "--worktree", "--unset-all", "user.signingkey"])
+        .output();
+
+    // If the host's global signingkey exists, repair is Ok(false).
+    // If the host has no global signingkey OR it points at a real file,
+    // repair is still Ok(false). The only way this fires is if the host's
+    // global signingkey is stale — and that's out of scope for this test.
+    let global = Command::new("git")
+        .current_dir(work_dir.path())
+        .args(["config", "--global", "user.signingkey"])
+        .output();
+    let global_key = global
+        .ok()
+        .and_then(|o| {
+            o.status
+                .success()
+                .then(|| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        })
+        .filter(|s| !s.is_empty());
+    let global_key_exists_or_absent = global_key.as_ref().map_or(true, |k| {
+        std::path::Path::new(k).exists() || k.starts_with("ssh-")
+    });
+    if !global_key_exists_or_absent {
+        // Skip — host has a stale global signingkey; not our test scenario.
+        return;
+    }
+
+    let repaired = manager.repair_stale_signingkey().unwrap();
+    assert!(!repaired, "no worktree override must not trigger a repair");
+}
+
+#[test]
+fn test_repair_stale_signingkey_cache_missing_is_noop() {
+    // No init_cache — cache_dir doesn't exist yet.
+    let (work_dir, _remote_dir) = setup_sync_env();
+    let crosslink_dir = work_dir.path().join(".crosslink");
+    std::fs::create_dir_all(&crosslink_dir).unwrap();
+    let manager = SyncManager::new(&crosslink_dir).unwrap();
+    assert!(!manager.cache_dir.exists());
+    let repaired = manager.repair_stale_signingkey().unwrap();
+    assert!(!repaired);
+}

--- a/crosslink/src/sync/trust.rs
+++ b/crosslink/src/sync/trust.rs
@@ -22,6 +22,49 @@ fn home_dir() -> Option<PathBuf> {
     }
 }
 
+/// Expand a leading `~/` or bare `~` in a path string against the user's home.
+///
+/// Returns the input unchanged if there's no tilde or home cannot be resolved.
+fn expand_tilde(path: &str) -> PathBuf {
+    if let Some(rest) = path.strip_prefix("~/") {
+        return home_dir().map_or_else(
+            || {
+                tracing::warn!(
+                    "tilde expansion failed: cannot determine home directory for '{}'",
+                    path
+                );
+                PathBuf::from(path)
+            },
+            |home| home.join(rest),
+        );
+    }
+    if path == "~" {
+        return home_dir().unwrap_or_else(|| PathBuf::from(path));
+    }
+    PathBuf::from(path)
+}
+
+/// Best guess whether a `user.signingkey` value is a filesystem path rather
+/// than literal key material (e.g. an inline `ssh-ed25519 AAAA...` line).
+///
+/// Only paths need existence validation; literal key material has nothing to
+/// check against the filesystem.
+fn signingkey_value_is_path(value: &str) -> bool {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    // Literal SSH / PGP key material — not a path.
+    if trimmed.starts_with("ssh-")
+        || trimmed.starts_with("ecdsa-")
+        || trimmed.starts_with("sk-")
+        || trimmed.starts_with("-----BEGIN")
+    {
+        return false;
+    }
+    true
+}
+
 impl SyncManager {
     /// Configure SSH signing in the hub cache worktree.
     ///
@@ -75,7 +118,7 @@ impl SyncManager {
     /// the key file exists, configures the hub cache worktree to use it.
     /// If no driver key is found, disables signing so commits can proceed
     /// unsigned rather than failing fatally.
-    fn fallback_to_driver_signing(&self) -> Result<()> {
+    pub(super) fn fallback_to_driver_signing(&self) -> Result<()> {
         // Try to read the driver's signing key from the main repo config
         let output = Command::new("git")
             .current_dir(&self.repo_root)
@@ -96,30 +139,7 @@ impl SyncManager {
         });
 
         if let Some(key_path) = driver_key {
-            // Expand tilde to home directory. Handle both "~/" and bare "~".
-            // Uses $HOME (Unix) / $USERPROFILE (Windows) directly, same
-            // approach as signing::dirs_next().
-            let expanded = key_path.strip_prefix("~/").map_or_else(
-                || {
-                    if key_path == "~" {
-                        home_dir().unwrap_or_else(|| std::path::PathBuf::from(&key_path))
-                    } else {
-                        std::path::PathBuf::from(&key_path)
-                    }
-                },
-                |rest| {
-                    home_dir().map_or_else(
-                        || {
-                            tracing::warn!(
-                                "tilde expansion failed: cannot determine home directory for '{}'",
-                                key_path
-                            );
-                            std::path::PathBuf::from(&key_path)
-                        },
-                        |home| home.join(rest),
-                    )
-                },
-            );
+            let expanded = expand_tilde(&key_path);
 
             if expanded.exists() {
                 tracing::info!(
@@ -142,6 +162,62 @@ impl SyncManager {
         }
 
         Ok(())
+    }
+
+    /// Self-heal a stale `user.signingkey` in the hub-cache worktree config.
+    ///
+    /// Reads the effective `user.signingkey` for `cache_dir`. If the value is
+    /// a filesystem path that no longer exists (typical when an agent worktree
+    /// containing the key was deleted — see GH #565), delegates to
+    /// [`Self::fallback_to_driver_signing`] to rewrite `config.worktree` with
+    /// the driver key (or disable signing if the driver has no key either).
+    ///
+    /// Returns `Ok(true)` if a repair was performed, `Ok(false)` when nothing
+    /// needed repairing. Designed to be called as a best-effort preamble to
+    /// every commit in the cache worktree: cheap on the happy path (one
+    /// `git config` read plus a single `Path::exists()` check), self-healing
+    /// on the sad path so future syncs succeed without manual intervention.
+    ///
+    /// Skips validation for literal key material (`ssh-ed25519 AAAA...`,
+    /// `-----BEGIN ...`) that git accepts inline alongside file paths.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error only if the fallback rewrite itself fails. A read
+    /// failure (no signing configured, git missing, etc.) is treated as
+    /// "nothing to repair" and returns `Ok(false)`.
+    pub fn repair_stale_signingkey(&self) -> Result<bool> {
+        if !self.cache_dir.exists() {
+            return Ok(false);
+        }
+
+        let output = Command::new("git")
+            .current_dir(&self.cache_dir)
+            .args(["config", "user.signingkey"])
+            .output();
+
+        let Ok(output) = output else { return Ok(false) };
+        if !output.status.success() {
+            return Ok(false); // No signingkey configured — nothing to repair.
+        }
+
+        let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if !signingkey_value_is_path(&value) {
+            return Ok(false); // Literal key material or empty — not our problem.
+        }
+
+        let expanded = expand_tilde(&value);
+        if expanded.exists() {
+            return Ok(false); // Path still valid — no repair needed.
+        }
+
+        tracing::warn!(
+            "hub-cache user.signingkey points at missing file '{}' \
+             (agent worktree likely deleted) — repairing (GH #565)",
+            expanded.display()
+        );
+        self.fallback_to_driver_signing()?;
+        Ok(true)
     }
 
     /// Ensure the agent's public key is published to `trust/keys/` on the hub.


### PR DESCRIPTION
## Summary

When an agent worktree's signing key is baked into the hub-cache's `.git/worktrees/-hub-cache/config.worktree` via `configure_signing()` and the agent worktree is later deleted, the worktree-scoped `user.signingkey` outlives the file it points at. Every subsequent \`crosslink sync\` that needs to commit in the cache (notably the dirty-state auto-recovery path at `sync/cache.rs:547`) hits:

```
error: Couldn't load public key /abs/.../deleted-worktree/...: No such file or directory
fatal: failed to write commit object
```

…and the tool wedges until a human edits `config.worktree` by hand. The error message doesn't point at `config.worktree`, so discovery is hostile.

Closes #565.

## Fix — self-heal at the commit site

The infrastructure was already there: `fallback_to_driver_signing` (PR #167 / #506) handles the missing-agent-key case, but only ran at `configure_signing` time (agent init), not on every sync. This PR:

- Adds `SyncManager::repair_stale_signingkey()` — reads the effective `user.signingkey` from the cache worktree, expands tilde, and if the value is a path that no longer exists, delegates to `fallback_to_driver_signing` to rewrite `config.worktree` with the driver key (or disable signing entirely if no driver key exists). Returns `Ok(false)` for the happy path (no signingkey, valid path, literal key material like `ssh-ed25519 AAAA...`).
- Calls `repair_stale_signingkey()` as a best-effort preamble inside `git_commit_in_cache`, so every commit path self-heals. A repair failure is logged but non-fatal — the existing signing error still surfaces if the fallback can't land.
- Factors the tilde expansion that was inline in `fallback_to_driver_signing` into a module-private `expand_tilde` helper so both sites use the same logic.
- Promotes `fallback_to_driver_signing` from `fn` to `pub(super) fn` so `repair_stale_signingkey` (same module) can invoke it.

### Why this approach and not lifecycle cleanup

Users can \`rm -rf\` worktrees out-of-band — lifecycle hooks would still miss those. Self-healing at the commit site covers every case regardless of how the worktree got deleted.

### Why inside `git_commit_in_cache` and not `hub_health_check`

`hub_health_check` only runs in `fetch()`. The commit site is the actual failure point; repairing there covers every caller without having to hunt down entry points. Cost: one `git config` read + one `Path::exists()` check per commit — trivial.

## Test plan

5 new unit tests in `sync::tests`, all passing:

- [x] `test_repair_stale_signingkey_missing_path_is_repaired` — simulates the #565 state (stale path left in `config.worktree` after agent deletion) and verifies repair fires.
- [x] `test_repair_stale_signingkey_valid_path_is_noop` — valid key file, no repair, config unchanged.
- [x] `test_repair_stale_signingkey_literal_key_is_skipped` — literal `ssh-ed25519 AAAA...` value is recognized as key material, not a path.
- [x] `test_repair_stale_signingkey_cache_missing_is_noop` — short-circuits when cache dir doesn't exist.
- [x] `test_repair_stale_signingkey_no_worktree_override_is_noop` — no local/worktree signingkey override, repair is a no-op. Guarded against flakes from the host's global `user.signingkey`.

Full suite:

- [x] `cargo test -p crosslink --lib` — 1702 passed, 0 failed (+5 new).
- [x] `cargo fmt --all` clean.
- [x] `cargo clippy -p crosslink --lib -- -D warnings` clean.

## Related

- PR #167 / issue #160 — original worktree-signing-key-leak fix (write side).
- #529 — hub-cache signing bypass / consistent signing-aware commit helpers.
- #506 — `fallback_to_driver_signing` (the code this PR now invokes on every commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)