### PR TITLE
fix(ci): authenticate smoke-verify against GHCR + flag manual public-visibility step (#728)

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -242,6 +242,19 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
 
+      # GHCR creates new packages as PRIVATE by default on first publish,
+      # regardless of repo visibility. Until the package is manually flipped
+      # to public via Settings -> Packages, even pulling a tag we just
+      # pushed in the same workflow requires auth — hence the login here.
+      # When the package is public this step is harmless (login still works,
+      # subsequent pulls just don't need it).
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Pull image
         run: docker pull --platform ${{ matrix.platform }} ${{ needs.publish-image.outputs.primary_tag }}
 


### PR DESCRIPTION
Follow-up to #578. After merge, the first nightly publish succeeded but `smoke-verify` failed with:

```
Run docker pull --platform linux/arm64 ghcr.io/forecast-bio/crosslink-agent:nightly
Error response from daemon: Head "https://ghcr.io/v2/forecast-bio/crosslink-agent/manifests/nightly": unauthorized
Error: Process completed with exit code 1
```

## Two bugs, one merged PR didn't catch them

**Bug 1 — the CI fix in this PR.** `smoke-verify` was missing the `docker login` step that `publish-image` already had. GHCR requires auth to pull from a private package — even if you just pushed it in the same workflow run. **This PR adds the login step.**

**Bug 2 — the user-facing fix, NOT in this PR (needs admin action below).** GHCR creates new packages as **private** on first publish, regardless of repo visibility. So even after this CI fix lands and the workflow goes green, **end users still cannot `docker pull ghcr.io/forecast-bio/crosslink-agent:nightly`** without authenticating — which means the original GH#576 *isn't actually solved yet*. The CI fix only papered over the symptom inside the workflow.

## Required one-time admin step (you, not CI)

To actually finish GH#576, an org admin must flip the package visibility to **public**, exactly once:

**Web UI** (easiest):
1. Go to https://github.com/forecast-bio/crosslink/pkgs/container/crosslink-agent
2. **Package settings** (right sidebar)
3. Scroll to **Danger Zone → Change package visibility**
4. **Change to Public**, confirm

**Or via CLI** (requires `admin:packages` scope on your `gh` auth):
```bash
gh api --method PATCH \
  /orgs/forecast-bio/packages/container/crosslink-agent/visibility \
  -f visibility=public
```

After that, anyone — no auth, no PAT, no `docker login` — can:
```bash
docker pull ghcr.io/forecast-bio/crosslink-agent:nightly
docker pull ghcr.io/forecast-bio/crosslink-agent:latest      # after the next v* tag
```

The `docker/login-action` step in this PR remains harmless on a public package — it just authenticates and then the pull doesn't strictly need it. Defense-in-depth so the workflow stays green if the package is ever flipped back to private.

## Why this wasn't caught in #578's smoke-verify

#578's `smoke-verify` couldn't have caught either bug pre-merge because the package didn't exist at all until the *first* push to `develop`, which only happened on the merge commit. The smoke-verify job ran for the first time post-merge, hit `unauthorized`, and surfaced the gap. That's the publish-pipeline equivalent of a deploy-only failure — fixable now that we've seen it, but not pre-merge testable from a feature branch.

## Files
- `.github/workflows/container-image.yml` — add `docker/login-action@v3` step to `smoke-verify` between `setup-qemu-action` and the first `docker pull`. Inline comment explains *why* (GHCR private-by-default) so it doesn't get deleted as redundant once the package is public.

## Test plan
- [x] YAML validated; smoke-verify steps now: `Set up QEMU → Log in to GHCR → Pull image → Inspect manifest → Run --version → Verify version-matches-tag`
- [x] **Reviewer**: after merge, the next push to `develop` should produce a fully green `container-image.yml` run, including a green `smoke-verify` matrix on both platforms
- [ ] **Reviewer (admin step)**: flip package visibility to public via the steps above. After that, `docker pull` from a clean machine with no `docker login` should succeed for `ghcr.io/forecast-bio/crosslink-agent:nightly`
- [ ] **Optional reviewer task**: confirm GH#576 can be closed once both the green CI and the public-pull-from-clean-machine are verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)