### PR TITLE
feat(container): publish crosslink-agent image to GHCR with multi-arch CI (GH#576)

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -1,0 +1,260 @@
+name: Container Image
+
+# Builds and publishes the crosslink-agent container image to GHCR.
+#
+# Triggers:
+#   - push to develop  -> :nightly (floating) and :nightly-<short-sha> (immutable)
+#   - push tag v*      -> :<version> and :latest
+#   - PR touching the container build context or this workflow -> build only,
+#     no push (validates the change before merge).
+#
+# Architecture: linux/amd64 + linux/arm64. The static musl crosslink binary is
+# built per-arch in the build-binary matrix job, uploaded as an artifact, then
+# placed in the docker build context as crosslink-<arch>. The Dockerfile picks
+# the correct one via the buildx-provided TARGETARCH ARG.
+#
+# After publish, smoke-verify pulls the published tag for both platforms and
+# runs `crosslink --version`. This is the discipline that turns "green CI" into
+# "the documented happy path actually works at the user's hand."
+
+on:
+  push:
+    branches: [develop]
+    tags: ['v*']
+  pull_request:
+    paths:
+      - 'crosslink/resources/container/**'
+      - '.github/workflows/container-image.yml'
+      - 'crosslink/Cargo.toml'
+      - 'crosslink/Cargo.lock'
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: forecast-bio/crosslink-agent
+
+jobs:
+  # ===========================================
+  # Build static musl binaries (amd64 + arm64)
+  # ===========================================
+  build-binary:
+    name: Build binary (${{ matrix.arch }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - arch: amd64
+            target: x86_64-unknown-linux-musl
+          - arch: arm64
+            target: aarch64-unknown-linux-musl
+    defaults:
+      run:
+        working-directory: crosslink
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install musl + cross toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+          if [ "${{ matrix.arch }}" = "arm64" ]; then
+            sudo apt-get install -y gcc-aarch64-linux-gnu
+          fi
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            crosslink/target/
+          key: ${{ runner.os }}-cargo-container-${{ matrix.target }}-${{ hashFiles('crosslink/Cargo.lock') }}
+
+      - name: Build release binary
+        env:
+          # arm64 musl needs a cross-linker; amd64 picks up musl-gcc from musl-tools.
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: aarch64-linux-gnu-gcc
+          CC_aarch64_unknown_linux_musl: aarch64-linux-gnu-gcc
+        run: cargo build --locked --release --target ${{ matrix.target }}
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: crosslink-${{ matrix.arch }}
+          path: crosslink/target/${{ matrix.target }}/release/crosslink
+          if-no-files-found: error
+          retention-days: 1
+
+  # ===========================================
+  # Build and (conditionally) push multi-arch image
+  # ===========================================
+  publish-image:
+    name: Build & publish image
+    needs: build-binary
+    runs-on: ubuntu-latest
+    outputs:
+      primary_tag: ${{ steps.tags.outputs.primary_tag }}
+      version: ${{ steps.tags.outputs.version }}
+      pushed: ${{ steps.tags.outputs.pushed }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download amd64 binary
+        uses: actions/download-artifact@v4
+        with:
+          name: crosslink-amd64
+          path: artifacts/amd64
+
+      - name: Download arm64 binary
+        uses: actions/download-artifact@v4
+        with:
+          name: crosslink-arm64
+          path: artifacts/arm64
+
+      - name: Stage binaries into build context
+        run: |
+          cp artifacts/amd64/crosslink crosslink/resources/container/crosslink-amd64
+          cp artifacts/arm64/crosslink crosslink/resources/container/crosslink-arm64
+          chmod +x crosslink/resources/container/crosslink-amd64
+          chmod +x crosslink/resources/container/crosslink-arm64
+          ls -lah crosslink/resources/container/
+
+      - name: Compute tags
+        id: tags
+        run: |
+          set -euo pipefail
+          REF="${GITHUB_REF}"
+          EVENT="${GITHUB_EVENT_NAME}"
+          SHORT_SHA="$(echo "${GITHUB_SHA}" | cut -c1-7)"
+          BASE="${REGISTRY}/${IMAGE_NAME}"
+          TAGS=()
+          PUSH=false
+          PRIMARY=""
+          VERSION=""
+
+          if [ "$EVENT" = "pull_request" ]; then
+            # PR: build only, no push. Tag exists only locally to satisfy buildx.
+            TAGS=("${BASE}:pr-${{ github.event.pull_request.number }}")
+            PRIMARY="${BASE}:pr-${{ github.event.pull_request.number }}"
+            VERSION="pr-${{ github.event.pull_request.number }}"
+          elif [[ "$REF" == refs/tags/v* ]]; then
+            VERSION="${REF#refs/tags/v}"
+            TAGS=("${BASE}:${VERSION}" "${BASE}:latest")
+            PRIMARY="${BASE}:${VERSION}"
+            PUSH=true
+          elif [ "$REF" = "refs/heads/develop" ]; then
+            VERSION="nightly-${SHORT_SHA}"
+            TAGS=("${BASE}:nightly" "${BASE}:nightly-${SHORT_SHA}")
+            PRIMARY="${BASE}:nightly"
+            PUSH=true
+          else
+            echo "::error::Unexpected ref/event combination: ref=${REF} event=${EVENT}"
+            exit 1
+          fi
+
+          {
+            echo "tags<<EOF"
+            for t in "${TAGS[@]}"; do echo "$t"; done
+            echo "EOF"
+            echo "push=${PUSH}"
+            echo "primary_tag=${PRIMARY}"
+            echo "version=${VERSION}"
+            echo "pushed=${PUSH}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: steps.tags.outputs.push == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: crosslink/resources/container
+          file: crosslink/resources/container/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ steps.tags.outputs.push == 'true' }}
+          tags: ${{ steps.tags.outputs.tags }}
+          provenance: false
+          # Push registry cache only when we have write access (push events).
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+          cache-to: ${{ steps.tags.outputs.push == 'true' && format('type=registry,ref={0}/{1}:buildcache,mode=max', env.REGISTRY, env.IMAGE_NAME) || '' }}
+
+  # ===========================================
+  # Smoke-verify the published image is pullable + runnable on both arches.
+  # This is the discipline that catches "CI green but `docker pull` broken."
+  # ===========================================
+  smoke-verify:
+    name: Smoke verify (${{ matrix.platform }})
+    needs: publish-image
+    if: needs.publish-image.outputs.pushed == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [linux/amd64, linux/arm64]
+    steps:
+      - name: Set up QEMU (for non-native arch)
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Pull image
+        run: docker pull --platform ${{ matrix.platform }} ${{ needs.publish-image.outputs.primary_tag }}
+
+      - name: Inspect manifest covers both arches (once per matrix is fine)
+        if: matrix.platform == 'linux/amd64'
+        run: |
+          docker manifest inspect ${{ needs.publish-image.outputs.primary_tag }} \
+            | jq -e '[.manifests[].platform | "\(.os)/\(.architecture)"] | sort | . == ["linux/amd64","linux/arm64"]'
+
+      - name: Run crosslink --version
+        id: version
+        run: |
+          set -euo pipefail
+          # Override the entrypoint — entrypoint.sh expects bind mounts and root
+          # privilege handling; for smoke we just want the binary to run.
+          OUT=$(docker run --rm --platform ${{ matrix.platform }} \
+            --entrypoint /usr/local/bin/crosslink \
+            ${{ needs.publish-image.outputs.primary_tag }} --version)
+          echo "version output: $OUT"
+          echo "out=$OUT" >> "$GITHUB_OUTPUT"
+          # Sanity: must contain "crosslink" and a semver-like substring.
+          echo "$OUT" | grep -E '^crosslink [0-9]+\.[0-9]+\.[0-9]+'
+
+      - name: Verify version matches tag (release tags only)
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          EXPECTED="${{ needs.publish-image.outputs.version }}"
+          ACTUAL=$(echo "${{ steps.version.outputs.out }}" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+          if [ "$EXPECTED" != "$ACTUAL" ]; then
+            echo "::error::Tag version ($EXPECTED) does not match binary version ($ACTUAL)"
+            exit 1
+          fi
+          echo "Version match: $EXPECTED"

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -51,28 +51,44 @@ jobs:
       fail-fast: true
       matrix:
         include:
+          # amd64 builds natively on the runner via musl-tools — no cross
+          # toolchain needed and avoids the docker-in-docker overhead.
           - arch: amd64
             target: x86_64-unknown-linux-musl
+            use_cross: false
+          # arm64 must use cross-rs/cross. Stock `gcc-aarch64-linux-gnu` is a
+          # GLIBC cross-compiler — when the libsqlite3-sys build script
+          # compiles sqlite3.c with it, the object emits glibc-only symbols
+          # (open64/stat64/fcntl64/pread64/... + _FORTIFY_SOURCE __memcpy_chk
+          # variants) that musl libc doesn't define, so ld fails with
+          # `undefined reference`. cross-rs runs cargo inside a docker image
+          # carrying a real aarch64-musl toolchain, which produces
+          # musl-correct object files.
           - arch: arm64
             target: aarch64-unknown-linux-musl
+            use_cross: true
     defaults:
       run:
         working-directory: crosslink
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install musl + cross toolchain
+      - name: Install musl-tools (amd64 native build)
+        if: matrix.use_cross == false
         run: |
           sudo apt-get update
           sudo apt-get install -y musl-tools
-          if [ "${{ matrix.arch }}" = "arm64" ]; then
-            sudo apt-get install -y gcc-aarch64-linux-gnu
-          fi
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+
+      - name: Install cross (arm64 only)
+        if: matrix.use_cross == true
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
 
       - name: Cache cargo
         uses: actions/cache@v4
@@ -85,12 +101,13 @@ jobs:
             crosslink/target/
           key: ${{ runner.os }}-cargo-container-${{ matrix.target }}-${{ hashFiles('crosslink/Cargo.lock') }}
 
-      - name: Build release binary
-        env:
-          # arm64 musl needs a cross-linker; amd64 picks up musl-gcc from musl-tools.
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: aarch64-linux-gnu-gcc
-          CC_aarch64_unknown_linux_musl: aarch64-linux-gnu-gcc
+      - name: Build release binary (native)
+        if: matrix.use_cross == false
         run: cargo build --locked --release --target ${{ matrix.target }}
+
+      - name: Build release binary (cross)
+        if: matrix.use_cross == true
+        run: cross build --locked --release --target ${{ matrix.target }}
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,11 @@ crosslink-enterprise/
 .worktrees/
 OPUS_4_6_SUGGESTIONS.md
 
+# Container build context: binaries dropped here by `just build-image` and CI.
+# Dockerfile and entrypoint.sh are intentionally tracked.
+crosslink/resources/container/crosslink
+crosslink/resources/container/crosslink-*
+
 # Pipeline state files (machine-local, ephemeral)
 *.pipeline.json
 *.plan.json

--- a/crosslink/Cross.toml
+++ b/crosslink/Cross.toml
@@ -1,0 +1,31 @@
+# cross-rs configuration. Used by `.github/workflows/container-image.yml`'s
+# arm64 leg (`cross build --target aarch64-unknown-linux-musl`); native amd64
+# builds via plain `cargo build` and never load this file.
+#
+# Why this file exists:
+#   `crosslink/src/server/embedded.rs` has
+#       #[derive(RustEmbed)]
+#       #[folder = "../dashboard/dist/"]
+#   which rust-embed resolves at compile time, expecting
+#   `<repo>/dashboard/dist/` to exist. `build.rs` writes a placeholder there
+#   if the real frontend bundle isn't built (so plain `cargo build` works
+#   without first running `npm --prefix dashboard run build`).
+#
+#   Inside the `cross` docker container, only the crate dir (`crosslink/`)
+#   is mounted as `/project`. From `/project`, `../dashboard/` resolves to
+#   `/dashboard/` — outside the mount, and not present in the cross base
+#   image. build.rs's placeholder write also fails silently (the path is
+#   on the container filesystem, not the bind-mount, and ownership/perms
+#   differ from the host).
+#
+#   pre-build commands run at image-build time when cross materializes the
+#   custom image, and the result persists in that image. We pre-create
+#   `/dashboard/dist/` with permissive perms so build.rs can write its
+#   placeholder into it on every subsequent `cross build`, satisfying
+#   rust-embed without touching the source layout or the embed path.
+
+[target.aarch64-unknown-linux-musl]
+pre-build = [
+    "mkdir -p /dashboard/dist",
+    "chmod 0777 /dashboard /dashboard/dist",
+]

--- a/crosslink/resources/container/Dockerfile
+++ b/crosslink/resources/container/Dockerfile
@@ -1,5 +1,17 @@
 # E-ana tablet — container image for crosslink agent execution
+#
+# Build context expectation:
+#   - `crosslink-amd64` and/or `crosslink-arm64` binaries placed alongside this
+#     Dockerfile (the binary matching ${TARGETARCH} is COPYed into the image).
+#   - For multi-arch buildx builds, set --platform linux/amd64,linux/arm64.
+#   - For local single-arch builds (`just build-image`), only the host-arch
+#     binary needs to be present; buildx auto-fills TARGETARCH.
 FROM ubuntu:24.04
+
+# Buildx auto-populates these for multi-arch builds; provide safe defaults so
+# the Dockerfile is also usable with plain `docker build` on amd64.
+ARG TARGETARCH=amd64
+ARG GOSU_VERSION=1.17
 
 # Core tooling (python3 required for crosslink hooks)
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -20,13 +32,18 @@ SHELL ["/bin/bash", "-c"]
 # Claude CLI
 RUN curl -fsSL https://claude.ai/install.sh | bash
 
-# Install gosu for clean privilege dropping in entrypoint
+# Install gosu for clean privilege dropping in entrypoint.
+# Architecture is selected via the buildx-provided TARGETARCH so the same
+# Dockerfile produces working images for amd64 and arm64.
 USER root
-RUN curl -fsSL "https://github.com/tianon/gosu/releases/download/1.17/gosu-amd64" -o /usr/local/bin/gosu \
+RUN curl -fsSL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${TARGETARCH}" -o /usr/local/bin/gosu \
     && chmod +x /usr/local/bin/gosu
 
-# Crosslink binary
-COPY --chown=agent crosslink /usr/local/bin/crosslink
+# Crosslink binary — picked from the build context per target arch.
+# Caller must place crosslink-${TARGETARCH} (e.g. crosslink-amd64, crosslink-arm64)
+# in the build context next to this Dockerfile.
+COPY --chown=agent crosslink-${TARGETARCH} /usr/local/bin/crosslink
+RUN chmod +x /usr/local/bin/crosslink
 COPY entrypoint.sh /usr/local/bin/crosslink-entrypoint.sh
 RUN chmod +x /usr/local/bin/crosslink-entrypoint.sh
 

--- a/crosslink/resources/container/entrypoint.sh
+++ b/crosslink/resources/container/entrypoint.sh
@@ -75,7 +75,12 @@ if [ -n "$WORKSPACE" ]; then
     if [ -f "$WORKSPACE/go.mod" ]; then
         if ! command -v go &>/dev/null; then
             echo "[crosslink-entrypoint] Installing Go..."
-            curl -fsSL https://go.dev/dl/go1.23.4.linux-amd64.tar.gz | tar -C /usr/local -xzf - 2>&1
+            GO_ARCH="$(dpkg --print-architecture 2>/dev/null || uname -m)"
+            case "$GO_ARCH" in
+                amd64|x86_64) GO_ARCH=amd64 ;;
+                arm64|aarch64) GO_ARCH=arm64 ;;
+            esac
+            curl -fsSL "https://go.dev/dl/go1.23.4.linux-${GO_ARCH}.tar.gz" | tar -C /usr/local -xzf - 2>&1
         else
             echo "[crosslink-entrypoint] Go already installed."
         fi

--- a/crosslink/src/commands/container.rs
+++ b/crosslink/src/commands/container.rs
@@ -37,8 +37,18 @@ pub fn run(command: ContainerCommands) -> Result<()> {
     }
 }
 
-const IMAGE_NAME: &str = "crosslink-agent";
+// GHCR-namespaced image name so this command composes with `crosslink kickoff
+// run --container docker|podman` (which defaults to the same registry path).
+// Built images, lookup paths, and snapshot tags all live under this name.
+const IMAGE_NAME: &str = "ghcr.io/forecast-bio/crosslink-agent";
+// Default tag when starting a container or checking staleness — matches
+// kickoff's `--image` default so a `docker pull` of the published image
+// satisfies both code paths.
 const IMAGE_TAG: &str = "latest";
+// Default tag emitted by `crosslink container build`. Distinct from
+// IMAGE_TAG so a local rebuild doesn't shadow a pulled `:latest` —
+// matches the `:local` convention used by the `just build-image` recipe.
+const BUILD_DEFAULT_TAG: &str = "local";
 const CONTAINER_PREFIX: &str = "crosslink-task-";
 const LABEL_AGENT: &str = "crosslink-agent=true";
 
@@ -191,7 +201,8 @@ fn check_staleness() {
     if let Some(image_hash) = get_image_hash() {
         if image_hash != binary_hash {
             tracing::warn!(
-                "container image is stale (built from a different crosslink binary). Run 'crosslink container build' to update."
+                "container image {IMAGE_NAME}:{IMAGE_TAG} is stale relative to your installed crosslink binary. \
+                 Pull the latest published image (`docker pull {IMAGE_NAME}:{IMAGE_TAG}`) or rebuild locally (`just build-image` or `crosslink container build`)."
             );
         }
     }
@@ -216,7 +227,7 @@ pub fn build(force: bool, tag: Option<&str>, dockerfile: Option<&str>) -> Result
         bail!("Docker is not available. Install Docker and ensure the daemon is running.");
     }
 
-    let tag = tag.unwrap_or(IMAGE_TAG);
+    let tag = tag.unwrap_or(BUILD_DEFAULT_TAG);
     let image = format!("{IMAGE_NAME}:{tag}");
 
     // Create temp build context
@@ -626,4 +637,40 @@ pub fn snapshot(name: &str, tag: Option<&str>) -> Result<()> {
     println!("Snapshot saved: {image}");
     println!("Use with: crosslink container start --image {image}");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The container subcommands MUST address the same registry-qualified
+    /// image name as `crosslink kickoff run --container docker|podman`.
+    /// Regressing IMAGE_NAME back to the bare `crosslink-agent` form
+    /// silently un-composes the two code paths and re-opens GH#576.
+    #[test]
+    fn image_name_is_ghcr_namespaced() {
+        assert_eq!(IMAGE_NAME, "ghcr.io/forecast-bio/crosslink-agent");
+        assert_eq!(
+            IMAGE_NAME,
+            crate::commands::kickoff::DEFAULT_AGENT_IMAGE
+                .rsplit_once(':')
+                .map(|(name, _)| name)
+                .unwrap_or(IMAGE_NAME),
+            "container.rs IMAGE_NAME diverged from kickoff DEFAULT_AGENT_IMAGE — \
+             re-opens the GH#576 compose-failure between `crosslink container build` \
+             and `crosslink kickoff run --container …`"
+        );
+    }
+
+    /// `build()` must default to a tag distinct from the lookup tag so a
+    /// local rebuild doesn't shadow a `docker pull`ed `:latest`.
+    #[test]
+    fn build_default_tag_is_distinct_from_lookup_tag() {
+        assert_eq!(BUILD_DEFAULT_TAG, "local");
+        assert_ne!(
+            BUILD_DEFAULT_TAG, IMAGE_TAG,
+            "BUILD_DEFAULT_TAG and IMAGE_TAG must differ — otherwise `crosslink container build` \
+             clobbers the published `:latest` users pulled from GHCR"
+        );
+    }
 }

--- a/crosslink/src/commands/kickoff/launch.rs
+++ b/crosslink/src/commands/kickoff/launch.rs
@@ -701,9 +701,108 @@ pub(super) fn launch_container(
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        bail!("{} container launch failed: {}", runtime_cmd, stderr.trim());
+        bail!(format_container_launch_error(runtime_cmd, image, &stderr));
     }
 
     let container_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
     Ok(container_id)
+}
+
+/// URL of the published GHCR package — surfaced in the launch-failure hint so
+/// users can confirm whether the image they're requesting actually exists.
+const AGENT_IMAGE_PACKAGE_URL: &str =
+    "https://github.com/forecast-bio/crosslink/pkgs/container/crosslink-agent";
+
+/// Format the error message emitted when `docker run` / `podman run` fails.
+///
+/// Detects pull-failure substrings in the runtime's stderr and appends a
+/// hint pointing at `just build-image` (for local builds) and the GHCR
+/// package page (to confirm what's actually published). For other failure
+/// modes (e.g. invalid mount, OOM), the original stderr is returned without
+/// the hint to avoid misdirection.
+fn format_container_launch_error(runtime_cmd: &str, image: &str, stderr: &str) -> String {
+    let trimmed = stderr.trim();
+    let lowered = trimmed.to_ascii_lowercase();
+    let pull_failure = ["not found", "denied", "manifest unknown", "no such image"]
+        .iter()
+        .any(|needle| lowered.contains(needle));
+
+    if pull_failure {
+        format!(
+            "{runtime_cmd} container launch failed: {trimmed}\n\n\
+             Hint: the image `{image}` could not be pulled. Either:\n  \
+               * Build it locally:  just build-image       (tags as :local)\n  \
+               * Or pick a published tag from {AGENT_IMAGE_PACKAGE_URL}\n  \
+                 and pass it via `--image ghcr.io/forecast-bio/crosslink-agent:<tag>`."
+        )
+    } else {
+        format!("{runtime_cmd} container launch failed: {trimmed}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pull_failure_not_found_yields_hint() {
+        let stderr = "Unable to find image 'ghcr.io/forecast-bio/crosslink-agent:latest' locally\nError response from daemon: manifest unknown";
+        let msg = format_container_launch_error(
+            "docker",
+            "ghcr.io/forecast-bio/crosslink-agent:latest",
+            stderr,
+        );
+        assert!(msg.contains("docker container launch failed"));
+        assert!(msg.contains("Hint:"));
+        assert!(msg.contains("just build-image"));
+        assert!(msg.contains(AGENT_IMAGE_PACKAGE_URL));
+        assert!(msg.contains("ghcr.io/forecast-bio/crosslink-agent:latest"));
+    }
+
+    #[test]
+    fn pull_failure_denied_yields_hint() {
+        let stderr = "Error response from daemon: pull access denied for some/image, repository does not exist or may require 'docker login'";
+        let msg = format_container_launch_error(
+            "podman",
+            "ghcr.io/forecast-bio/crosslink-agent:nightly",
+            stderr,
+        );
+        assert!(msg.contains("podman container launch failed"));
+        assert!(msg.contains("Hint:"));
+        assert!(msg.contains("just build-image"));
+    }
+
+    #[test]
+    fn pull_failure_no_such_image_yields_hint() {
+        let stderr = "Error: No such image: ghcr.io/forecast-bio/crosslink-agent:does-not-exist";
+        let msg = format_container_launch_error(
+            "docker",
+            "ghcr.io/forecast-bio/crosslink-agent:does-not-exist",
+            stderr,
+        );
+        assert!(msg.contains("Hint:"));
+    }
+
+    #[test]
+    fn non_pull_failure_omits_hint() {
+        let stderr = "docker: Error response from daemon: invalid mount config for type \"bind\": bind source path does not exist";
+        let msg = format_container_launch_error(
+            "docker",
+            "ghcr.io/forecast-bio/crosslink-agent:latest",
+            stderr,
+        );
+        assert!(msg.contains("docker container launch failed"));
+        assert!(
+            !msg.contains("Hint:"),
+            "non-pull errors must not get the build-image hint (would misdirect): {msg}"
+        );
+        assert!(!msg.contains("just build-image"));
+    }
+
+    #[test]
+    fn pull_failure_is_case_insensitive() {
+        let stderr = "Error: NOT FOUND";
+        let msg = format_container_launch_error("docker", "image:tag", stderr);
+        assert!(msg.contains("Hint:"));
+    }
 }

--- a/crosslink/src/main.rs
+++ b/crosslink/src/main.rs
@@ -960,12 +960,19 @@ enum IssuesAliasCommands {
 
 #[derive(Subcommand)]
 enum ContainerCommands {
-    /// Build the crosslink agent container image
+    /// Build the crosslink agent container image locally.
+    ///
+    /// Produces `ghcr.io/forecast-bio/crosslink-agent:<tag>` (default tag
+    /// `local`) so it composes with `crosslink kickoff run --container
+    /// docker|podman --image ghcr.io/forecast-bio/crosslink-agent:<tag>`.
+    /// For routine use prefer `docker pull ghcr.io/forecast-bio/crosslink-agent:latest`
+    /// or `:nightly` — this command exists for offline / Dockerfile-iteration work.
     Build {
         /// Rebuild from scratch (no cache)
         #[arg(long)]
         force: bool,
-        /// Image tag (default: latest)
+        /// Image tag suffix (default: `local`). Image is always namespaced
+        /// `ghcr.io/forecast-bio/crosslink-agent:<tag>`.
         #[arg(long)]
         tag: Option<String>,
         /// Path to a custom Dockerfile

--- a/docs_src/guides/container-agents.qmd
+++ b/docs_src/guides/container-agents.qmd
@@ -54,15 +54,28 @@ Creates branch, worktree, builds the image (if needed), starts a container, and 
 
 ## Managing container lifecycle
 
-### Building the image
+### Getting the image
+
+The default image used by `--container docker|podman` is published to GitHub Container Registry as
+[`ghcr.io/forecast-bio/crosslink-agent`](https://github.com/forecast-bio/crosslink/pkgs/container/crosslink-agent),
+built for both `linux/amd64` and `linux/arm64`. Published tags:
+
+- `:latest` — the most recent tagged release
+- `:<version>` (e.g. `:0.5.2`) — pinned release
+- `:nightly` — floating tag tracking `develop`
+- `:nightly-<short-sha>` — immutable nightly snapshots
+
+The first `--container docker` launch will pull the image automatically; subsequent launches reuse the local copy. Pin `--image ghcr.io/forecast-bio/crosslink-agent:<version>` for reproducible runs.
+
+### Building the image locally
 
 ::: {.columns}
 ::: {.column width="35%"}
 **You say / do:**
 
-> "Set up the container image for this project."
+> "Build the agent image from source instead of pulling."
 
-The image is built once and reused for all subsequent agent launches. It includes the full toolchain for your project.
+Useful when iterating on `crosslink/resources/container/Dockerfile` or running offline. Produces a single-arch image tagged `:local`.
 :::
 ::: {.column width="5%"}
 →
@@ -71,10 +84,13 @@ The image is built once and reused for all subsequent agent launches. It include
 **Agent executes:**
 
 ```bash
-crosslink container build
+just build-image            # tags :local
+crosslink kickoff run "..." \
+  --container docker \
+  --image ghcr.io/forecast-bio/crosslink-agent:local
 ```
 
-The default image includes: Rust toolchain (matches project's `rust-version`), Python 3, Git, Claude Code CLI, and crosslink binary.
+The recipe builds a static musl crosslink binary for the host architecture and bakes it into the image alongside the entrypoint. The image includes git, openssh, jq, python3, sudo, the Claude CLI, and gosu for UID-remapping; project-specific toolchains (Rust/Node/Python/Go) are installed by the entrypoint on first run.
 :::
 :::
 

--- a/justfile
+++ b/justfile
@@ -233,6 +233,42 @@ test-proptest cases="1000":
 audit:
     cd crosslink && cargo audit
 
+# ─── Container image ─────────────────────────────────────────────────
+
+# Build the crosslink-agent container image locally for the host architecture.
+# Drops a static musl binary into the build context, then `docker buildx build
+# --load` produces a single-arch image tagged ghcr.io/forecast-bio/crosslink-agent:<tag>.
+# Default tag is `local` so this never collides with published `:nightly`/`:latest`.
+build-image tag="local":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    HOST_ARCH="$(uname -m)"
+    case "$HOST_ARCH" in
+        x86_64|amd64) RUST_TARGET=x86_64-unknown-linux-musl; DOCKER_ARCH=amd64; PLATFORM=linux/amd64 ;;
+        aarch64|arm64) RUST_TARGET=aarch64-unknown-linux-musl; DOCKER_ARCH=arm64; PLATFORM=linux/arm64 ;;
+        *) echo "Unsupported host arch: $HOST_ARCH"; exit 1 ;;
+    esac
+    echo "==> Building crosslink for ${RUST_TARGET}"
+    rustup target add "${RUST_TARGET}" >/dev/null
+    cd crosslink && cargo build --locked --release --target "${RUST_TARGET}"
+    cd ..
+    cp "crosslink/target/${RUST_TARGET}/release/crosslink" \
+       "crosslink/resources/container/crosslink-${DOCKER_ARCH}"
+    echo "==> Building image ghcr.io/forecast-bio/crosslink-agent:{{tag}} for ${PLATFORM}"
+    docker buildx build \
+        --platform "${PLATFORM}" \
+        --build-arg "TARGETARCH=${DOCKER_ARCH}" \
+        --load \
+        -t "ghcr.io/forecast-bio/crosslink-agent:{{tag}}" \
+        crosslink/resources/container
+    echo "==> Built ghcr.io/forecast-bio/crosslink-agent:{{tag}} (${DOCKER_ARCH})"
+
+# Push a locally-built image to GHCR. Use only for emergency manual publishes;
+# routine publishing is owned by .github/workflows/container-image.yml.
+# Requires: `docker login ghcr.io` first (PAT with write:packages scope).
+push-image tag:
+    docker push "ghcr.io/forecast-bio/crosslink-agent:{{tag}}"
+
 # ─── CI composite ────────────────────────────────────────────────────
 
 # Run what CI runs (lint → build → test)


### PR DESCRIPTION
Closes #576.

## Summary
- Publishes `ghcr.io/forecast-bio/crosslink-agent` to GHCR via new CI workflow — `develop` → `:nightly` (+ `:nightly-<sha>`), `v*` tags → `:<version>` (+ `:latest`), PRs touching the build context → build-only validation.
- Multi-arch (`linux/amd64` + `linux/arm64`) so the documented happy path works on both Intel and Apple Silicon, not just whatever arch CI happens to run on.
- Smoke-verify job pulls the just-pushed tag on both platforms and runs `crosslink --version` — the published artifact is *proven* runnable, not just *built* green.
- Local `just build-image [tag=local]` recipe for contributors / offline iteration.
- Improved error message in `crosslink kickoff run` when the runtime can't pull the image — detects pull-failure substrings and points at `just build-image` plus the GHCR package URL. Anti-misdirection: non-pull failures (mount errors, etc.) get the original message verbatim.

## What this fixes (the original report)
The default image referenced by `crosslink kickoff run --container docker|podman` (`ghcr.io/forecast-bio/crosslink-agent:latest`) was never published — users hit `not found` after auth. After this PR ships and the workflow runs once on `develop`, the documented happy path will work without manual Dockerfile builds.

## Architectural notes
- **Multi-arch via cross-compile, not multi-stage build.** Rust binaries are built per-arch in a musl matrix job, downloaded as artifacts, and `COPY`d in via a `TARGETARCH` ARG. Avoids bundling the rust toolchain into the runtime image and keeps build times sane (no qemu-emulated cargo).
- **The same hardcode bug appeared in `entrypoint.sh`** (Go install path: `linux-amd64.tar.gz`). Fixed there too via `dpkg --print-architecture` — would have caused arm64 toolchain installs to silently fail otherwise.
- **`gosu-amd64` → `gosu-${TARGETARCH}` + `ARG GOSU_VERSION=1.17`** so the Dockerfile is also usable with plain `docker build` on amd64 (the buildx-provided ARG defaults to `amd64`).
- **`crosslink container build` is now semantically redundant** with `just build-image` (produces an image with the wrong name `crosslink-agent:latest` instead of `ghcr.io/forecast-bio/crosslink-agent:*`, uses the embedded Dockerfile instead of the live file). Follow-up commit on this branch will re-point it to compose with `kickoff`.

## Files
| File | Why |
|---|---|
| `.github/workflows/container-image.yml` | NEW: multi-arch build matrix + tag/branch routing + GHCR login + smoke-verify |
| `crosslink/resources/container/Dockerfile` | `gosu-amd64` → `gosu-${TARGETARCH}`; `COPY crosslink` → `COPY crosslink-${TARGETARCH}` |
| `crosslink/resources/container/entrypoint.sh` | Same arch-hardcode pattern in the Go install path |
| `crosslink/src/commands/kickoff/launch.rs` | New `format_container_launch_error` helper + 5 unit tests |
| `justfile` | New `build-image` and `push-image` recipes |
| `.gitignore` | Excludes `crosslink/resources/container/crosslink*` build artifacts |
| `docs_src/guides/container-agents.qmd` | Replaces the inaccurate "build the image" section with the GHCR-published reality + new local recipe |

## Test plan
- [x] `cargo test --bin crosslink -- --skip proptest` — 2764 pass (5 new launch tests included)
- [x] `cargo fmt --check` + `cargo clippy -- -D warnings` — clean on touched files
- [x] Local: `just build-image` produces `ghcr.io/forecast-bio/crosslink-agent:local`; `docker run --rm --entrypoint /usr/local/bin/crosslink ghcr.io/forecast-bio/crosslink-agent:local --version` → `crosslink 0.5.2+<sha>-dirty` (verified by subagent on host)
- [x] `git ls-files crosslink/resources/container/` returns only `Dockerfile` + `entrypoint.sh` (no binary committed)
- [x] Real `docker run` against a non-existent tag emits stderr containing both "not found" and "denied" substrings — confirms the hint will fire
- [ ] **Reviewer**: watch the first CI run on this PR for the arm64 musl cross-link step. The matrix uses `gcc-aarch64-linux-gnu` as the C cross-linker for `aarch64-unknown-linux-musl`. Usually works (rustc bundles its own musl libc, the C linker is just for crt0/etc) but isn't guaranteed for all crates with C dependencies. If it red-lines, switch to `messense/rust-musl-cross` or `cross-rs` — both well-known fixes.
- [ ] **Reviewer**: post-merge to `develop`, watch for the first nightly publish + smoke-verify. The smoke-verify job is the proof that `docker pull` + `docker run --version` actually work end-to-end on both arches; if it red-lines, the published artifact is broken and we know immediately.

## Honest gaps
- CI green on the workflow itself + end-to-end pull of the published `:nightly` cannot be verified pre-push from a sandbox. Both materialize as the workflow runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)