### PR TITLE
fix(kickoff): fold CLAUDE_CONFIG_DIR into env(1) argv so it survives the timeout wrapper

### DIFF
--- a/crosslink/src/commands/kickoff/launch.rs
+++ b/crosslink/src/commands/kickoff/launch.rs
@@ -144,15 +144,25 @@ pub(super) fn spawn_watchdog(
 /// so any `CLAUDE_CONFIG_DIR` set by the caller is silently lost (#555).
 /// Baking it into the command string bypasses tmux env handling entirely.
 ///
+/// The `CLAUDE_CONFIG_DIR=val` assignment is folded into the existing `env`
+/// argv (between `-u CLAUDECODE` and `claude`) rather than placed as a shell
+/// prefix. Shell prefix assignments (`VAR=val cmd`) are positional — they
+/// only take effect when `VAR=val` precedes the *leading* command name. With
+/// `timeout` (or any other wrapper) at column zero, a shell-prefix assignment
+/// degenerates into a literal positional arg and `timeout` tries to exec it
+/// as a binary path (`ENOENT`). Folding the assignment into `env`'s argv is
+/// robust to additional wrappers prepended later (nice, chrt, bwrap, etc.).
+/// See GH#587.
+///
 /// When `sandbox_command` is set, the claude invocation is wrapped:
 /// ```text
-/// timeout 3600s my-sandbox --project-dir /path -- CLAUDE_CONFIG_DIR='/p' env -u CLAUDECODE claude ...
+/// timeout 3600s my-sandbox --project-dir /path -- env -u CLAUDECODE CLAUDE_CONFIG_DIR='/p' claude ...
 /// ```
 /// Without sandbox:
 /// ```text
-/// timeout 3600s CLAUDE_CONFIG_DIR='/p' env -u CLAUDECODE claude ...
+/// timeout 3600s env -u CLAUDECODE CLAUDE_CONFIG_DIR='/p' claude ...
 /// ```
-/// When `claude_config_dir` is `None`, the prefix is omitted.
+/// When `claude_config_dir` is `None`, the assignment is omitted.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn build_agent_command(
     timeout_cmd: &str,
@@ -172,10 +182,11 @@ pub(super) fn build_agent_command(
     } else {
         ""
     };
-    // Shell prefix assignments (`VAR=value command`) set the variable in the
-    // environment passed to `command` only — they don't mutate the outer
-    // shell's env, so this is a per-invocation override.
-    let env_prefix = claude_config_dir
+    // Fold `CLAUDE_CONFIG_DIR=val` into env(1)'s argv so the assignment takes
+    // effect regardless of what wraps the resulting command (timeout, sandbox
+    // wrappers, etc.). `env` accepts `KEY=val` between options and the
+    // command, mutating only the environment passed to the exec'd process.
+    let env_assignment = claude_config_dir
         .filter(|v| !v.is_empty())
         .map(|v| format!("CLAUDE_CONFIG_DIR={} ", shell_escape_arg(v)))
         .unwrap_or_default();
@@ -183,7 +194,7 @@ pub(super) fn build_agent_command(
     let escaped_tools = shell_escape_arg(allowed_tools);
     let escaped_kickoff = shell_escape_arg(kickoff_file);
     let claude_cmd = format!(
-        "{env_prefix}env -u CLAUDECODE claude{skip_flag} --model {escaped_model} --allowedTools {escaped_tools} -- \"$(cat {escaped_kickoff})\""
+        "env -u CLAUDECODE {env_assignment}claude{skip_flag} --model {escaped_model} --allowedTools {escaped_tools} -- \"$(cat {escaped_kickoff})\""
     );
     sandbox_command.map_or_else(
         || format!("{timeout_cmd} {timeout_secs}s {claude_cmd}"),

--- a/crosslink/src/commands/kickoff/tests.rs
+++ b/crosslink/src/commands/kickoff/tests.rs
@@ -1922,6 +1922,20 @@ fn write_claude_stub(dir: &std::path::Path) {
     std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755)).unwrap();
 }
 
+/// Find a timeout binary the test host actually has. macOS without
+/// `brew install coreutils` has neither `timeout` nor `gtimeout`; some
+/// minimal CI images strip them too. Returns `None` when no usable
+/// candidate exists so callers can skip cleanly instead of false-failing.
+#[cfg(unix)]
+fn resolve_test_timeout_cmd() -> Option<&'static str> {
+    ["timeout", "gtimeout"].into_iter().find(|cmd| {
+        std::process::Command::new(cmd)
+            .arg("--version")
+            .output()
+            .is_ok_and(|o| o.status.success())
+    })
+}
+
 #[cfg(unix)]
 fn run_built_command_in_bash(
     cmd: &str,
@@ -1951,12 +1965,17 @@ fn test_build_agent_command_env_var_actually_reaches_claude() {
     // assignment after `timeout` where shell grammar treats it as a
     // literal positional arg — `timeout` then tried to exec
     // `CLAUDE_CONFIG_DIR=...` as a binary and bailed with ENOENT.
+    let Some(timeout_cmd) = resolve_test_timeout_cmd() else {
+        eprintln!("skipping: neither `timeout` nor `gtimeout` available on test host");
+        return;
+    };
+
     let tmp = tempfile::tempdir().unwrap();
     write_claude_stub(tmp.path());
     std::fs::write(tmp.path().join("KICKOFF.md"), "noop").unwrap();
 
     let cmd = build_agent_command(
-        "timeout",
+        timeout_cmd,
         3600,
         "opus",
         "Read,Write",
@@ -1989,21 +2008,30 @@ fn test_build_agent_command_env_var_reaches_claude_through_sandbox() {
     // sits between `timeout` and the env+claude pair, so the env
     // assignment must still ride along on env(1)'s argv (not as a
     // shell prefix that would silently degenerate to a positional arg).
+    let Some(timeout_cmd) = resolve_test_timeout_cmd() else {
+        eprintln!("skipping: neither `timeout` nor `gtimeout` available on test host");
+        return;
+    };
+
     let tmp = tempfile::tempdir().unwrap();
     write_claude_stub(tmp.path());
     std::fs::write(tmp.path().join("KICKOFF.md"), "noop").unwrap();
 
-    // Trivial pass-through "sandbox" — just `env --` so it consumes its
-    // tail without altering behavior. Lets the assertion exercise the
-    // wrap-around-claude code path without needing bwrap/firejail
-    // installed on the test host.
+    // Trivial pass-through "sandbox" — a shell script that just execs its
+    // tail. Avoids depending on `env --` (which BSD env may reject) or on
+    // bwrap/firejail being installed on the test host.
+    use std::os::unix::fs::PermissionsExt;
+    let sandbox = tmp.path().join("noop-sandbox");
+    std::fs::write(&sandbox, "#!/bin/sh\nexec \"$@\"\n").unwrap();
+    std::fs::set_permissions(&sandbox, std::fs::Permissions::from_mode(0o755)).unwrap();
+
     let cmd = build_agent_command(
-        "timeout",
+        timeout_cmd,
         3600,
         "opus",
         "Read,Write",
         "KICKOFF.md",
-        Some("env --"),
+        Some(&sandbox.to_string_lossy()),
         tmp.path(),
         false,
         Some("/sandbox-passthrough/value"),
@@ -2030,12 +2058,17 @@ fn test_build_agent_command_omitted_env_var_does_not_break_launch() {
     // When CLAUDE_CONFIG_DIR isn't set on the host, the constructed command
     // must still execute cleanly — no stray empty assignment that confuses
     // env(1), and the stub claude reports an empty CCD value.
+    let Some(timeout_cmd) = resolve_test_timeout_cmd() else {
+        eprintln!("skipping: neither `timeout` nor `gtimeout` available on test host");
+        return;
+    };
+
     let tmp = tempfile::tempdir().unwrap();
     write_claude_stub(tmp.path());
     std::fs::write(tmp.path().join("KICKOFF.md"), "noop").unwrap();
 
     let cmd = build_agent_command(
-        "timeout",
+        timeout_cmd,
         3600,
         "opus",
         "Read,Write",

--- a/crosslink/src/commands/kickoff/tests.rs
+++ b/crosslink/src/commands/kickoff/tests.rs
@@ -1817,9 +1817,11 @@ fn test_build_agent_command_plan_kickoff() {
 
 #[test]
 fn test_build_agent_command_propagates_claude_config_dir() {
-    // When the caller has CLAUDE_CONFIG_DIR set, it should be baked into the
-    // shell command string as a prefix assignment — this bypasses tmux's
-    // frozen-at-startup env (#555).
+    // When the caller has CLAUDE_CONFIG_DIR set, it must be baked into the
+    // shell command string so it bypasses tmux's frozen-at-startup env
+    // (#555). GH#587 required folding the assignment into env(1)'s argv
+    // rather than emitting it as a shell prefix — see build_agent_command
+    // docstring for why.
     let cmd = build_agent_command(
         "timeout",
         3600,
@@ -1833,7 +1835,7 @@ fn test_build_agent_command_propagates_claude_config_dir() {
     );
     assert_eq!(
         cmd,
-        "timeout 3600s CLAUDE_CONFIG_DIR='/Users/me/.claude-work' env -u CLAUDECODE claude --model 'opus' --allowedTools 'Read,Write' -- \"$(cat 'KICKOFF.md')\""
+        "timeout 3600s env -u CLAUDECODE CLAUDE_CONFIG_DIR='/Users/me/.claude-work' claude --model 'opus' --allowedTools 'Read,Write' -- \"$(cat 'KICKOFF.md')\""
     );
 }
 
@@ -1877,9 +1879,9 @@ fn test_build_agent_command_escapes_claude_config_dir_with_quotes() {
 
 #[test]
 fn test_build_agent_command_with_sandbox_includes_claude_config_dir() {
-    // The env prefix must live on the claude side of the sandbox boundary
-    // so the sandboxed claude process inherits the variable, not the
-    // sandbox wrapper itself.
+    // The env assignment must live on the claude side of the sandbox
+    // boundary so the sandboxed claude process inherits the variable, not
+    // the sandbox wrapper itself. Folded into env(1)'s argv per GH#587.
     let cmd = build_agent_command(
         "timeout",
         3600,
@@ -1892,8 +1894,171 @@ fn test_build_agent_command_with_sandbox_includes_claude_config_dir() {
         Some("/Users/me/.claude-work"),
     );
     assert!(cmd.contains(
-        "bwrap --bind '/tmp/my-worktree' /workspace -- CLAUDE_CONFIG_DIR='/Users/me/.claude-work' env -u CLAUDECODE claude"
+        "bwrap --bind '/tmp/my-worktree' /workspace -- env -u CLAUDECODE CLAUDE_CONFIG_DIR='/Users/me/.claude-work' claude"
     ));
+}
+
+// ============================================================================
+// GH#587: integration tests that actually parse the constructed command line
+// through a shell. The string-shape unit tests above check what we emit; these
+// tests check that what we emit is what a shell will execute correctly. The
+// 0.8.0 regression would have been caught here — the shell-prefix form
+// `timeout 3600s CCD=val env ... claude ...` parsed as a literal positional
+// arg to timeout and never reached claude.
+// ============================================================================
+
+/// Stub `claude` shim used by the integration tests. Prints
+/// `CCD=<CLAUDE_CONFIG_DIR>` to stdout and exits 0. Ignores all CLI args so
+/// the real flag plumbing doesn't interfere with the assertion.
+#[cfg(unix)]
+fn write_claude_stub(dir: &std::path::Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let stub = dir.join("claude");
+    std::fs::write(
+        &stub,
+        "#!/bin/sh\nprintf 'CCD=%s\\n' \"$CLAUDE_CONFIG_DIR\"\nexit 0\n",
+    )
+    .unwrap();
+    std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755)).unwrap();
+}
+
+#[cfg(unix)]
+fn run_built_command_in_bash(
+    cmd: &str,
+    cwd: &std::path::Path,
+    extra_path: &std::path::Path,
+) -> std::process::Output {
+    let path = format!(
+        "{}:{}",
+        extra_path.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    std::process::Command::new("bash")
+        .arg("-c")
+        .arg(cmd)
+        .current_dir(cwd)
+        .env("PATH", &path)
+        .output()
+        .expect("failed to spawn bash")
+}
+
+#[test]
+#[cfg(unix)]
+fn test_build_agent_command_env_var_actually_reaches_claude() {
+    // GH#587 regression test: the command string must parse correctly when
+    // executed through a shell, with CLAUDE_CONFIG_DIR landing in the env
+    // that the (stub) `claude` process sees. The 0.8.0 build placed the
+    // assignment after `timeout` where shell grammar treats it as a
+    // literal positional arg — `timeout` then tried to exec
+    // `CLAUDE_CONFIG_DIR=...` as a binary and bailed with ENOENT.
+    let tmp = tempfile::tempdir().unwrap();
+    write_claude_stub(tmp.path());
+    std::fs::write(tmp.path().join("KICKOFF.md"), "noop").unwrap();
+
+    let cmd = build_agent_command(
+        "timeout",
+        3600,
+        "opus",
+        "Read,Write",
+        "KICKOFF.md",
+        None,
+        tmp.path(),
+        false,
+        Some("/expected/value"),
+    );
+
+    let output = run_built_command_in_bash(&cmd, tmp.path(), tmp.path());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "command failed:\n  status: {:?}\n  stdout: {stdout}\n  stderr: {stderr}\n  cmd: {cmd}",
+        output.status
+    );
+    assert!(
+        stdout.contains("CCD=/expected/value"),
+        "CLAUDE_CONFIG_DIR did not reach claude:\n  stdout: {stdout}\n  cmd: {cmd}"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn test_build_agent_command_env_var_reaches_claude_through_sandbox() {
+    // Same parse-and-execute test but with a sandbox wrapper. The wrapper
+    // sits between `timeout` and the env+claude pair, so the env
+    // assignment must still ride along on env(1)'s argv (not as a
+    // shell prefix that would silently degenerate to a positional arg).
+    let tmp = tempfile::tempdir().unwrap();
+    write_claude_stub(tmp.path());
+    std::fs::write(tmp.path().join("KICKOFF.md"), "noop").unwrap();
+
+    // Trivial pass-through "sandbox" — just `env --` so it consumes its
+    // tail without altering behavior. Lets the assertion exercise the
+    // wrap-around-claude code path without needing bwrap/firejail
+    // installed on the test host.
+    let cmd = build_agent_command(
+        "timeout",
+        3600,
+        "opus",
+        "Read,Write",
+        "KICKOFF.md",
+        Some("env --"),
+        tmp.path(),
+        false,
+        Some("/sandbox-passthrough/value"),
+    );
+
+    let output = run_built_command_in_bash(&cmd, tmp.path(), tmp.path());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "command failed:\n  status: {:?}\n  stdout: {stdout}\n  stderr: {stderr}\n  cmd: {cmd}",
+        output.status
+    );
+    assert!(
+        stdout.contains("CCD=/sandbox-passthrough/value"),
+        "CLAUDE_CONFIG_DIR did not reach claude through sandbox:\n  stdout: {stdout}\n  cmd: {cmd}"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn test_build_agent_command_omitted_env_var_does_not_break_launch() {
+    // When CLAUDE_CONFIG_DIR isn't set on the host, the constructed command
+    // must still execute cleanly — no stray empty assignment that confuses
+    // env(1), and the stub claude reports an empty CCD value.
+    let tmp = tempfile::tempdir().unwrap();
+    write_claude_stub(tmp.path());
+    std::fs::write(tmp.path().join("KICKOFF.md"), "noop").unwrap();
+
+    let cmd = build_agent_command(
+        "timeout",
+        3600,
+        "opus",
+        "Read,Write",
+        "KICKOFF.md",
+        None,
+        tmp.path(),
+        false,
+        None,
+    );
+
+    let output = run_built_command_in_bash(&cmd, tmp.path(), tmp.path());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "command failed:\n  status: {:?}\n  stdout: {stdout}\n  stderr: {stderr}\n  cmd: {cmd}",
+        output.status
+    );
+    assert!(
+        stdout.contains("CCD="),
+        "expected stub to print CCD= line:\n  stdout: {stdout}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes GH#587 — critical regression in 0.8.0. `crosslink kickoff run` (and `kickoff plan`) cannot launch any local-process agent: the tmux session opens, the watchdog records `running`, the `claude` process is never spawned, and an hour later the watchdog flips status to `timed-out`. No work happens.

## Root cause

PR #558 added a `CLAUDE_CONFIG_DIR=val` shell-prefix assignment INSIDE `claude_cmd`, then wrapped it with `timeout` OUTSIDE `claude_cmd`. The emitted line:

```
timeout 3600s CLAUDE_CONFIG_DIR='/.../config/claude' env -u CLAUDECODE claude ...
```

Shell-prefix `VAR=val cmd` syntax **only** takes effect when `VAR=val` precedes the *leading* command name. With `timeout` at column zero, `CLAUDE_CONFIG_DIR=...` degenerates into a literal positional argv element. `timeout` interprets its first non-flag positional as the command to exec, and tries to `exec("CLAUDE_CONFIG_DIR=/...")` → ENOENT.

The four `build_agent_command` unit tests added in #558 passed because they only asserted string-shape equality with the (broken) emitted form. No test ever piped the string through a shell.

## Fix (Option A from the issue)

Fold the `CLAUDE_CONFIG_DIR=val` assignment into `env(1)`'s argv, between `-u CLAUDECODE` and `claude`:

```
timeout 3600s env -u CLAUDECODE CLAUDE_CONFIG_DIR='...' claude ...
```

`env` accepts `KEY=val` arguments between options and the command — the assignment lives in `env`'s short-lived shim and is inherited by the exec'd `claude`. Robust to any wrappers prepended at column zero in the future (`nice`, `chrt`, `bwrap`, `firejail`, chained sandboxes) because the assignment rides on env's argv rather than depending on shell positional grammar.

## New tests that would have caught the regression

Three new integration tests `#[cfg(unix)]` actually shell-execute the constructed command line with a stub `claude` script that prints `CCD=<CLAUDE_CONFIG_DIR>` to stdout:

- `test_build_agent_command_env_var_actually_reaches_claude` — the exact regression test pattern proposed in the issue. Pre-fix, this test fails with `timeout: failed to run command 'CLAUDE_CONFIG_DIR=...': No such file or directory` — the precise 0.8.0 symptom.
- `test_build_agent_command_env_var_reaches_claude_through_sandbox` — same check with a pass-through sandbox wrapper interposed between `timeout` and the env+claude pair.
- `test_build_agent_command_omitted_env_var_does_not_break_launch` — the `None` path still produces an executable line with no stray empty assignment.

The two existing string-shape tests (`test_build_agent_command_propagates_claude_config_dir`, `test_build_agent_command_with_sandbox_includes_claude_config_dir`) are updated to assert the new (correct) shape. The `build_agent_command` docstring now documents why the env-argv form is structurally robust and references GH#587.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --lib --bin crosslink --tests` — clean on touched files
- [x] `cargo test --bin crosslink` — **2820 passed** (2817 baseline + 3 new)
- [x] All 11 `test_build_agent_command_*` tests pass, including the 3 new shell-execution integration tests
- [x] Manual smoke (in commit description's repro one-liner): `bash -c "timeout 3600s VAR=hello echo test"` fails today with ENOENT; the new emitted shape `bash -c "timeout 3600s env VAR=hello echo test"` works
- [x] Manual: `crosslink kickoff run` on a real workspace with `CLAUDE_CONFIG_DIR` set in the parent shell, confirm `claude` actually starts inside the tmux session and the agent produces work (verifies the integration path beyond the unit-test stub)

🤖 Generated with [Claude Code](https://claude.com/claude-code)