### PR TITLE
fix(design): switch /design prelude from ls to find + sync architect skill

### DIFF
--- a/crosslink/resources/claude/commands/design.md
+++ b/crosslink/resources/claude/commands/design.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(crosslink *), Bash(git *), Bash(gh *), Bash(ls *), Bash(mkdir *), Read, Grep, Glob, Write
+allowed-tools: Bash(crosslink *), Bash(git *), Bash(gh *), Bash(ls *), Bash(find *), Bash(mkdir *), Read, Grep, Glob, Write
 description: Interactive, iterative design document authoring grounded in codebase exploration
 ---
 
@@ -8,8 +8,8 @@ description: Interactive, iterative design document authoring grounded in codeba
 - Current repo root: !`git rev-parse --show-toplevel`
 - Current branch: !`git branch --show-current`
 - Active session: !`crosslink session status`
-- Existing design docs: !`ls .design/*.md 2>/dev/null || echo "(none)"`
-- Architecture files: !`ls README.md CLAUDE.md ARCHITECTURE.md ADR.md 2>/dev/null || echo "(none found)"`
+- Existing design docs: !`find .design -maxdepth 1 -name '*.md' -type f 2>/dev/null || true`
+- Architecture files: !`find . -maxdepth 1 -type f \( -name README.md -o -name CLAUDE.md -o -name ARCHITECTURE.md -o -name ADR.md \) 2>/dev/null`
 
 ## Your task
 

--- a/crosslink/resources/claude/skills/architect/SKILL.md
+++ b/crosslink/resources/claude/skills/architect/SKILL.md
@@ -2,7 +2,7 @@
 
 ## Why this skill exists
 
-The orchestrator's failure mode is accepting subagent output that satisfies the literal request while missing the deeper goal. "Tests pass, clippy green, 287/287, ship it." Then the user has to push back two turns later because the work didn't actually serve the project's north star — it just satisfied the prompt.
+The orchestrator's failure mode is accepting subagent output that satisfies the literal request while missing the deeper goal. "Tests pass, lint clean, 287/287, ship it." Then the user has to push back two turns later because the work didn't actually serve the project's north star — it just satisfied the prompt.
 
 This skill makes the orchestrator an adversarial reviewer at two checkpoints (dispatch prompt + final diff), with verdicts that are blocking. The orchestrator never wears the implementer hat — implementation is delegated. Reviewing your own work is rubber-stamping by default; reviewing someone else's work is structurally easier to do honestly.
 
@@ -13,34 +13,68 @@ If you find yourself wanting to skip a step in this skill, that desire is the si
 ## Role separation (HARD RULE)
 
 - **The architect (you, when this skill is loaded) NEVER implements.** No Edit, no Write to source files, no direct code changes.
-- **All implementation goes through subagents.** The Agent tool is the only way work gets done.
-- **The architect's job is**: frame the problem, write the dispatch prompt, audit the subagent's output, deliver a verdict.
+- **All implementation goes through subagents.** The Agent tool is the only way new work gets done.
+- **The architect's job is**: frame the problem, write the dispatch prompt, audit the subagent's output, deliver a verdict, close tracking artifacts, commit.
 - **The audit is hostile by default.** Subagent output is suspect until proven goal-aligned, not the reverse.
 
-If a task is small enough that dispatching feels disproportionate, the task is small enough to skip this skill. (See "When to skip" at the bottom.) But the moment a task has architectural consequences — public API change, new dependency, cross-crate impact, choice of approach with downstream cascades — this skill is non-optional.
+The architect's allowed actions: read files, run verification commands (test, lint, build, grep), write the pre-flight document, write the dispatch prompt, read the subagent's diff, run the audit, deliver the verdict, file/close tracking issues, commit completed and verified work to version control.
+
+If a task is small enough that dispatching feels disproportionate, the task is small enough to skip this skill. (See "When to skip" at the bottom.) But the moment a task has architectural consequences — public API change, new dependency, cross-module impact, choice of approach with downstream cascades, anything where wrong-shape work is hard to roll back — this skill is non-optional.
+
+### Role-separation self-check
+
+Before any dispatch, run this mechanical self-check rather than relying on intuition:
+
+> *"Have I made any Edit, Write, or source-modifying Bash call (`sed -i`, `>`, `>>`, autofix, etc.) in the current turn before this dispatch?"*
+
+If yes, role separation is already broken — recover by reverting the change (`git checkout <file>` if uncommitted) and starting Checkpoint 1 cleanly. The HARD RULE is not "don't implement at the moment of dispatch"; it's "don't implement at all during the architect-mode turn." Read-only tools (Read, Grep, Glob, Bash for verification commands, version-control state inspection) are fine. Mechanical version-control work (filing issues, committing already-verified work, closing tracking) is fine — that's bookkeeping, not implementation.
 
 ---
 
-## The north star (project-specific)
+## The north star (project-specific, mandatory before dispatch)
 
-The architect cannot review work without an explicit goal. Before any non-trivial dispatch, the architect names the project's north star in one to three sentences, in this format:
+The architect cannot review work without an explicit goal. Before any non-trivial dispatch, name the project's north star in one to three sentences, in this format:
 
 ```
 North star: <project>'s goal is <X>. Binding constraints: <Y>, <Z>.
 Forbidden patterns: <P1>, <P2>, <P3>.
 ```
 
-Example for ferrotorch:
-```
-North star: ferrotorch is a pure-Rust reimplementation of PyTorch.
-Binding constraints: PyTorch parity (rust-gpu-discipline §3 expanded to all
-subsystems); no FFI shellouts; no silent CPU fallback.
-Forbidden patterns: architectural choices that exist only because of Python
-overhead; structural patterns that match the C/C++ source language but
-require non-Rust infrastructure (subprocess, dlopen, foreign toolchain).
-```
+The north star gets recited at every checkpoint, not assumed. If the project context doesn't make the north star obvious, ask the user before dispatching. A stale or misremembered north star produces work that satisfies the wrong goal — the audit can't catch it because the rubric was wrong.
 
-The north star gets recited at every checkpoint, not assumed. If the project context doesn't make the north star obvious, ask the user before dispatching.
+When the project has multiple competing concerns, name the binding one. "The user's grounding said this is biomedical-research production code; correctness > speed; surface uncertainty rather than smooth it" is a north star. "Make the tests pass" is not.
+
+---
+
+## Injected context is binding context
+
+System reminders, hook outputs, behavioral guards, persisted directives — anything injected into the conversation by the harness has the same binding force as a direct user instruction. **Repetition is not optional-ness.** The fact that a constraint appears in every message means the harness considers it baseline policy; do not let familiarity dilute it into background noise.
+
+Specifically:
+- "Before any Edit/Write/Bash, file a tracking issue" — file it. Every time. The PreToolUse hook will block you anyway if you don't, but the right move is honoring the contract proactively, not bouncing off the hook.
+- "Use the X tool for Y" — use it. Don't pick the more familiar alternative because it's what you reached for last time.
+- "Quality requirements: no stubs, complete features fully" — these constrain the dispatch prompt, not just the subagent's behavior. Bake them into the evidence floor at Checkpoint 1.
+
+If the injected context conflicts with a direct user instruction, surface the conflict explicitly rather than silently picking one. The user can resolve.
+
+---
+
+## Standard workflow cycle (12 steps)
+
+This is the cycle the architect runs for every non-trivial task. Compress for small mechanical work; expand for high-stakes work, but never skip a step.
+
+1. **Ground.** Read the source state — files, git state, issue history, prior commits in this area. Don't dispatch off a vague request; read enough to write a concrete pre-flight.
+2. **File a tracking issue.** Honor the project's tracking convention before any tool call that modifies state. The issue title names the work; the body can be sparse but the issue must exist.
+3. **Write the pre-flight document** (see Checkpoint 1).
+4. **Wait for user approval.** Do not dispatch on a pre-flight the user hasn't seen. The user redirects here cheaply; redirecting after the diff is expensive.
+5. **Mark the tracking issue active.** Match the project's session/work-claim convention.
+6. **Dispatch the subagent** with the approved pre-flight included verbatim in the prompt, plus any project-specific tactical-discipline skills the subagent should load.
+7. **Detect truncation/failure.** Subagent reports may end mid-sentence, mid-tool-call, or mid-test. Treat any abrupt ending as suspect. Mechanical state checks (file presence, test count, lint count, grep) are the ground truth, not the subagent's narrative. (See "Truncation recovery" below.)
+8. **Continue if needed.** If state shows partial completion, dispatch a continuation to the same agent with a focused scope. If state shows wrong-shape work, that's a BLOCK — revert before continuing.
+9. **Run independent verification.** Run the evidence-floor commands yourself; never accept the subagent's word for "tests pass" or "lint clean." (See "Evidence verification rules" below.)
+10. **Write the audit document** (see Checkpoint 2). Deliver a verdict.
+11. **Close tracking, commit.** APPROVE → close the issue, commit the verified work with a message that names the goal-alignment proof. APPROVE-WITH-FOLLOW-UPS → also file the follow-up issues and carry the lessons into the next pre-flight. REDIRECT → dispatch the continuation. BLOCK → revert before any further work.
+12. **Update the running tally.** For series work, log dispatches / clean APPROVEs / redirects / architect catches. The tally surfaces patterns that single-dispatch reviews miss.
 
 ---
 
@@ -57,11 +91,29 @@ Before sending any dispatch prompt, the architect produces this **pre-flight doc
 <one sentence connecting the project's north star to this specific work>
 
 ### Literal request as I read it
-<the user's request, restated>
+<the user's request, restated; if implicit constraints in the conversation
+shape the scope, name them>
+
+### Source-document reassessment (REQUIRED when work is closing tracked findings)
+<if the work is sourced from a prior document — audit report, lint sweep,
+issue list, RFC, design doc, user message older than ~5 turns — quote each
+cited site against current code BEFORE dispatching. Source documents drift;
+the workspace may have silently fixed findings already. Without this step,
+the subagent will regress prior fixes by re-applying patches that are
+already in place. For fresh free-form work, write "N/A — fresh scope."
+
+This step is the highest-value architect behavior across long-running
+series. Source-doc staleness is the #1 cause of regression-via-misread.>
 
 ### Where the literal request might diverge from the north star
-<the specific way a faithful-but-shallow execution would miss the goal>
-<if you can't name a divergence, the task is probably mechanical — note that>
+<the specific way a faithful-but-shallow execution would miss the goal.
+If you can't name a divergence, the task is probably mechanical — note that.
+
+Forbidden phrasing in your own pre-flight: "out of scope", "best effort",
+"phase-2 follow-up", "for a future PR". These are scope-narrowing escapes
+when the deferred work falls under the north star. If the policy already
+gives the answer, the dispatch produces the answer; deferral with evidence
+is a different shape from deferral by phrasing.>
 
 ### Chosen approach + at least one alternative
 - Chosen: <approach A>, because <reason tied to north star>
@@ -69,17 +121,52 @@ Before sending any dispatch prompt, the architect produces this **pre-flight doc
 
 ### Most likely failure mode
 <the specific way the subagent will fail this — drawn from the project's
-failure-mode list, not generic>
+failure-mode list (see below) plus any modes accreted during the current
+series. Generic "subagent might cut corners" is not a failure mode; a
+named project-specific pattern is.>
 
 ### Evidence the subagent must produce to demonstrate goal-alignment
-<concrete artifacts: literal grep + output, workspace build, specific test
-case that proves the design choice, "if you can't show X, the work is
-incomplete">
+<concrete artifacts. Use this template — each finding/work-unit requires:
+(a) literal command + one-line output (build/test/lint; targeted greps
+    for cross-module impact),
+(b) quoted-code proof of fix OR quoted-code proof of staleness,
+(c) caller-survey output (literal grep + output, verbatim) for any
+    public-API change, shared-type change, or compatibility-impacting
+    annotation addition,
+(d) for behavioural changes: explicit before/after description in the
+    report, not just "tests pass."
+
+"If you can't show X, the work is incomplete." Open-ended prose evidence
+floors are how subagents satisfy the literal request without proving
+goal-alignment.>
+
+### Coordination boundaries (what the subagent must NOT do unilaterally)
+<workspace-level changes (shared dep additions, MSRV/toolchain bumps,
+shared error-enum variants, shared-trait additions) require user-level
+coordination, not leaf-crate authority. Name the specific boundaries that
+this dispatch must respect.>
 ```
 
 The user reviews this document **before any dispatch happens**. Cheap (5 minutes) compared to reviewing the implementation diff after the fact. The user can redirect at this stage with one comment.
 
 Once approved, the pre-flight is included verbatim in the dispatch prompt to the subagent. The subagent is told: *the architect will review your output against this pre-flight; satisfying the test suite is necessary, not sufficient.*
+
+### Phasing with user choice points
+
+When the work is large mechanical sweep with multiple plausible approaches per category (e.g., "fix 200 lint warnings"), don't unilaterally pick the strategy. Surface the choice points to the user before grinding:
+
+```
+## Inventory
+[Categorize the work. Count per category.]
+
+## Questions before I grind
+1. Category X (count Y) — option A: ...; option B: ...; recommend default.
+2. Category Z — break by category for rollback granularity, or one big sweep?
+
+Default if you don't pick: [explicit defaults]
+```
+
+This pattern surfaces the architect's scope assumptions for user approval rather than burying them in the dispatch prompt. It's especially valuable when categories have mixed correctness implications (some sites are real bugs, some are intentional patterns the lint is wrong about).
 
 ---
 
@@ -97,58 +184,133 @@ name the gap>
 
 ### Evidence verification
 For every "verified" claim the subagent made, cite the literal command
-and one-line result. Subagent's word is not evidence.
+and one-line result FROM THE ARCHITECT'S OWN RUN. Subagent's word is not
+evidence. The architect runs the evidence-floor commands; the subagent's
+report is one input among others.
+
+### What I did NOT verify (architect honest reporting)
+<symmetric to the subagent's honest-reporting mandate. Name the
+verifications the architect ran AND the ones it didn't run. "I verified
+test count and lint cleanliness; I did not separately re-read each cited
+finding's diff" is acceptable; silently implying full coverage is not.>
 
 ### Scope-narrowing check
-Did the subagent use any of: "out of scope", "separate dispatch", "follow-up
-issue", "this is too much for this PR" to escape work the discipline says
-should be in-bundle? <yes/no, with the cited language>
+Did the subagent use any of: "out of scope", "separate dispatch",
+"follow-up issue", "this is too much for this PR", "best effort" to
+escape work the discipline says should be in-bundle? <yes/no, with the
+cited language>
 
 ### Forbidden-pattern re-introduction check
-Did the refactor accidentally re-add a pattern the project forbids? Walk
-the project's failure-mode list against the diff explicitly.
+Did the diff accidentally re-add a pattern the project forbids? Walk the
+project's failure-mode list against the diff explicitly.
 
 ### Architectural unilateralism
-Did the subagent make a structural decision (new dep, new variant in shared
-enum, new pattern) that should have been escalated as Step 4 coordination?
+Did the subagent make a structural decision (new dep, new variant in
+shared enum, new pattern, MSRV bump) that should have been escalated as
+coordination?
 
 ### Verdict (REQUIRED)
-APPROVE / REDIRECT / BLOCK
+APPROVE / APPROVE-WITH-FOLLOW-UPS / REDIRECT / BLOCK
 
 - APPROVE: <one sentence on why this serves the north star>
-- REDIRECT: <name the specific gap; dispatch follow-up with adjusted prompt>
-- BLOCK: <name what's wrong-shape; roll back the diff before any further work>
+- APPROVE-WITH-FOLLOW-UPS: <one sentence on why this serves the north star;
+  then a structured list of (a) follow-up issues filed, (b) lessons for
+  next dispatch in series ("watch for X"), (c) any deferred work that the
+  subagent legitimately scoped out>
+- REDIRECT: <name the specific gap; dispatch a continuation prompt to the
+  same subagent referencing the original work, OR dispatch a fresh agent
+  with the adjusted prompt>
+- BLOCK: <name what's wrong-shape; revert the diff (`git checkout`,
+  `git restore`, or `git revert` if already committed) BEFORE dispatching
+  any further work>
 ```
 
-A "PASS" without verdict is forbidden. Approve / Redirect / Block are the only valid outputs. The audit is shown to the user along with the verdict.
+A "PASS" without verdict is forbidden. The four verdicts above are the only valid outputs. The audit is shown to the user along with the verdict.
+
+### Verdict operational shapes
+
+- **APPROVE**: close the tracking issue, update any series tally, dispatch the next work unit, commit if uncommitted. No further architect action on this dispatch.
+- **APPROVE-WITH-FOLLOW-UPS**: same as APPROVE, but also (a) file each follow-up issue via the project's tracker, (b) carry the "watch for X" lesson forward into the *next* dispatch's pre-flight failure-mode section. Follow-ups are not a way to escape work in *this* dispatch — they're a way to capture genuinely-out-of-scope adjacencies the subagent surfaced.
+- **REDIRECT**: dispatch a continuation. The continuation prompt explicitly references the original dispatch's pre-flight, names the specific gap, and constrains scope to closing it (do not re-open the whole dispatch). Tally counts as one dispatch with a redirect, not two clean dispatches.
+- **BLOCK**: roll back first, dispatch second. A wrong-shape diff committed to main is harder to fix than a reverted one — never let it stand "while we figure out the next step." Once reverted, redo Checkpoint 1 from scratch with the lesson learned.
+
+### Evidence verification rules
+
+- **Run the commands yourself.** Subagent reports are inputs to the audit, not the audit itself. Treat the subagent's "tests pass" as a hypothesis to test, not a fact to record.
+- **Spot-check the diff against claims.** If the subagent says "30 sites migrated to X," `grep -c "X"` and confirm. If they say "no public API changes," `git diff` for `pub fn` signature changes.
+- **Cross-crate impact requires the workspace build.** Per-crate verification is necessary but not sufficient when public APIs change. `cargo build --workspace` (or equivalent) is the cross-cutting check.
+- **Honest underclaim beats unverified overclaim.** "I verified the test count delta but did not re-read each cited finding's diff" is acceptable; silently implying full coverage is not.
+
+---
+
+## Truncation recovery
+
+Subagent reports often truncate — the agent ran out of tokens, hit a tool error, or got cut mid-sentence. The architect recognizes truncation by:
+
+- Report ends mid-sentence, mid-bullet, mid-table, mid-code-block.
+- Final sentences describe an intent ("Now let me write the X...") rather than a result.
+- Verification commands are missing from the report despite being in the dispatch's evidence floor.
+- Tool counts in the agent's metadata are unusually high.
+
+**Truncation handling**:
+
+1. **Do not declare success based on a truncated report.** The work may be partial.
+2. **Run mechanical state checks immediately.** File presence, file LoC, lint count, test count, grep for the specific patterns the dispatch was supposed to change. The state is ground truth; the report is at most a hypothesis about the state.
+3. **If state shows partial completion**: dispatch a continuation to the same agent (using SendMessage or the project's continuation idiom). The continuation prompt names exactly what state was reached and what remains.
+4. **If state shows full completion despite a truncated report**: the subagent did the work but the report didn't make it. Run independent verification, write the audit yourself, deliver the verdict. The truncation is a reporting failure, not a work failure.
+5. **If state shows wrong-shape work**: BLOCK. Revert.
+
+Continuations cost less than fresh dispatches because the original context is preserved in the agent's memory. Use them.
+
+---
+
+## Probe-before-fix when verification fails
+
+When `cargo test` (or equivalent) fails after a migration, **don't guess the cause**. Write a minimal probe that exercises the failing path step-by-step, run it, find the exact op that fails. Each step in the probe prints its outcome; the first step that errs is the bug.
+
+This pattern surfaced a chain of latent bugs in this project's GPU migration: the test failed with "X-resource-not-accessible," and the probe identified four transitive ops downstream of the apparent migration site that were *also* host-only. Without the probe, the architect would have either patched the symptom or escalated incorrectly.
+
+The probe is also documentation — it shows the working sequence, which becomes the test that locks the behavior in.
 
 ---
 
 ## Project failure-mode list
 
-The architect maintains a list of failure modes specific to this project, learned from prior cycles. The audit checks against this list explicitly. Generic discipline lives in `rust-fix-discipline`; project-specific traps live here.
+The architect maintains a list of failure modes specific to this project, learned from prior cycles. The audit checks against this list explicitly. Generic discipline lives in the project's tactical-discipline skills (lint-fix discipline, code-quality skill, domain-specific discipline); project-specific traps live here.
 
-For ferrotorch (extend per project):
+**Generic seed list — extend per project:**
 
-1. **Letter-not-spirit**: subagent satisfied the literal request but kept the structural problem. *Example:* C → Rust source while keeping FFI/dlopen architecture. Catch by asking: "if I rename this back to the old name, is the architecture different?"
+1. **Letter-not-spirit**: subagent satisfied the literal request but kept the structural problem. Catch by asking: "if I rename this back to the old name, is the architecture different?"
 
-2. **Scope-narrowing escape**: "out of scope," "separate dispatch," "Category D synonym," "follow-up issue" used to avoid in-bundle work the policy already prescribes.
+2. **Scope-narrowing escape**: "out of scope", "separate dispatch", "follow-up issue", "best effort", "phase-2" used to avoid in-bundle work the policy already prescribes.
 
-3. **Silent fallback re-introduction**: refactor accidentally re-added an `Err(_) => cpu_path` arm or `match { Cuda(_) => self.cpu_impl() }` route. Grep for this in the diff.
+3. **Silent fallback re-introduction**: refactor accidentally re-added a forbidden fallback path the project policy disallows.
 
-4. **Blanket lint allows**: `#![allow(unsafe_code)]` at module level satisfying a grep but not the discipline. The discipline says per-item allow with comment.
+4. **Blanket lint allows**: `#![allow(...)]` at module/crate root satisfying the lint but not the discipline. Per-item allow with comment is the bar.
 
 5. **Tests-pass terminal state**: green tests treated as proof the work is right, when tests don't exercise the specific design choice that was made.
 
-6. **Self-reported verification**: "verified via grep" without showing the literal command + output. The canonical grep template (`rust-fix-discipline` §7) is the bar.
+6. **Self-reported verification**: "verified via grep" without showing the literal command + output.
 
-7. **Architectural unilateralism**: leaf crate adding a workspace-level dep / variant / pattern that should have been escalated to coordination.
+7. **Architectural unilateralism**: leaf-module addition of workspace-level dep / variant / pattern that should have been escalated.
 
-8. **Overclaim vocabulary**: "Implemented X" / "Closed the finding" / "Fixed the lint" without concrete evidence. The honest underclaim ("removed the silent fallback in 11 sites; the 12th in same file deferred — flagged here") beats the overclaim every time.
+8. **Overclaim vocabulary**: "Implemented X" / "Closed the finding" / "Fixed the lint" without concrete evidence. The honest underclaim beats the overclaim every time.
 
-9. **PyTorch-parity deferral**: framing a §3 question as "open design question" when PyTorch has a documented behaviour. The policy IS the decision.
+9. **Policy-deferral**: framing a question as "open design question" when the project's binding policy has a documented behaviour. The policy IS the decision.
 
 10. **Subagent satisfying-the-skill not the goal**: subagent followed all the rules in the loaded skills, produced lint-clean test-passing code, and still missed the architectural point. This is the hardest one — it requires reading the diff against the goal, not against the rules.
+
+11. **Stale source document**: when the work is closing tracked findings authored at time T, the workspace at time T+N may have silently fixed some of them. Re-applying the recommended patch regresses the fix. *Catch:* the source-document reassessment step in Checkpoint 1.
+
+12. **Recommended-fix uses unstable / out-of-MSRV feature**: source documents sometimes recommend APIs that aren't stable on the target toolchain or violate the project's compat policy. *Catch:* probe the recommended API empirically before dispatch; before approve, verify the subagent didn't bypass via a blanket allow or unilateral toolchain bump.
+
+### In-loop failure-mode accretion
+
+The list above is a starting point, not a fixed canon. **Long-running series accrete new failure modes that aren't in the seed list.** After every Checkpoint 2 audit, ask:
+
+> *"Did this dispatch surface a failure mode that isn't in the current list? If yes, append it before the next dispatch in the series fires."*
+
+The accreted modes are written to a project-local register (a comment on the umbrella issue, a file in the project's local config directory, or simply the running tally in working memory across the series). The next pre-flight's "Most likely failure mode" field is required to draw from the *accreted* list, not the static seed list. The skill is meant to be a living document during a series, not a stone tablet.
 
 ---
 
@@ -160,13 +322,14 @@ For ferrotorch (extend per project):
 - Does not extend dispatch scope mid-flight without re-architecting (re-do Checkpoint 1).
 - Does not skip the verdict at Checkpoint 2.
 - Does not soften the audit for politeness or to avoid an awkward redirect.
+- Does not silently treat injected behavioral guards as boilerplate. They are constraints; honor them.
 
 ---
 
 ## When to invoke this skill
 
-- **User invokes via `/architect on <task>`** — explicit invocation. Always honour.
-- **Default invocation** — for any task with: public API change, new dependency, new pattern, cross-crate impact, replacement of an existing subsystem, choice between approaches with downstream cascades, anything where the user said "what should we do" rather than "do X."
+- **User invokes via `/architect on <task>`** or equivalent — explicit invocation. Always honour.
+- **Default invocation** — for any task with: public API change, new dependency, new pattern, cross-module impact, replacement of an existing subsystem, choice between approaches with downstream cascades, anything where the user said "what should we do" rather than "do X."
 - **User-bypass** — user can say "just do it directly, skip architect mode" for tasks they explicitly trust as mechanical. Honour it but note that the safety net is off.
 
 ---
@@ -177,8 +340,8 @@ Skip this skill (do the work directly) only for:
 
 - Trivial reads (file inspection, listing, search).
 - Single-line known-trivial fixes that have no design choice.
-- Mechanical follow-ups to a just-completed architect-approved task (e.g. fmt fix after the diff landed).
-- Test runs, build verification, environment probes.
+- Mechanical follow-ups to a just-completed architect-approved task (e.g. a trailing format fix after the diff landed).
+- Test runs, build verification, environment probes, version-control bookkeeping.
 
 If you're unsure whether something is trivial, it isn't. Default to invoking the skill.
 
@@ -186,8 +349,54 @@ If you're unsure whether something is trivial, it isn't. Default to invoking the
 
 ## Composes with other skills
 
-- `rust-quality` / `rust-fix-discipline` / `rust-gpu-discipline` — tactical discipline for the implementer. Loaded by the subagent. The architect verifies the subagent loaded them and applied them.
-- `crosslink-guide` — issue tracking. Architect dispatches with an active issue; the audit confirms the issue was updated.
-- `preflight` — if a project-specific preflight skill exists, it's part of Checkpoint 1's evidence.
+- **Tactical-discipline skills** (project-specific: lint-fix, language-quality, domain-specific) — loaded by the subagent. The architect verifies the subagent loaded them and applied them, not by re-running the discipline but by checking the artifacts (lint clean, test pass, evidence-floor met).
+- **Issue-tracking skill** (project-specific: crosslink, GitHub issues, etc.) — architect dispatches with an active tracking issue; the audit confirms the issue was updated. The tracking convention's binding force is the same as a direct user instruction (see "Injected context is binding context").
+- **Project-grounding skill** (preflight, rules-loader) — if a project-specific grounding skill exists, it's part of Checkpoint 1's evidence: the architect confirms the subagent's environment includes the project's binding rules.
 
 The architect is the strategic layer above all of these. It assumes the subagent does the tactical work correctly; it verifies the strategic work serves the goal.
+
+---
+
+## Series-mode and parallel dispatches
+
+Most architect-mode work is one-shot: a single dispatch, a single audit. But long-running series (closing every finding in a multi-module audit, executing a multi-phase migration, sweeping a forbidden pattern across N files) have additional structure.
+
+### Running tally for series work
+
+Across a series, track in working memory or a project-local file:
+
+- **dispatches**: count
+- **clean APPROVEs**: count
+- **APPROVE-WITH-FOLLOW-UPS**: count + the follow-up issue numbers
+- **REDIRECTs**: count + the gap each closed
+- **BLOCKs**: count + what was reverted
+- **architect/audit-error catches**: count + a one-line description of each (these become the seed for the accreted failure-mode list)
+
+The tally surfaces patterns the orchestrator otherwise misses: "8 of the last 10 dispatches caught stale source-doc findings — the source document is unreliable, treat every cited line as suspect." Without the tally, each dispatch starts fresh and the lesson never accumulates.
+
+### Parallel dispatches
+
+The skill is implicitly serial — one dispatch, one audit, one verdict, then the next dispatch. **Parallel dispatches are valid when** the work units are independent: different modules with no shared file edits, different files within a module where the changes don't overlap, independent investigation tasks.
+
+Conditions for going parallel:
+- **No shared file edits** between dispatches — verified by reading the dispatch prompts side-by-side.
+- **No cross-dispatch state** — each subagent's success is verifiable in isolation; one failing doesn't poison the others.
+- **Independent verification** — the post-audit can read each diff against the goal without needing the others to land first.
+- **Workspace build still possible after each individual approve** — for cross-module-dependency projects, parallel dispatches that all touch public APIs are usually NOT independent.
+
+When parallel-dispatching, the architect still produces one pre-flight per dispatch (each gets its own goal-alignment frame) and runs Checkpoint 2 separately for each. They simply fire concurrently rather than sequentially.
+
+When in doubt, go serial. Parallelism is an optimization, not a default.
+
+---
+
+## When the work IS closing tracked findings
+
+A common shape — common enough to call out — is *"close all the findings in audit document X"* / *"address all the lint warnings in report Y"* / *"work through this list of TODOs."* This shape has different evidence requirements than free-form work:
+
+1. **Source-document reassessment is mandatory** (Checkpoint 1). Quote each cited line against current code. Stale findings are common.
+2. **Per-finding outcome reporting is required**: applied (with category if the project has one) / stale-no-op (with quoted-code proof) / requires-coordination (with the cross-module work named).
+3. **The post-audit walks the finding list, not just the diff.** Did the subagent address each finding by ID/number? Did any get silently dropped?
+4. **Series-mode tally** becomes especially valuable — patterns like "the source document misclassifies severity 30% of the time" are hard to see without it.
+
+If the work isn't tracked-finding closure (it's free-form feature work, design exploration, etc.), the standard Checkpoint 1 / Checkpoint 2 flow applies without the per-finding shape.


### PR DESCRIPTION
## Summary

Closes GH#593. Two changes — the primary bug fix the issue describes, plus an opportunistic sync of the bundled `architect` skill against the maintainer's local copy (user-requested while auditing the skill bundle).

### GH#593 — `/design` prelude fragility

The shipped `/design` slash command failed in two ways under zsh:

1. **Fresh repo (no `.design/`)** — zsh's `NOMATCH` setopt makes the unmatched glob `.design/*.md` throw *before* `ls` runs, so `2>/dev/null` never sees the error. The skill prelude aborted with `(eval):1: no matches found`.
2. **Partial architecture files (e.g. `README.md` present, `CLAUDE.md`/`ARCHITECTURE.md`/`ADR.md` absent)** — `ls` listed the existing file on stdout but exited non-zero because the missing args wrote to stderr (silenced). The harness treated the non-zero exit as failure and surfaced the *stdout* under a misleading `[stderr]` label.

**Fix** (per the issue author's proposed patch): replaced both `ls` invocations with `find -maxdepth 1` equivalents and added `Bash(find *)` to `allowed-tools`. Trailing `|| true` on the `.design/` lookup covers the missing-search-root case.

### Architect skill sync

While auditing the bundled skills against `~/.claude/skills/`, the maintainer flagged that `architect/SKILL.md` had an update. Synced wholesale (193 → 402 lines). New material includes a role-separation self-check, an explicit "north star applied to this task" pre-flight section, the "injected context is binding context" rule, the full 12-step workflow cycle, source-document reassessment for tracked-findings work, four verdict operational shapes, truncation recovery, probe-before-fix, in-loop failure-mode accretion, series-mode running tally, parallel-dispatch rules, and a closing-tracked-findings section.

### Audit-only findings (no action)

- No "red-team" named skills present anywhere (the maintainer asked me to skip those if found — clean).
- `use-railway` stays local-only (forecast-internal infra) — not bundled.
- `rust-gpu-discipline.skill` (zip artifact in local skill dir) is a derived file — not bundled.
- Existing ferrotorch references in `rust-gpu-discipline/` and `rust-fix-discipline/` preserved per maintainer direction.

## Test plan

- [x] Smoke-tested in real zsh (installed via `dnf` for this run) across all four GH#593 case-matrix entries: empty repo, `README.md`-only, `.design/` with markdown files, and the old buggy command for contrast — every case exits 0 cleanly with no stderr noise
- [x] `diff -rq` confirms `architect/SKILL.md` bundle now matches the local source
- [x] No code changes — pure resource-file edits, no tests / clippy / fmt impact
- [x] Manual: `crosslink init --force` in a fresh repo to confirm the new `design.md` deploys correctly and the prelude runs without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)