### PR TITLE
fix(sync): write tracker_remote at init + structured push-failure classifier

### DIFF
--- a/crosslink/resources/crosslink/hook-config.json
+++ b/crosslink/resources/crosslink/hook-config.json
@@ -6,6 +6,7 @@
   "kickoff_verification": "local",
   "signing_enforcement": "audit",
   "auto_steal_stale_locks": false,
+  "tracker_remote": "origin",
   "blocked_git_commands": [
     "git push", "git merge", "git rebase", "git cherry-pick",
     "git reset", "git checkout .", "git restore .", "git clean",

--- a/crosslink/src/commands/init/mod.rs
+++ b/crosslink/src/commands/init/mod.rs
@@ -303,6 +303,114 @@ fn init_agent_identity(crosslink_dir: &Path, agent_id: &str) -> Result<()> {
     Ok(())
 }
 
+/// Detect the project's git remote and align `tracker_remote` in
+/// `hook-config.json` with reality so the value is visible/editable
+/// on disk rather than depending on the runtime fallback in
+/// `sync::read_tracker_remote`.
+///
+/// The embedded template ships with `"tracker_remote": "origin"` as
+/// the default. This function:
+///
+///   - leaves a manually-edited value alone (anything other than the
+///     literal default `"origin"`) so `init --force` doesn't clobber
+///     local customizations;
+///   - leaves `"origin"` alone when the repo either has an `origin`
+///     remote (configured or not, the value is the right placeholder)
+///     OR has no remotes at all (then `origin` is the conventional
+///     placeholder the user can fill in later);
+///   - upgrades `"origin"` to the actual remote name when the repo has
+///     a single non-origin remote, or multiple remotes none of which
+///     are `origin` (alphabetically first wins — deterministic, no
+///     prompt; the user can `crosslink config set tracker_remote
+///     <name>` to override).
+///
+/// The byte-equality preservation in the no-change cases is what
+/// keeps `crosslink workflow diff --check` happy: any re-serialize
+/// would reorder keys (`serde_json`'s default `Map` is a `BTreeMap`)
+/// and drift the file from the embedded template. See GH#586.
+fn populate_tracker_remote(config_path: &Path, project_root: &Path) -> Result<()> {
+    if !config_path.exists() {
+        return Ok(());
+    }
+
+    let raw = fs::read_to_string(config_path)?;
+    let mut config: serde_json::Value = serde_json::from_str(&raw)?;
+
+    let current = config
+        .get("tracker_remote")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    // Anything other than the literal template default is a manual
+    // edit — never touch it.
+    if let Some(v) = &current {
+        if v != "origin" {
+            return Ok(());
+        }
+    }
+
+    let detected = match detect_git_remotes(project_root).as_slice() {
+        [] => None,
+        [only] => Some(only.clone()),
+        many if many.iter().any(|r| r == "origin") => Some("origin".to_string()),
+        many => Some(many[0].clone()),
+    };
+
+    // Decide the new value (or no-op).
+    let new_value = match (current.as_deref(), detected.as_deref()) {
+        // Template-default + (no detected OR detected is also "origin"):
+        // file already matches reality. No-op preserves byte-equality
+        // with the embedded template so `workflow diff --check` passes.
+        (Some("origin"), None | Some("origin")) => return Ok(()),
+        // Template-default + repo has a real non-origin remote: upgrade.
+        (Some("origin"), Some(other)) => other.to_string(),
+        // Key absent (older config or hand-edit removed it): restore
+        // it from detection or fall back to the template default.
+        (None, Some(d)) => d.to_string(),
+        (None, None) => "origin".to_string(),
+        // Manual non-default — short-circuited at the top of the
+        // function. This arm is unreachable but exhausts the match.
+        (Some(_), _) => return Ok(()),
+    };
+
+    if let serde_json::Value::Object(map) = &mut config {
+        map.insert(
+            "tracker_remote".to_string(),
+            serde_json::Value::String(new_value),
+        );
+    }
+
+    let output = serde_json::to_string_pretty(&config)?;
+    fs::write(config_path, format!("{output}\n"))?;
+    Ok(())
+}
+
+/// List git remote names in `project_root` via `git remote`. Returns
+/// an empty vector when git fails, when the directory isn't a repo, or
+/// when no remotes are configured. Result is sorted to make the
+/// "alphabetically first" tiebreaker in [`populate_tracker_remote`]
+/// deterministic across hosts.
+fn detect_git_remotes(project_root: &Path) -> Vec<String> {
+    let output = std::process::Command::new("git")
+        .current_dir(project_root)
+        .args(["remote"])
+        .output();
+    let Ok(output) = output else {
+        return Vec::new();
+    };
+    if !output.status.success() {
+        return Vec::new();
+    }
+    let mut remotes: Vec<String> = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+        .collect();
+    remotes.sort();
+    remotes
+}
+
 /// Detect project lint/test commands and populate `agent_overrides` in
 /// hook-config.json so kickoff agents can self-validate their work (#495).
 ///
@@ -882,6 +990,12 @@ pub fn run(path: &Path, opts: &InitOpts<'_>) -> Result<()> {
 
     // Auto-detect lint/test commands for agent overrides (#495)
     populate_agent_tool_commands(&config_path, path)?;
+
+    // Detect the git remote and write `tracker_remote` so the value is
+    // visible on disk rather than relying on the runtime fallback
+    // in `sync::read_tracker_remote`. Idempotent — preserves manual
+    // values across `init --force`. See GH#586.
+    populate_tracker_remote(&config_path, path)?;
 
     // Write .crosslink/.gitignore for multi-agent files
     let crosslink_gitignore = crosslink_dir.join(".gitignore");
@@ -2536,5 +2650,216 @@ mod tests {
             manifest.files[".claude/hooks/prompt-guard.py"].sha256, expected_hash,
             "Manifest hash should match on-disk file for non-merged files"
         );
+    }
+
+    // =========================================================================
+    // GH#586: populate_tracker_remote + detect_git_remotes
+    // =========================================================================
+
+    /// Helper: write a minimal `hook-config.json` to a tempdir. Mirrors the
+    /// embedded template's shape but only includes the keys our tests care
+    /// about so we can assert before/after on the `tracker_remote` field.
+    fn write_minimal_hook_config(dir: &Path, body: &str) -> std::path::PathBuf {
+        let crosslink_dir = dir.join(".crosslink");
+        fs::create_dir_all(&crosslink_dir).unwrap();
+        let path = crosslink_dir.join("hook-config.json");
+        fs::write(&path, body).unwrap();
+        path
+    }
+
+    /// Helper: add a git remote. Tests construct several different remote
+    /// configurations via this helper to exercise the selection rules.
+    fn add_remote(repo: &Path, name: &str, url: &str) {
+        let out = std::process::Command::new("git")
+            .current_dir(repo)
+            .args(["remote", "add", name, url])
+            .output()
+            .expect("git remote add failed");
+        assert!(
+            out.status.success(),
+            "git remote add {name}: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    #[test]
+    fn test_detect_git_remotes_empty_when_no_remotes() {
+        let dir = test_dir();
+        let remotes = detect_git_remotes(dir.path());
+        assert!(
+            remotes.is_empty(),
+            "fresh repo with no remotes should yield empty list; got {remotes:?}"
+        );
+    }
+
+    #[test]
+    fn test_detect_git_remotes_single() {
+        let dir = test_dir();
+        add_remote(dir.path(), "origin", "https://github.com/me/repo.git");
+        assert_eq!(detect_git_remotes(dir.path()), vec!["origin".to_string()]);
+    }
+
+    #[test]
+    fn test_detect_git_remotes_sorted() {
+        let dir = test_dir();
+        add_remote(dir.path(), "upstream", "https://github.com/up/r.git");
+        add_remote(dir.path(), "fork", "https://github.com/me/r.git");
+        add_remote(dir.path(), "origin", "https://github.com/me/r.git");
+        // Sorted output makes the alphabetically-first tiebreaker in
+        // populate_tracker_remote deterministic.
+        assert_eq!(
+            detect_git_remotes(dir.path()),
+            vec![
+                "fork".to_string(),
+                "origin".to_string(),
+                "upstream".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_populate_tracker_remote_writes_single_remote() {
+        let dir = test_dir();
+        add_remote(dir.path(), "upstream", "https://example.com/r.git");
+        let cfg = write_minimal_hook_config(dir.path(), "{}");
+
+        populate_tracker_remote(&cfg, dir.path()).unwrap();
+
+        let after: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&cfg).unwrap()).unwrap();
+        assert_eq!(
+            after.get("tracker_remote").and_then(|v| v.as_str()),
+            Some("upstream"),
+            "single remote should be selected unconditionally"
+        );
+    }
+
+    #[test]
+    fn test_populate_tracker_remote_prefers_origin_when_multiple() {
+        let dir = test_dir();
+        add_remote(dir.path(), "fork", "https://github.com/me/r.git");
+        add_remote(dir.path(), "origin", "https://github.com/me/r.git");
+        add_remote(dir.path(), "upstream", "https://github.com/up/r.git");
+        let cfg = write_minimal_hook_config(dir.path(), "{}");
+
+        populate_tracker_remote(&cfg, dir.path()).unwrap();
+
+        let after: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&cfg).unwrap()).unwrap();
+        assert_eq!(
+            after.get("tracker_remote").and_then(|v| v.as_str()),
+            Some("origin")
+        );
+    }
+
+    #[test]
+    fn test_populate_tracker_remote_falls_back_alphabetically_without_origin() {
+        let dir = test_dir();
+        add_remote(dir.path(), "upstream", "https://github.com/up/r.git");
+        add_remote(dir.path(), "fork", "https://github.com/me/r.git");
+        let cfg = write_minimal_hook_config(dir.path(), "{}");
+
+        populate_tracker_remote(&cfg, dir.path()).unwrap();
+
+        let after: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&cfg).unwrap()).unwrap();
+        assert_eq!(
+            after.get("tracker_remote").and_then(|v| v.as_str()),
+            Some("fork"),
+            "without origin, the alphabetically-first remote wins"
+        );
+    }
+
+    #[test]
+    fn test_populate_tracker_remote_writes_origin_when_no_remotes() {
+        // User's pick: zero remotes still writes `origin` so the value is
+        // visible in the config and the user can change it without
+        // re-running init.
+        let dir = test_dir();
+        let cfg = write_minimal_hook_config(dir.path(), "{}");
+
+        populate_tracker_remote(&cfg, dir.path()).unwrap();
+
+        let after: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&cfg).unwrap()).unwrap();
+        assert_eq!(
+            after.get("tracker_remote").and_then(|v| v.as_str()),
+            Some("origin")
+        );
+    }
+
+    #[test]
+    fn test_populate_tracker_remote_upgrades_default_when_repo_has_non_origin_only() {
+        // Embedded template default + single non-origin remote → upgrade.
+        let dir = test_dir();
+        add_remote(dir.path(), "upstream", "https://example.com/r.git");
+        let cfg = write_minimal_hook_config(dir.path(), r#"{"tracker_remote": "origin"}"#);
+
+        populate_tracker_remote(&cfg, dir.path()).unwrap();
+
+        let after: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&cfg).unwrap()).unwrap();
+        assert_eq!(
+            after.get("tracker_remote").and_then(|v| v.as_str()),
+            Some("upstream"),
+            "default 'origin' should be upgraded when the repo has a different real remote"
+        );
+    }
+
+    #[test]
+    fn test_populate_tracker_remote_byte_equal_noop_when_default_matches_reality() {
+        // The critical case for `workflow diff --check`: when the on-disk
+        // value already matches what populate would have chosen (or
+        // when no remote is configured and "origin" is the placeholder),
+        // the function must leave the file byte-for-byte unchanged so
+        // serde's BTreeMap re-serialization doesn't reorder keys.
+        let dir = test_dir();
+        // Case A: zero remotes — "origin" is the conventional placeholder.
+        let cfg = write_minimal_hook_config(
+            dir.path(),
+            "{\n  \"a_key\": 1,\n  \"tracker_remote\": \"origin\",\n  \"z_key\": 2\n}",
+        );
+        let before = fs::read_to_string(&cfg).unwrap();
+        populate_tracker_remote(&cfg, dir.path()).unwrap();
+        let after = fs::read_to_string(&cfg).unwrap();
+        assert_eq!(
+            before, after,
+            "file must be byte-identical when value matches detection"
+        );
+
+        // Case B: an `origin` remote actually exists.
+        add_remote(dir.path(), "origin", "https://example.com/r.git");
+        populate_tracker_remote(&cfg, dir.path()).unwrap();
+        let after_b = fs::read_to_string(&cfg).unwrap();
+        assert_eq!(
+            before, after_b,
+            "file must stay byte-identical when current 'origin' matches detected 'origin'"
+        );
+    }
+
+    #[test]
+    fn test_populate_tracker_remote_preserves_manual_value() {
+        let dir = test_dir();
+        add_remote(dir.path(), "origin", "https://github.com/me/r.git");
+        let cfg = write_minimal_hook_config(dir.path(), r#"{"tracker_remote": "custom-name"}"#);
+
+        populate_tracker_remote(&cfg, dir.path()).unwrap();
+
+        let after: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&cfg).unwrap()).unwrap();
+        assert_eq!(
+            after.get("tracker_remote").and_then(|v| v.as_str()),
+            Some("custom-name"),
+            "manually-set tracker_remote must survive populate (idempotency)"
+        );
+    }
+
+    #[test]
+    fn test_populate_tracker_remote_noop_when_config_missing() {
+        let dir = test_dir();
+        let cfg = dir.path().join(".crosslink/hook-config.json");
+        // No fs::write — file doesn't exist.
+        populate_tracker_remote(&cfg, dir.path()).unwrap();
+        assert!(!cfg.exists(), "should not create config when missing");
     }
 }

--- a/crosslink/src/shared_writer/core.rs
+++ b/crosslink/src/shared_writer/core.rs
@@ -328,28 +328,34 @@ impl SharedWriter {
                 Ok(_) => return Ok(PushOutcome::Pushed),
                 Err(e) => {
                     let err_str = e.to_string();
-                    if err_str.contains("Could not resolve host")
-                        || err_str.contains("Could not read from remote")
-                    {
-                        tracing::warn!(
-                            "Warning: push failed (offline), changes saved locally only: {}",
-                            message
-                        );
-                        return Ok(PushOutcome::LocalOnly);
-                    }
-                    if err_str.contains("rejected") || err_str.contains("non-fast-forward") {
-                        if attempt < MAX_RETRIES - 1 {
-                            self.check_divergence()?;
-                            self.recover_from_push_conflict(remote)?;
-                            continue;
+                    match crate::sync::classify_push_failure(&err_str, remote) {
+                        crate::sync::PushFailure::Offline => {
+                            tracing::warn!("push failed (offline), {message} saved locally only");
+                            return Ok(PushOutcome::LocalOnly);
                         }
-                        tracing::warn!(
-                            "Warning: push failed after {} retries (conflict), changes saved locally only: {}",
-                            MAX_RETRIES, message
-                        );
-                        return Ok(PushOutcome::LocalOnly);
+                        // Misconfigured / auth / unknown: surface loudly so
+                        // the user sees a real config bug rather than a
+                        // generic (offline) warning. Local cache state is
+                        // consistent so we still return LocalOnly. GH#586.
+                        f @ (crate::sync::PushFailure::RemoteMisconfigured { .. }
+                        | crate::sync::PushFailure::AuthFailed
+                        | crate::sync::PushFailure::Other(_)) => {
+                            tracing::error!("{}", f.user_message(message));
+                            return Ok(PushOutcome::LocalOnly);
+                        }
+                        crate::sync::PushFailure::NonFastForward => {
+                            if attempt < MAX_RETRIES - 1 {
+                                self.check_divergence()?;
+                                self.recover_from_push_conflict(remote)?;
+                                continue;
+                            }
+                            tracing::warn!(
+                                "push failed after {} retries (conflict), {message} saved locally only",
+                                MAX_RETRIES
+                            );
+                            return Ok(PushOutcome::LocalOnly);
+                        }
                     }
-                    return Err(e);
                 }
             }
         }

--- a/crosslink/src/sync/cache.rs
+++ b/crosslink/src/sync/cache.rs
@@ -721,28 +721,43 @@ impl SyncManager {
                 Ok(_) => return Ok(()),
                 Err(e) => {
                     let err_str = e.to_string();
-                    if err_str.contains("Could not resolve host")
-                        || err_str.contains("Could not read from remote")
-                    {
-                        return Ok(()); // Offline — commit is local
-                    }
-                    if err_str.contains("rejected") || err_str.contains("non-fast-forward") {
-                        if attempt < 2 {
-                            self.check_divergence()?;
-                            // Pull to sync with remote before retry (#473).
-                            // If pull fails, run health check and try once more.
-                            if self
-                                .git_in_cache(&["pull", "--rebase", &self.remote, HUB_BRANCH])
-                                .is_err()
-                            {
-                                self.hub_health_check();
-                                self.git_in_cache(&["pull", "--rebase", &self.remote, HUB_BRANCH])?;
-                            }
-                            continue;
+                    match super::classify_push_failure(&err_str, &self.remote) {
+                        // True offline — local commit is intact, push retries
+                        // on next call. Stays silent here (this path runs on
+                        // every lock claim/release; warn would spam). GH#586.
+                        super::PushFailure::Offline => return Ok(()),
+                        // Misconfigured / auth / unknown: surface loudly so
+                        // the user knows to act. State stays consistent
+                        // locally so we don't fail the lock operation.
+                        f @ (super::PushFailure::RemoteMisconfigured { .. }
+                        | super::PushFailure::AuthFailed
+                        | super::PushFailure::Other(_)) => {
+                            tracing::error!("{}", f.user_message("lock"));
+                            return Ok(());
                         }
-                        bail!("Push failed after 3 retries for locks.json");
+                        // Local is behind — pull-and-retry the existing way.
+                        super::PushFailure::NonFastForward => {
+                            if attempt < 2 {
+                                self.check_divergence()?;
+                                // Pull to sync with remote before retry (#473).
+                                // If pull fails, run health check and try once more.
+                                if self
+                                    .git_in_cache(&["pull", "--rebase", &self.remote, HUB_BRANCH])
+                                    .is_err()
+                                {
+                                    self.hub_health_check();
+                                    self.git_in_cache(&[
+                                        "pull",
+                                        "--rebase",
+                                        &self.remote,
+                                        HUB_BRANCH,
+                                    ])?;
+                                }
+                                continue;
+                            }
+                            bail!("Push failed after 3 retries for locks.json");
+                        }
                     }
-                    return Err(e);
                 }
             }
         }

--- a/crosslink/src/sync/heartbeats.rs
+++ b/crosslink/src/sync/heartbeats.rs
@@ -57,30 +57,40 @@ impl SyncManager {
         let push_result = self.git_in_cache(&["push", &self.remote, HUB_BRANCH]);
         if let Err(e) = &push_result {
             let err_str = e.to_string();
-            if err_str.contains("Could not resolve host")
-                || err_str.contains("Could not read from remote")
-            {
-                tracing::warn!("heartbeat push failed (offline), changes saved locally only");
-                return Ok(());
-            }
-            // If push is rejected (conflict), clean dirty state and try pull+push once
-            if err_str.contains("rejected") || err_str.contains("non-fast-forward") {
-                // Bail if local has diverged too far — sign of a rebase loop
-                self.check_divergence()?;
-
-                self.clean_dirty_state()?;
-                if self
-                    .git_in_cache(&["pull", "--rebase", &self.remote, HUB_BRANCH])
-                    .is_err()
-                {
-                    self.hub_health_check();
-                    self.git_in_cache(&["pull", "--rebase", &self.remote, HUB_BRANCH])?;
+            match super::classify_push_failure(&err_str, &self.remote) {
+                super::PushFailure::Offline => {
+                    tracing::warn!("heartbeat push failed (offline), changes saved locally only");
+                    return Ok(());
                 }
-                if let Err(retry_err) = self.git_in_cache(&["push", &self.remote, HUB_BRANCH]) {
-                    tracing::warn!(
-                        "heartbeat push failed after retry (conflict), changes saved locally only: {}",
-                        retry_err
-                    );
+                // Repeatable, user-fixable failure modes get tracing::error
+                // with actionable guidance. Local state is consistent so
+                // we don't fail the heartbeat write. GH#586.
+                f @ (super::PushFailure::RemoteMisconfigured { .. }
+                | super::PushFailure::AuthFailed
+                | super::PushFailure::Other(_)) => {
+                    tracing::error!("{}", f.user_message("heartbeat"));
+                    return Ok(());
+                }
+                // If push is rejected (conflict), clean dirty state and
+                // try pull+push once.
+                super::PushFailure::NonFastForward => {
+                    // Bail if local has diverged too far — sign of a rebase loop
+                    self.check_divergence()?;
+
+                    self.clean_dirty_state()?;
+                    if self
+                        .git_in_cache(&["pull", "--rebase", &self.remote, HUB_BRANCH])
+                        .is_err()
+                    {
+                        self.hub_health_check();
+                        self.git_in_cache(&["pull", "--rebase", &self.remote, HUB_BRANCH])?;
+                    }
+                    if let Err(retry_err) = self.git_in_cache(&["push", &self.remote, HUB_BRANCH]) {
+                        tracing::warn!(
+                            "heartbeat push failed after retry (conflict), changes saved locally only: {}",
+                            retry_err
+                        );
+                    }
                 }
             }
         }

--- a/crosslink/src/sync/mod.rs
+++ b/crosslink/src/sync/mod.rs
@@ -35,6 +35,126 @@ pub use crate::signing::SignatureVerification;
 pub use self::core::SyncManager;
 pub use self::locks::LockMode;
 
+/// Categorization of a `git push` failure for actionable diagnostics.
+///
+/// Substring matching on the raw stderr is brittle (the three push sites
+/// each maintained their own list and silently miscategorized misconfigured-
+/// remote failures as `(offline)`); this enum gives callers a single
+/// vocabulary to act on. See GH#586.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PushFailure {
+    /// Network unreachable, DNS failed, connection timed out. Transient —
+    /// the local cache stays consistent and the push will succeed on a
+    /// later attempt once connectivity returns. Worth a `tracing::warn!`
+    /// so the user knows state didn't propagate, but not an error.
+    Offline,
+    /// Remote name doesn't resolve to a usable git endpoint. Repeatable
+    /// and fixable: the user needs to point `tracker_remote` at an
+    /// existing remote or `git remote add` the missing one. `tracing::error!`
+    /// with actionable guidance.
+    RemoteMisconfigured { remote: String, detail: String },
+    /// Push rejected because the local branch is behind. Callers typically
+    /// pull-and-retry; only surface as an error when retries are exhausted.
+    NonFastForward,
+    /// SSH key denied, HTTP 401/403, missing token. Actionable error.
+    AuthFailed,
+    /// Anything not in the above buckets. Carries the raw stderr so
+    /// callers can surface it verbatim.
+    Other(String),
+}
+
+/// Classify a `git push` stderr blob into a `PushFailure` variant.
+///
+/// Patterns are matched in **specificity order** — auth phrases first
+/// (some of them also match the offline patterns), then
+/// remote-misconfigured, then non-fast-forward, then offline, with
+/// everything else falling through to `Other`. The `remote` argument
+/// is the remote name that was being pushed to; it gets carried into
+/// `RemoteMisconfigured` so callers can render a precise hint.
+pub(crate) fn classify_push_failure(err_str: &str, remote: &str) -> PushFailure {
+    // 1. Auth — check first because failed auth often also produces
+    //    "Could not read from remote repository" lower in the stderr,
+    //    which would otherwise match the Offline bucket.
+    let auth_markers = [
+        "Permission denied",
+        "Authentication failed",
+        "publickey",
+        " 403 ",
+        " 401 ",
+        "fatal: Authentication",
+    ];
+    if auth_markers.iter().any(|m| err_str.contains(m)) {
+        return PushFailure::AuthFailed;
+    }
+
+    // 2. Remote misconfigured — explicit diagnostic git emits when the
+    //    remote name doesn't resolve to a real git endpoint (either
+    //    because it isn't a configured remote, or because its URL is
+    //    junk).
+    let misconfigured_markers = [
+        "does not appear to be a git repository",
+        "Repository not found",
+        "is not a valid remote name",
+    ];
+    if misconfigured_markers.iter().any(|m| err_str.contains(m)) {
+        return PushFailure::RemoteMisconfigured {
+            remote: remote.to_string(),
+            detail: err_str.to_string(),
+        };
+    }
+
+    // 3. Non-fast-forward — local is behind remote.
+    if err_str.contains("! [rejected]") || err_str.contains("non-fast-forward") {
+        return PushFailure::NonFastForward;
+    }
+
+    // 4. Offline — network/DNS/route layer.
+    let offline_markers = [
+        "Could not resolve host",
+        "Could not read from remote",
+        "Connection timed out",
+        "Network is unreachable",
+        "Temporary failure in name resolution",
+        "No route to host",
+    ];
+    if offline_markers.iter().any(|m| err_str.contains(m)) {
+        return PushFailure::Offline;
+    }
+
+    PushFailure::Other(err_str.to_string())
+}
+
+impl PushFailure {
+    /// Render an actionable user-facing message for non-offline failure
+    /// modes. The caller decides log level (`warn!` for offline,
+    /// `error!` for everything else); this helper centralizes the text.
+    pub(crate) fn user_message(&self, action: &str) -> String {
+        match self {
+            PushFailure::Offline => {
+                format!("push failed (offline), {action} saved locally only")
+            }
+            PushFailure::RemoteMisconfigured { remote, .. } => format!(
+                "push failed: remote '{remote}' is not a valid git endpoint. \
+                 Configure it with `crosslink config set tracker_remote <existing-remote>`, \
+                 or add a new one with `git remote add {remote} <url>`. \
+                 Local state for {action} is preserved."
+            ),
+            PushFailure::NonFastForward => format!(
+                "push failed: local branch is behind remote (non-fast-forward). \
+                 Run `crosslink sync` to reconcile. {action} saved locally."
+            ),
+            PushFailure::AuthFailed => format!(
+                "push failed: authentication denied by the remote. \
+                 Check your SSH key (`ssh -T git@<host>`) or your auth token. \
+                 {action} saved locally."
+            ),
+            PushFailure::Other(detail) => {
+                format!("push failed with unexpected error: {detail}. {action} saved locally.")
+            }
+        }
+    }
+}
+
 /// Read the configured tracker remote name from `.crosslink/hook-config.json`.
 ///
 /// Returns the value of `tracker_remote` if set, otherwise `"origin"`.

--- a/crosslink/src/sync/tests.rs
+++ b/crosslink/src/sync/tests.rs
@@ -3291,3 +3291,120 @@ fn test_repair_stale_signingkey_cache_missing_is_noop() {
     let repaired = manager.repair_stale_signingkey().unwrap();
     assert!(!repaired);
 }
+
+// ============================================================================
+// GH#586: structured push-failure classifier
+// ============================================================================
+
+#[test]
+fn classify_push_failure_offline_dns() {
+    let stderr = "fatal: unable to access 'https://github.com/foo/bar.git/': \
+                   Could not resolve host: github.com";
+    assert_eq!(
+        classify_push_failure(stderr, "origin"),
+        PushFailure::Offline
+    );
+}
+
+#[test]
+fn classify_push_failure_offline_unreachable() {
+    let stderr = "fatal: unable to access remote: Network is unreachable";
+    assert_eq!(
+        classify_push_failure(stderr, "origin"),
+        PushFailure::Offline
+    );
+}
+
+#[test]
+fn classify_push_failure_offline_timeout() {
+    let stderr = "ssh: connect to host github.com port 22: Connection timed out";
+    assert_eq!(
+        classify_push_failure(stderr, "origin"),
+        PushFailure::Offline
+    );
+}
+
+#[test]
+fn classify_push_failure_remote_misconfigured() {
+    // What git emits when 'origin' isn't a real remote.
+    let stderr = "fatal: 'bogus' does not appear to be a git repository\n\
+                  fatal: Could not read from remote repository.";
+    match classify_push_failure(stderr, "bogus") {
+        PushFailure::RemoteMisconfigured { remote, .. } => assert_eq!(remote, "bogus"),
+        other => panic!("expected RemoteMisconfigured, got {other:?}"),
+    }
+}
+
+#[test]
+fn classify_push_failure_remote_misconfigured_not_found() {
+    // GitHub's 404 response phrasing.
+    let stderr = "remote: Repository not found.\nfatal: repository 'https://...' not found";
+    assert!(matches!(
+        classify_push_failure(stderr, "origin"),
+        PushFailure::RemoteMisconfigured { .. }
+    ));
+}
+
+#[test]
+fn classify_push_failure_non_fast_forward() {
+    let stderr = "To github.com:foo/bar.git\n ! [rejected]        main -> main (non-fast-forward)";
+    assert_eq!(
+        classify_push_failure(stderr, "origin"),
+        PushFailure::NonFastForward
+    );
+}
+
+#[test]
+fn classify_push_failure_auth_publickey() {
+    // Common SSH auth-failure stderr.
+    let stderr = "git@github.com: Permission denied (publickey).\n\
+                  fatal: Could not read from remote repository.";
+    assert_eq!(
+        classify_push_failure(stderr, "origin"),
+        PushFailure::AuthFailed
+    );
+}
+
+#[test]
+fn classify_push_failure_auth_token() {
+    let stderr = "remote: HTTP 403 forbidden\nfatal: Authentication failed";
+    assert_eq!(
+        classify_push_failure(stderr, "origin"),
+        PushFailure::AuthFailed
+    );
+}
+
+#[test]
+fn classify_push_failure_other_falls_through() {
+    let stderr = "fatal: some entirely novel git failure";
+    match classify_push_failure(stderr, "origin") {
+        PushFailure::Other(detail) => assert!(detail.contains("novel git failure")),
+        other => panic!("expected Other, got {other:?}"),
+    }
+}
+
+#[test]
+fn classify_push_failure_auth_beats_offline_when_both_present() {
+    // Failed SSH auth typically produces 'Could not read from remote' too.
+    // The classifier must pick Auth, not Offline.
+    let stderr = "git@github.com: Permission denied (publickey).\n\
+                  fatal: Could not read from remote repository.";
+    assert_eq!(
+        classify_push_failure(stderr, "origin"),
+        PushFailure::AuthFailed
+    );
+}
+
+#[test]
+fn push_failure_user_message_includes_remote_name() {
+    let failure = PushFailure::RemoteMisconfigured {
+        remote: "upstream".to_string(),
+        detail: "detail".to_string(),
+    };
+    let msg = failure.user_message("comment");
+    assert!(
+        msg.contains("'upstream'"),
+        "message should name the remote: {msg}"
+    );
+    assert!(msg.contains("crosslink config set tracker_remote"));
+}


### PR DESCRIPTION
## Summary

Closes GH#586. Two compounding bugs on fresh-repo workflows:

1. **`crosslink init` never wrote `tracker_remote` to `hook-config.json`.** The value depended on a runtime fallback in `sync::read_tracker_remote` (defaults to `"origin"`), so the on-disk config could drift from in-memory state — and a `crosslink config set` of any unrelated key could trigger a team-preset reapply that visibly altered other settings.
2. **Push errors when the remote couldn't be resolved were mis-categorized as `(offline)`.** Three call sites (`sync/cache.rs`, `sync/heartbeats.rs`, `shared_writer/core.rs`) each maintained their own substring check for `"Could not resolve host"` / `"Could not read from remote"`. Any other failure mode (unknown remote, push refused, auth) fell through, producing `(offline)` warnings on every command that masked real config bugs.

## Three fixes (one commit per scope choice)

### Fix 1 — `tracker_remote` visible on disk

- Embedded template `resources/crosslink/hook-config.json` ships with `"tracker_remote": "origin"`.
- New `populate_tracker_remote()` in `commands/init/mod.rs` runs after the template write. It detects git remotes via `git remote` and upgrades the value from the template default `"origin"` to a non-origin remote when the repo has one. Decision matrix preserves byte-equality with the template in the matches-reality case, which keeps `crosslink workflow diff --check` passing (real footgun that broke that test on the first try — caught here, not in CI).
- Manual non-default values are short-circuited at the top of the function so `init --force` never clobbers user customizations.

### Fix 2 — structured `PushFailure` classifier

New `PushFailure` enum (`Offline / RemoteMisconfigured / NonFastForward / AuthFailed / Other`) and `classify_push_failure(stderr, remote)` in `sync/mod.rs`, pattern-matched in **specificity order**: Auth first (failed SSH auth often emits `Could not read from remote` too — would otherwise miscategorize as Offline), then `RemoteMisconfigured` (`does not appear to be a git repository`, `Repository not found`), then `NonFastForward`, then `Offline`, with the catch-all carrying the raw stderr.

All three push call sites refactored to share the classifier.

### Fix 3 — log level reflects actionability

Per scope choice: `tracing::warn!` for true `Offline` (transient, worth knowing about but not a blocker); `tracing::error!` for `RemoteMisconfigured` / `AuthFailed` / `Other` with `PushFailure::user_message()` rendering actionable guidance — misconfigured surfaces `crosslink config set tracker_remote <existing-remote>` or `git remote add`; auth points at SSH key / token; the catch-all surfaces the raw stderr verbatim.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --lib --bin crosslink --tests` clean on touched files
- [x] `cargo test --bin crosslink` — **2842 passed** (2820 baseline + 22 new)
- [x] **22 new unit tests**: 11 classifier (all 5 buckets + auth-beats-offline ordering edge case + `user_message` rendering); 11 init helper (`detect_git_remotes` empty/single/sorted + `populate_tracker_remote` decision matrix including the byte-equality preservation case that gates `workflow diff --check`)
- [x] `test_check_passes_when_defaults_match` still passes — byte-equality preservation in the no-op cases keeps on-disk JSON identical to the embedded template when reality matches the default
- [x] Manual: `crosslink init` in a fresh repo with a non-origin remote (e.g. `upstream` only) and confirm `cat .crosslink/hook-config.json` shows `"tracker_remote": "upstream"` without a separate `crosslink config set`
- [x] Manual: point `tracker_remote` at a bogus name and run `crosslink quick "x"` — confirm the warning is `tracing::error!` with the actionable hint, not `(offline)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)