### PR TITLE
fix(kickoff): stop --force-reinitting hook-config.json on every worktree + container start

### DIFF
--- a/crosslink/resources/container/entrypoint.sh
+++ b/crosslink/resources/container/entrypoint.sh
@@ -125,10 +125,15 @@ fi
 
 # --- Crosslink init ---
 # Set up hooks, skills, and policy in the workspace so container agents are
-# bound by the same rules as host agents.
+# bound by the same rules as host agents. Plain `init` (no --force) is
+# idempotent: it short-circuits when `.crosslink/` and `.claude/` already
+# exist in the worktree (the common case, since both are git-committed and
+# arrive with the worktree checkout). This is what prevents the entrypoint
+# from re-templating `hook-config.json` on every container start and leaking
+# spurious diffs into agent PRs. See GH#583.
 if [ -n "$WORKSPACE" ] && command -v crosslink &>/dev/null; then
     echo "[crosslink-entrypoint] Initializing crosslink hooks in workspace..."
-    gosu agent bash -c "cd '$WORKSPACE' && crosslink init --force" 2>&1 || true
+    gosu agent bash -c "cd '$WORKSPACE' && crosslink init" 2>&1 || true
 fi
 
 echo "[crosslink-entrypoint] Setup complete. Running command as agent..."

--- a/crosslink/src/commands/kickoff/launch.rs
+++ b/crosslink/src/commands/kickoff/launch.rs
@@ -433,10 +433,17 @@ pub(super) fn init_worktree_agent(
     crosslink_dir: &Path,
     compact_name: &str,
 ) -> Result<String> {
-    // Run crosslink init --force in the worktree
+    // Run `crosslink init` in the worktree. Plain init (no --force) is
+    // idempotent: it short-circuits when `.crosslink/` and `.claude/` already
+    // exist, which is the common case for a worktree freshly checked out
+    // from a branch that has both committed. We keep `--skip-signing` and
+    // `--defaults` to suppress the TUI walkthrough on the rare path where
+    // init actually has work to do. Dropping `--force` here prevents the
+    // worktree's `hook-config.json` from being re-templated and leaking a
+    // spurious diff into every agent-produced PR. See GH#583.
     let output = Command::new("crosslink")
         .current_dir(worktree_dir)
-        .args(["init", "--force", "--skip-signing", "--defaults"])
+        .args(["init", "--skip-signing", "--defaults"])
         .output()
         .context("Failed to run crosslink init in worktree")?;
 


### PR DESCRIPTION
## Summary

Closes GH#583. The container entrypoint at `crosslink/resources/container/entrypoint.sh` ran `crosslink init --force` on every container start, which unconditionally re-templated `.crosslink/hook-config.json` from the embedded default. That left a ~50-line diff in every agent-produced worktree (top-level keys moving into `agent_overrides`, new `agent_lint_commands`/`agent_test_commands` fields appearing) which leaked into every kickoff PR and required reviewers to remember to `git restore .crosslink/hook-config.json` before merging.

## Scope

Two call sites — the user's issue only named the container entrypoint, but the same bug pattern exists on the host side and the symptom required **both** to be fixed:

- **`crosslink/resources/container/entrypoint.sh:131`** — container's init call.
- **`crosslink/src/commands/kickoff/launch.rs::init_worktree_agent`** — host-side init that runs against the freshly-created worktree **before** the container starts. The host pass re-templates first, then the container pass re-templates again; dropping `--force` from only one wouldn't make the diff go away.

## Fix

Drop `--force` from both call sites. Plain `crosslink init` short-circuits at `commands/init/mod.rs:751` when `.crosslink/` and `.claude/` already exist (the common case for any worktree checked out from a branch that committed both), making the init a deliberate no-op on existing state instead of an unconditional re-template.

Kept `--skip-signing` and `--defaults` on the host call because they suppress the TUI walkthrough on the rare path where init genuinely has work to do (one of the dirs missing). Users who want to refresh hooks deliberately still run `crosslink init --force` manually — the existing documented path.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --lib --bin crosslink -- -D warnings` — clean
- [x] `cargo test --bin crosslink kickoff::` — 149/149 pass
- [x] `bash -n entrypoint.sh` — clean
- [x] Manual: run `crosslink kickoff run --container docker ...` against a repo that committed `.crosslink/` + `.claude/`, confirm the agent's first `git diff` no longer shows `hook-config.json` modified
- [x] Manual: same against a repo with `.crosslink/` deliberately gitignored, confirm init still creates it (plain `init` does the full setup when the dir is absent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)