### PR TITLE
docs: document every undocumented config key + state file in .crosslink/

### DIFF
--- a/docs_src/_quarto.yml
+++ b/docs_src/_quarto.yml
@@ -32,6 +32,7 @@ website:
         menu:
           - reference/commands.qmd
           - reference/hook-config.qmd
+          - reference/state-files.qmd
           - reference/rules.qmd
           - reference/kickoff-report.qmd
     right:
@@ -68,6 +69,7 @@ website:
           contents:
             - reference/commands.qmd
             - reference/hook-config.qmd
+            - reference/state-files.qmd
             - reference/rules.qmd
             - reference/kickoff-report.qmd
 

--- a/docs_src/guides/container-agents.qmd
+++ b/docs_src/guides/container-agents.qmd
@@ -21,6 +21,18 @@ Container execution gives your agents the same workflow with stronger sandboxing
 
 &nbsp;
 
+### Local sandbox alternative
+
+If you can't run Docker or Podman but still want some host isolation for local kickoffs, set the `sandbox.command` key in `hook-config.json` (see [hook configuration reference](../reference/hook-config.qmd#sandbox-command)). The configured command is prefixed to every local kickoff `claude` invocation, so you can wrap the agent in `firejail`, `bwrap`, `nsjail`, macOS `sandbox-exec`, or any tool that accepts the command to run as its trailing argument.
+
+```bash
+crosslink config set sandbox.command "firejail --quiet --net=none"
+```
+
+A container is still the stronger answer when one is available -- this lever just makes the local path less raw when it's the only option.
+
+&nbsp;
+
 ---
 
 ## Quick start

--- a/docs_src/reference/hook-config.qmd
+++ b/docs_src/reference/hook-config.qmd
@@ -4,7 +4,7 @@ title: "Hook configuration"
 
 Hooks run automatically during agent sessions and rarely need manual configuration. This reference documents the full configuration surface for fine-tuning enforcement behavior.
 
-Hook behavior is controlled by `.crosslink/hook-config.json`. This file is created by `crosslink init` and can be edited to customize enforcement.
+Hook behavior is controlled by `.crosslink/hook-config.json`. This file is created by `crosslink init` and can be edited to customize enforcement. For machine-specific overrides that should not be committed, use the [`hook-config.local.json` overlay](state-files.qmd#hook-config-local-json) -- same schema, shallow-merged on top.
 
 ## Configuration file
 
@@ -245,7 +245,7 @@ The `sentinel` block configures the autonomous sentinel daemon, which polls conf
 }
 ```
 
-### `sentinel.enabled`
+### `sentinel.enabled` {#sentinel-enabled}
 
 Master switch for the sentinel daemon. Bool. Default: `false`. When `false`, `crosslink daemon start` will run the heartbeat/coordination loop but skip sentinel polling entirely.
 

--- a/docs_src/reference/hook-config.qmd
+++ b/docs_src/reference/hook-config.qmd
@@ -96,6 +96,159 @@ Bash commands that bypass the issue-required check. These are typically read-onl
 
 The hook splits chained commands (using `&&`, `;`, `|`) and checks that **every** component matches an allowed prefix. A command like `crosslink list && rm -rf /` would be blocked because `rm -rf /` doesn't match any allowed prefix.
 
+### `tracker_remote`
+
+Git remote name used for crosslink's `hub` and `knowledge` coordination branches. String. Default: `"origin"`. Override when your coordination remote differs from your code remote -- e.g. `crosslink config set tracker_remote upstream`.
+
+### `external-cache-ttl`
+
+TTL in seconds for cached external-repo metadata (used by `crosslink issue` commands that reach into another project's hub branch). Integer. Default: `300` (5 minutes). Lower for fast-moving coordination repos, higher to reduce network round-trips.
+
+### `external-url-ttl`
+
+TTL in seconds for cached URL → repo resolution results (e.g. parsing `https://github.com/owner/repo` into the canonical alias). Integer. Default: `86400` (24 hours).
+
+### `repo-alias`
+
+Map of named aliases for external repositories, used by commands that accept `--repo <alias>`. Stored as `repo-alias.<name>` keys -- set with `crosslink config set repo-alias.upstream https://github.com/owner/repo`. Default: `{}` (none).
+
+### `sandbox.command` {#sandbox-command}
+
+Optional sandbox-wrapper command applied to local kickoff launches. String. Default: unset (no sandboxing). When set, the kickoff agent's `claude` invocation is prefixed with this command; the value must be a binary on `$PATH` accepting the command to run as its trailing argument. See [Local sandbox alternative](../guides/container-agents.qmd#local-sandbox-alternative) in the container-agents guide for usage notes.
+
+&nbsp;
+
+---
+
+## Agent overrides
+
+The `agent_overrides` object lets kickoff agents run under a different policy from interactive sessions in the same repo. When a key appears under `agent_overrides`, it shadows the same-named top-level key **only for agent processes** -- interactive `claude` sessions and human shells still see the top-level value. Two additional keys (`agent_lint_commands`, `agent_test_commands`) have no top-level counterpart and only exist here.
+
+```json
+{
+  "agent_overrides": {
+    "tracking_mode": "relaxed",
+    "blocked_git_commands": [
+      "git push --force", "git push -f",
+      "git reset --hard",
+      "git clean -f", "git clean -fd", "git clean -fdx",
+      "git checkout .", "git restore ."
+    ],
+    "gated_git_commands": [],
+    "agent_lint_commands": [],
+    "agent_test_commands": []
+  }
+}
+```
+
+### `agent_overrides.tracking_mode`
+
+Tracking mode applied to kickoff agents (overrides the top-level `tracking_mode`). Values: `"strict"`, `"normal"`, `"relaxed"`. Default: `"relaxed"`. Agents typically run under `"relaxed"` so they aren't blocked by the issue-required check during long autonomous loops, while humans in the same repo stay under `"strict"`.
+
+### `agent_overrides.blocked_git_commands`
+
+Git mutation commands blocked for agents only. Same prefix-matching semantics as the top-level `blocked_git_commands`. Default: a narrower destructive-only list (`git push --force`, `git reset --hard`, `git clean -f`, `git checkout .`, `git restore .`) so agents can still push to feature branches but cannot destroy history or wipe the worktree.
+
+### `agent_overrides.gated_git_commands`
+
+Git commands requiring an active issue for agents only. Default: `[]` (empty) -- the gated-list is intentionally empty for agents since they always run with an active issue claimed.
+
+### `agent_overrides.agent_lint_commands`
+
+Lint commands the agent runs as part of its self-validation pass at the end of a kickoff. Auto-populated during `crosslink init` from detected project conventions (e.g. `["cargo clippy", "npm run lint"]`); leave empty to disable. Default: `[]`.
+
+### `agent_overrides.agent_test_commands`
+
+Test commands the agent runs as part of its self-validation pass. Auto-populated during `crosslink init` from detected project conventions (e.g. `["cargo test", "npm test"]`); leave empty to disable. Default: `[]`.
+
+&nbsp;
+
+---
+
+## Sentinel configuration
+
+The `sentinel` block configures the autonomous sentinel daemon, which polls configured sources (e.g. GitHub label changes) and dispatches kickoff agents in response. Disabled by default. The full block:
+
+```json
+{
+  "sentinel": {
+    "enabled": false,
+    "interval_minutes": 10,
+    "max_concurrent_agents": 3,
+    "sources": {
+      "github_labels": {
+        "enabled": true,
+        "labels": ["agent-todo: replicate", "agent-todo: fix"]
+      }
+    },
+    "default_agent": {
+      "model": "claude-sonnet-4-6",
+      "timeout_minutes": 30,
+      "verify": "local"
+    },
+    "escalation": {
+      "enabled": true,
+      "model": "claude-opus-4-6",
+      "cooldown_minutes": 30,
+      "max_attempts": 2,
+      "timeout_multiplier_pct": 150
+    }
+  }
+}
+```
+
+### `sentinel.enabled`
+
+Master switch for the sentinel daemon. Bool. Default: `false`. When `false`, `crosslink daemon start` will run the heartbeat/coordination loop but skip sentinel polling entirely.
+
+### `sentinel.interval_minutes`
+
+Minutes between sentinel poll cycles. Integer (1-1440). Default: `10`. Lower values pick up new signals faster at the cost of API rate-limit headroom.
+
+### `sentinel.max_concurrent_agents`
+
+Maximum number of agents sentinel may have running simultaneously. Integer (1-10). Default: `3`. Excess signals queue until in-flight agents finish.
+
+### `sentinel.sources.github_labels.enabled`
+
+Enable the GitHub-label polling source. Bool. Default: `true`. The label source watches the project's GitHub issues for any of the configured `labels` and dispatches an agent per matching issue.
+
+### `sentinel.sources.github_labels.labels`
+
+Labels that trigger sentinel dispatch when applied to a GitHub issue. String array. Default: `["agent-todo: replicate", "agent-todo: fix"]`. Add a label here, apply it on an issue, and sentinel will pick it up on the next poll cycle.
+
+### `sentinel.default_agent.model`
+
+Model used for sentinel's first-attempt agent dispatch. String. Default: `"claude-sonnet-4-6"`. Sentinel uses Sonnet by default for cost; escalation (below) bumps to Opus on failure.
+
+### `sentinel.default_agent.timeout_minutes`
+
+Per-agent timeout in minutes for sentinel-dispatched runs. Integer (5-480). Default: `30`.
+
+### `sentinel.default_agent.verify`
+
+Verification level for sentinel agents. Values: `"local"`, `"ci"`, `"thorough"`. Default: `"local"`. Matches the `--verify` flag on `crosslink kickoff run`.
+
+### `sentinel.escalation.enabled`
+
+Enable automatic model escalation on first-attempt failure. Bool. Default: `true`. When `true`, sentinel retries failed dispatches with `sentinel.escalation.model` after the cooldown.
+
+### `sentinel.escalation.model`
+
+Model used for escalated retries. String. Default: `"claude-opus-4-6"`.
+
+### `sentinel.escalation.cooldown_minutes`
+
+Minutes to wait after a failed attempt before re-dispatching with the escalation model. Integer (5-1440). Default: `30`. Gives the system time for transient failures (rate limits, flaky CI) to clear.
+
+### `sentinel.escalation.max_attempts`
+
+Maximum number of dispatch attempts per signal across initial + escalation runs. Integer (1-5). Default: `2`. After this many failures, sentinel marks the signal failed and stops retrying.
+
+### `sentinel.escalation.timeout_multiplier_pct`
+
+Timeout multiplier for escalation attempts, expressed as a percentage of the default agent timeout. Integer. Default: `150` (1.5×). With the default 30-minute base, escalated retries get 45 minutes.
+
 &nbsp;
 
 ---

--- a/docs_src/reference/hook-config.qmd
+++ b/docs_src/reference/hook-config.qmd
@@ -112,6 +112,14 @@ TTL in seconds for cached URL → repo resolution results (e.g. parsing `https:/
 
 Map of named aliases for external repositories, used by commands that accept `--repo <alias>`. Stored as `repo-alias.<name>` keys -- set with `crosslink config set repo-alias.upstream https://github.com/owner/repo`. Default: `{}` (none).
 
+### `crosslink_binary`
+
+Explicit absolute path to the `crosslink` binary used by the Python hook scripts when shelling out. String. Default: unset (hooks fall back to `$PATH`, then common install locations like `~/.cargo/bin/crosslink`). Set this when `crosslink` lives somewhere unusual or when multiple installs need disambiguating -- e.g. `crosslink config set crosslink_binary /opt/forecast/bin/crosslink`.
+
+### `context_budget_chars`
+
+Estimated character budget the `prompt-guard.py` hook uses to warn before context exhaustion. Integer. Default: `1000000` (1M chars, roughly aligned with a 200k-token window). Set to `0` (or any non-positive value) to disable the guard entirely.
+
 ### `sandbox.command` {#sandbox-command}
 
 Optional sandbox-wrapper command applied to local kickoff launches. String. Default: unset (no sandboxing). When set, the kickoff agent's `claude` invocation is prefixed with this command; the value must be a binary on `$PATH` accepting the command to run as its trailing argument. See [Local sandbox alternative](../guides/container-agents.qmd#local-sandbox-alternative) in the container-agents guide for usage notes.
@@ -160,6 +168,46 @@ Lint commands the agent runs as part of its self-validation pass at the end of a
 ### `agent_overrides.agent_test_commands`
 
 Test commands the agent runs as part of its self-validation pass. Auto-populated during `crosslink init` from detected project conventions (e.g. `["cargo test", "npm test"]`); leave empty to disable. Default: `[]`.
+
+&nbsp;
+
+---
+
+## Watchdog configuration
+
+The `watchdog` block controls the per-kickoff sidecar that detects stalled local agents and sends a "continue" nudge to their tmux session. It applies only to local (non-container) kickoffs -- container agents have their own timeout enforcement via `--stop-timeout`. The block is read by `read_watchdog_config` in the kickoff launcher; omitting any sub-key keeps its default.
+
+```json
+{
+  "watchdog": {
+    "enabled": true,
+    "staleness_secs": 300,
+    "max_nudges": 5,
+    "check_interval_secs": 120,
+    "grace_period_secs": 300
+  }
+}
+```
+
+### `watchdog.enabled`
+
+Master switch for the per-kickoff watchdog sidecar. Bool. Default: `true`. When `false`, no watchdog process is spawned alongside local kickoffs and stalled agents are left alone until the overall `--timeout` fires.
+
+### `watchdog.staleness_secs`
+
+Seconds without a heartbeat before the watchdog considers an agent stalled and sends a nudge. Integer. Default: `300` (5 minutes). Heartbeats are written by the `PostToolUse` hook on every tool call, so a healthy agent refreshes this every few seconds.
+
+### `watchdog.max_nudges`
+
+Maximum number of "continue" nudges the watchdog will send before giving up and exiting. Integer. Default: `5`. Once exhausted, the watchdog leaves the tmux session running but stops trying to revive it -- the surrounding `--timeout` will eventually clean up.
+
+### `watchdog.check_interval_secs`
+
+Seconds between watchdog poll cycles. Integer. Default: `120` (2 minutes). Lower values catch stalls faster at the cost of slightly more shell wake-ups; this is rarely worth tuning.
+
+### `watchdog.grace_period_secs`
+
+Seconds the watchdog waits after launch before its first check, giving the agent time to start up and write its first heartbeat. Integer. Default: `300` (5 minutes). If your kickoffs are reliably idle for longer than this at the start (e.g. slow toolchain installs in the worktree), raise it.
 
 &nbsp;
 

--- a/docs_src/reference/state-files.qmd
+++ b/docs_src/reference/state-files.qmd
@@ -1,0 +1,224 @@
+---
+title: "State and config files"
+---
+
+`.crosslink/` holds the per-repo configuration and coordination state that crosslink reads at runtime. [`hook-config.json`](hook-config.qmd) has its own reference page; this page documents the remaining files in that directory. Each is either user-editable (configuration) or written by crosslink as a mirror of internal state (read-only for users, but documented here so the format is auditable).
+
+&nbsp;
+
+---
+
+## `hook-config.local.json` {#hook-config-local-json}
+
+Per-developer overlay for [`hook-config.json`](hook-config.qmd). Same schema, same keys, **same precedence rules**. Optional -- omit the file entirely when you don't need overrides.
+
+The hook scripts and the Rust `crosslink config` plumbing both load `hook-config.json` first, then shallow-merge `hook-config.local.json` on top. A key set in the local file wins; everything else falls through to the shared config. Use this when you want to keep machine-specific tweaks (a different `crosslink_binary` path, a tighter `tracking_mode`, custom `allowed_bash_prefixes`) out of the committed config.
+
+```bash
+# Write to the local overlay instead of the shared file:
+crosslink config set --local tracking_mode relaxed
+crosslink config set --local crosslink_binary /opt/forecast/bin/crosslink
+```
+
+This file is intentionally ignored by `crosslink init --force` so resets won't clobber your local preferences. Add `.crosslink/hook-config.local.json` to your project `.gitignore` (init does this for you) so it stays out of version control.
+
+&nbsp;
+
+---
+
+## `agent.json`
+
+Machine-local agent identity. Written by `crosslink agent init` (and updated by `crosslink kickoff run` for spawned agents). Gitignored -- every machine and every worktree has its own.
+
+```json
+{
+  "agent_id": "driver--my-feature-abc123",
+  "machine_id": "dollspace",
+  "description": "Driver agent for forecast-bio/crosslink",
+  "role": "driver",
+  "ssh_key_path": "keys/driver_ed25519",
+  "ssh_fingerprint": "SHA256:abc123...",
+  "ssh_public_key": "ssh-ed25519 AAAA... driver@crosslink"
+}
+```
+
+### `agent_id`
+
+Stable identifier for this agent in the coordination hub. String. Format depends on role: `"driver--<name>"` for a main-repo signing identity, `"<parent>--<slug>"` for a kickoff agent inside a worktree (where `<parent>` is the driver that spawned it).
+
+### `machine_id`
+
+Short hostname/handle that disambiguates same-named agents across machines. String. Defaults to `$HOSTNAME` at `crosslink agent init` time; safe to edit by hand if you want a different label in the hub UI.
+
+### `description`
+
+Free-text description shown in `crosslink agent status` and on the coordination dashboard. String, optional.
+
+### `role`
+
+Session role. Values: `"driver"` (main-repo signing identity, owns the SSH key), `"agent"` (autonomous worktree agent, inherits the driver's key). Default: `"driver"`. The role controls whether `crosslink agent init` generates a new SSH key or reuses the parent's.
+
+### `ssh_key_path`
+
+Path to the agent's SSH private key, relative to `.crosslink/`. String, typically `"keys/<agent_id>_ed25519"`. Used by `crosslink commit` and any other path that signs hub commits. Leave unset when an agent has no key (e.g. a worktree agent inheriting from its driver).
+
+### `ssh_fingerprint`
+
+SSH public-key fingerprint (`SHA256:...`). String, optional. Surfaced by `crosslink agent status` and used by `crosslink trust check`.
+
+### `ssh_public_key`
+
+Full SSH public-key line (`ssh-ed25519 AAAA... comment`). String, optional. Published to the hub via `crosslink trust approve` so other agents can verify this agent's signatures.
+
+&nbsp;
+
+---
+
+## `locks.json`
+
+Coordination locks tracking which agents currently hold which issues. Lives on the shared `crosslink/hub` branch but cached locally at `.crosslink/.hub-cache/locks.json` for fast reads. Most fields are written by `crosslink locks claim` / `release` / `steal`; the only user-tunable knob is `settings.stale_lock_timeout_minutes`.
+
+```json
+{
+  "version": 1,
+  "locks": {
+    "42": {
+      "agent_id": "driver--my-feature-abc123",
+      "branch": "feature/my-feature",
+      "claimed_at": "2026-05-11T17:30:00Z",
+      "signed_by": "SHA256:abc123..."
+    }
+  },
+  "settings": {
+    "stale_lock_timeout_minutes": 60
+  }
+}
+```
+
+### `version`
+
+Schema version of the locks file. Integer. Current: `1`. Bumped only on incompatible schema changes.
+
+### `locks`
+
+Map from issue ID (string-encoded integer) to the active lock. Each entry has the four fields below. Written by `crosslink locks claim` and friends; do not hand-edit -- use the CLI so signatures stay consistent.
+
+### `locks.<issue_id>.agent_id`
+
+The agent currently holding the lock. String. Set by `crosslink locks claim` and verified against the SSH signature on each operation.
+
+### `locks.<issue_id>.branch`
+
+Branch the agent is working on for this issue. String, optional. Surfaced by `crosslink locks list` so you can map locks to in-flight worktrees.
+
+### `locks.<issue_id>.claimed_at`
+
+ISO-8601 UTC timestamp of the claim. Compared against `settings.stale_lock_timeout_minutes` for stale-lock detection.
+
+### `locks.<issue_id>.signed_by`
+
+SSH fingerprint of the signing key. Used to verify the claim was made by an agent crosslink trusts -- see [`signing_enforcement`](hook-config.qmd#signing_enforcement) for how strictness is configured.
+
+### `settings.stale_lock_timeout_minutes`
+
+Minutes after which a lock is considered stale and eligible for `crosslink locks steal` (or auto-steal when [`auto_steal_stale_locks`](hook-config.qmd#auto_steal_stale_locks) is on). Integer. Default: `60`. Lower for fast-moving solo work, raise when agents legitimately run long without heartbeats.
+
+&nbsp;
+
+---
+
+## `swarm.toml`
+
+Trust model configuration consumed by `crosslink swarm review` and related ADIHQ-style review passes. Written by `crosslink trust-model init <model>`; safe to hand-edit afterwards. Optional -- when absent, every command behaves as if the file contains the default `"local-only"` profile.
+
+```toml
+[trust]
+model = "local-only"
+description = "Single-tenant dev box; no external attackers in threat model."
+
+[ignore]
+patterns = ["timing attack", "side-channel"]
+reason = "By design — out of scope for local-only deployments."
+
+[boundaries]
+external = []
+internal = ["http", "ws", "cli"]
+```
+
+### `[trust].model`
+
+Trust model identifier. String. Values: `"local-only"`, `"multi-tenant"`, `"public-api"`, `"custom"`. Default: `"local-only"`. Drives the priors that review agents apply when triaging findings.
+
+### `[trust].description`
+
+Free-text description of the threat model surfaced to review agents as context. String, optional.
+
+### `[ignore].patterns`
+
+Substrings (case-insensitive) matched against finding titles. Matches are auto-triaged as `by-design`. String array, optional. Use to suppress noise from finding classes that don't apply to your deployment (e.g. timing attacks for a local-only tool).
+
+### `[ignore].reason`
+
+Reason string attached to findings auto-triaged by the `patterns` list. String, optional. Shown in the review report so suppressions are auditable.
+
+### `[boundaries].external`
+
+Interfaces crossing your trust boundary (HTTP, websocket, gRPC, CLI input, file). String array, optional. Review agents treat untrusted-input checks as higher priority when an interface is listed here.
+
+### `[boundaries].internal`
+
+Interfaces inside your trust boundary. String array, optional. Findings on these surfaces may be downgraded depending on the trust model.
+
+&nbsp;
+
+---
+
+## `session.json`
+
+Mirror of the current session row from `issues.db`, written by the crosslink daemon every 30 seconds. Lets external tooling (status-line scripts, IDE plugins, the TUI) read the current session without opening the SQLite database.
+
+```json
+{
+  "session_id": 47,
+  "started_at": "2026-05-11T17:06:23Z",
+  "active_issue_id": 731
+}
+```
+
+### `session_id`
+
+Database primary key of the active session. Integer.
+
+### `started_at`
+
+ISO-8601 UTC timestamp of `crosslink session start`.
+
+### `active_issue_id`
+
+Issue currently set as focus via `crosslink session work <id>`. Integer or `null` when no issue is claimed.
+
+This file is read-only from a user's perspective -- editing it doesn't change the session, since the daemon overwrites it on the next flush. Use `crosslink session work <id>` / `end` to change state.
+
+&nbsp;
+
+---
+
+## Other files in `.crosslink/`
+
+These exist for completeness; they're internal state with no user-tunable fields and don't need editing.
+
+| File | Purpose |
+|---|---|
+| `issues.db` | SQLite database — issues, comments, sessions, heartbeats. Use the `crosslink` CLI, not direct SQL. |
+| `daemon.log`, `daemon.pid` | Output and PID of `crosslink daemon`. |
+| `sentinel.log`, `sentinel.pid` | Output and PID of the sentinel loop (when enabled via [`sentinel.enabled`](hook-config.qmd#sentinel-enabled)). |
+| `driver-key.pub` | Cached copy of the driver's SSH public key for trust lookups. |
+| `heartbeats/` | Per-agent heartbeat JSON written by the `PostToolUse` hook. Ephemeral. |
+| `keys/` | Generated SSH keypairs for `crosslink agent init`. Never edit by hand. |
+| `last_test_run` | Single-line timestamp set by `crosslink issue tested`, consumed by the test-reminder hook. |
+| `repo-id` | Single-line opaque repo identifier used in compact agent IDs. |
+| `promotion-log.json` | Audit log of `L<n>` → `#<n>` issue promotions across sync. |
+| `.gitignore` | Lists state files that should not be committed (managed by `crosslink init`). |
+| `.hub-cache/`, `hub-cache/`, `.external-cache/`, `.style-cache/` | Read-through caches for hub branches, external repos, and the style sync source. Safe to delete; they rebuild on next sync. |
+| `rules/`, `rules.local/` | Project rules injected into agent context. Edit via `crosslink workflow` or directly as Markdown -- see [Rules reference](rules.qmd). |
+| `meta/`, `orchestrator/`, `locks/` | Internal subsystem state managed by `crosslink sync`, `crosslink swarm`, and the lock subsystem respectively. |


### PR DESCRIPTION
## Summary

Closes GH#582 and the follow-up scope expansion. The original issue listed 19 undocumented keys in `.crosslink/hook-config.json`; this PR documents those plus every other undocumented key crosslink reads, plus every other user-editable file in `.crosslink/`.

### Commit 1 — original 19 hook-config keys (`73345d5c`)

Appended to `docs_src/reference/hook-config.qmd`:

- 5 keys into `## Fields`: `tracker_remote`, `external-cache-ttl`, `external-url-ttl`, `repo-alias`, `sandbox.command`
- New `## Agent overrides` section with `agent_overrides.{tracking_mode, blocked_git_commands, gated_git_commands, agent_lint_commands, agent_test_commands}`
- New `## Sentinel configuration` section with 13 keys grouped under top-level / sources / default_agent / escalation

Plus a "Local sandbox alternative" subsection in `docs_src/guides/container-agents.qmd` cross-linked to the new `sandbox.command` entry.

### Commit 2 — additional 7 keys (`940a1d14`)

Found by greping every `config.get(...)` / `config[...]` site in `src/` and `.claude/hooks/`:

- 5 keys in a new `## Watchdog configuration` section: `watchdog.{enabled, staleness_secs, max_nudges, check_interval_secs, grace_period_secs}` (read by `read_watchdog_config` in `kickoff/launch.rs`)
- `crosslink_binary` and `context_budget_chars` appended to `## Fields` (read by the Python hooks)

### Commit 3 — new state-files reference page (`6c3df2d4`)

Per the user's expanded directive ("document everything undocumented, nothing is out of scope"), added `docs_src/reference/state-files.qmd` covering every remaining file in `.crosslink/`:

- **hook-config.local.json** — per-developer overlay
- **agent.json** — machine-local agent identity (all 7 fields)
- **locks.json** — coordination lock file including the previously-undocumented `settings.stale_lock_timeout_minutes`
- **swarm.toml** — trust model configuration ([trust] / [ignore] / [boundaries] tables)
- **session.json** — daemon-flushed session state mirror

Plus a closing table briefly acknowledging 14 internal state items (databases, logs, PIDs, caches, keys, subsystem dirs) so they're not invisible.

Registered the new page in both navbar and sidebar via `_quarto.yml`. Cross-link from `hook-config.qmd` to the overlay file. Explicit `{#sentinel-enabled}` and `{#hook-config-local-json}` anchors so cross-references through dotted-key headings stay stable.

## Coverage

Documented keys in `hook-config.qmd` after this PR: **37**, up from the 11 baseline (verified exhaustive by grep). New state-files page documents **5 user-editable files** with full schemas plus an internal-state table covering the rest.

## Test plan

- [x] All key/default values cross-checked against the source-of-truth: `config_registry.rs`, `resources/crosslink/hook-config.json`, `src/identity.rs`, `src/locks.rs`, `src/trust_model.rs`, `src/daemon.rs`, `WatchdogConfig::default()` in `kickoff/types.rs`
- [x] Cross-links between `hook-config.qmd` and `state-files.qmd` use explicit anchors for any dotted-key target
- [x] `_quarto.yml` navbar + sidebar both register the new page
- [x] Render the quarto site locally (or rely on the CI docs build) to verify the new page lands and all anchors resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)