### PR TITLE
fix(signing): register active signing key in allowed_signers so verify-commit passes

### DIFF
--- a/crosslink/src/signing.rs
+++ b/crosslink/src/signing.rs
@@ -616,6 +616,29 @@ impl AllowedSigners {
     pub fn is_trusted(&self, principal: &str) -> bool {
         self.entries.iter().any(|e| e.principal == principal)
     }
+
+    /// Check if a public key is already trusted under any principal.
+    ///
+    /// Compares by the `<type> <base64>` body, ignoring trailing
+    /// comments. Used by signing self-registration (GH#585) to make
+    /// "ensure my key is trusted" idempotent regardless of what
+    /// principal it was previously registered under.
+    #[must_use]
+    pub fn contains_key(&self, public_key: &str) -> bool {
+        let target = key_body(public_key);
+        self.entries
+            .iter()
+            .any(|e| key_body(&e.public_key) == target)
+    }
+}
+
+/// Extract the `<type> <base64>` portion of an SSH public-key line,
+/// dropping any trailing comment / principal data.
+fn key_body(line: &str) -> String {
+    line.split_whitespace()
+        .take(2)
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 // ── SSH verify-commit output parsing ────────────────────────────────
@@ -2370,5 +2393,76 @@ f@host sk-ecdsa-sha2-nistp256 FFFF\n";
         )
         .unwrap();
         assert!(!invalid, "Tampered content should fail verification");
+    }
+
+    // ========================================================================
+    // GH#585: AllowedSigners::contains_key
+    // ========================================================================
+
+    fn signers_with(entries: &[(&str, &str, Option<&str>)]) -> AllowedSigners {
+        AllowedSigners {
+            entries: entries
+                .iter()
+                .map(|(p, k, m)| AllowedSignerEntry {
+                    principal: (*p).to_string(),
+                    public_key: (*k).to_string(),
+                    metadata_comment: m.map(str::to_string),
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn test_contains_key_exact_match() {
+        let signers = signers_with(&[(
+            "agent@crosslink",
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExample agent@host",
+            None,
+        )]);
+        assert!(signers.contains_key("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExample agent@host"));
+    }
+
+    #[test]
+    fn test_contains_key_matches_ignoring_trailing_comment() {
+        // The same key under different principals / with different trailing
+        // comments should still match — what matters is the cryptographic body.
+        let signers = signers_with(&[(
+            "agent@crosslink",
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExample agent@host-A",
+            None,
+        )]);
+        assert!(signers.contains_key(
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExample driver@completely-different-host"
+        ));
+        assert!(signers.contains_key("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExample"));
+    }
+
+    #[test]
+    fn test_contains_key_rejects_different_key() {
+        let signers = signers_with(&[(
+            "agent@crosslink",
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExample agent@host",
+            None,
+        )]);
+        // Same type, different base64 body — must NOT match.
+        assert!(!signers.contains_key("ssh-ed25519 AAAADifferent agent@host"));
+    }
+
+    #[test]
+    fn test_contains_key_rejects_different_key_type() {
+        let signers = signers_with(&[(
+            "agent@crosslink",
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExample",
+            None,
+        )]);
+        // Same base64 body (highly unlikely in real keys, but) different type
+        // — different cryptographic key.
+        assert!(!signers.contains_key("ssh-rsa AAAAC3NzaC1lZDI1NTE5AAAAIExample"));
+    }
+
+    #[test]
+    fn test_contains_key_empty_signers() {
+        let signers = signers_with(&[]);
+        assert!(!signers.contains_key("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExample"));
     }
 }

--- a/crosslink/src/sync/tests.rs
+++ b/crosslink/src/sync/tests.rs
@@ -2637,6 +2637,161 @@ fn test_configure_signing_with_key() {
     );
 }
 
+// ========================================================================
+// GH#585: configure_signing self-registers the active key in
+// allowed_signers so verify-commit can validate hub commits made by it.
+// ========================================================================
+
+/// Override the test repo's `user.signingkey` so `driver_signing_key()`
+/// returns the test's fake key rather than whatever the host machine has
+/// in its global git config (which would otherwise leak into these tests).
+fn set_repo_signing_key(repo_root: &Path, key_path: &Path) {
+    Command::new("git")
+        .current_dir(repo_root)
+        .args([
+            "config",
+            "--local",
+            "user.signingkey",
+            &key_path.to_string_lossy(),
+        ])
+        .status()
+        .expect("git config user.signingkey failed");
+}
+
+#[test]
+fn test_configure_signing_registers_active_key_in_allowed_signers() {
+    let (work_dir, _remote_dir) = setup_sync_env();
+    let crosslink_dir = work_dir.path().join(".crosslink");
+    let manager = SyncManager::new(&crosslink_dir).unwrap();
+    manager.init_cache().unwrap();
+
+    // Write a key pair: <key> + <key>.pub. The body of the pubkey is
+    // distinctive so we can assert it landed in allowed_signers.
+    let keys_dir = crosslink_dir.join("keys");
+    std::fs::create_dir_all(&keys_dir).unwrap();
+    let key_file = keys_dir.join("driver_ed25519");
+    std::fs::write(&key_file, "-----BEGIN OPENSSH PRIVATE KEY-----\nfake\n").unwrap();
+    let pubkey_line = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAGH585-self-register-test driver@host";
+    std::fs::write(format!("{}.pub", key_file.display()), pubkey_line).unwrap();
+
+    // Override the test repo's user.signingkey so driver_signing_key()
+    // returns OUR fake key, not the test host's global signingkey.
+    // This reproduces the GH#585 scenario: a driver workspace using
+    // its own SSH signing key, which configure_signing must register
+    // in allowed_signers.
+    set_repo_signing_key(work_dir.path(), &key_file);
+
+    let agent = AgentConfig {
+        agent_id: "self-register-driver".to_string(),
+        machine_id: "test-host".to_string(),
+        description: None,
+        role: AgentRole::Driver,
+        ssh_key_path: None,
+        ssh_fingerprint: None,
+        ssh_public_key: None,
+    };
+    let agent_json = serde_json::to_string_pretty(&agent).unwrap();
+    std::fs::write(crosslink_dir.join("agent.json"), agent_json).unwrap();
+
+    manager.configure_signing(&crosslink_dir).unwrap();
+
+    let allowed_signers = manager.cache_dir.join("trust").join("allowed_signers");
+    let content = std::fs::read_to_string(&allowed_signers)
+        .expect("allowed_signers should exist after configure_signing");
+    assert!(
+        content.contains("AAAAC3NzaC1lZDI1NTE5AAAAGH585-self-register-test"),
+        "driver signing key body should be registered in allowed_signers; got:\n{content}"
+    );
+    assert!(
+        content.contains("self-register-driver@crosslink"),
+        "entry should use the agent.json identity as principal; got:\n{content}"
+    );
+}
+
+#[test]
+fn test_configure_signing_self_registration_is_idempotent() {
+    // Calling configure_signing twice must not duplicate the entry.
+    // The contains_key check dedupes by key body across all principals,
+    // so the second call observes "already trusted" and no-ops.
+    let (work_dir, _remote_dir) = setup_sync_env();
+    let crosslink_dir = work_dir.path().join(".crosslink");
+    let manager = SyncManager::new(&crosslink_dir).unwrap();
+    manager.init_cache().unwrap();
+
+    let keys_dir = crosslink_dir.join("keys");
+    std::fs::create_dir_all(&keys_dir).unwrap();
+    let key_file = keys_dir.join("driver_ed25519");
+    std::fs::write(&key_file, "-----BEGIN OPENSSH PRIVATE KEY-----\nfake\n").unwrap();
+    let pubkey_line = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAGH585-idempotency-test driver@host";
+    std::fs::write(format!("{}.pub", key_file.display()), pubkey_line).unwrap();
+    set_repo_signing_key(work_dir.path(), &key_file);
+
+    let agent = AgentConfig {
+        agent_id: "idempotency-driver".to_string(),
+        machine_id: "test-host".to_string(),
+        description: None,
+        role: AgentRole::Driver,
+        ssh_key_path: None,
+        ssh_fingerprint: None,
+        ssh_public_key: None,
+    };
+    let agent_json = serde_json::to_string_pretty(&agent).unwrap();
+    std::fs::write(crosslink_dir.join("agent.json"), agent_json).unwrap();
+
+    manager.configure_signing(&crosslink_dir).unwrap();
+    manager.configure_signing(&crosslink_dir).unwrap();
+    manager.configure_signing(&crosslink_dir).unwrap();
+
+    let allowed_signers = manager.cache_dir.join("trust").join("allowed_signers");
+    let content = std::fs::read_to_string(&allowed_signers).unwrap();
+    let occurrences = content.matches("idempotency-driver@crosslink").count();
+    assert_eq!(
+        occurrences, 1,
+        "principal should appear exactly once across 3 configure_signing calls; got {occurrences} in:\n{content}"
+    );
+}
+
+#[test]
+fn test_configure_signing_skips_self_registration_when_pub_missing() {
+    // When the .pub companion isn't on disk, self-registration must
+    // gracefully no-op (log debug, return Ok) rather than failing the
+    // whole configure_signing call.
+    let (work_dir, _remote_dir) = setup_sync_env();
+    let crosslink_dir = work_dir.path().join(".crosslink");
+    let manager = SyncManager::new(&crosslink_dir).unwrap();
+    manager.init_cache().unwrap();
+
+    let keys_dir = crosslink_dir.join("keys");
+    std::fs::create_dir_all(&keys_dir).unwrap();
+    let key_file = keys_dir.join("driver_ed25519");
+    std::fs::write(&key_file, "-----BEGIN OPENSSH PRIVATE KEY-----\nfake\n").unwrap();
+    // No .pub companion written.
+    set_repo_signing_key(work_dir.path(), &key_file);
+
+    let agent = AgentConfig {
+        agent_id: "no-pub-driver".to_string(),
+        machine_id: "test-host".to_string(),
+        description: None,
+        role: AgentRole::Driver,
+        ssh_key_path: None,
+        ssh_fingerprint: None,
+        ssh_public_key: None,
+    };
+    let agent_json = serde_json::to_string_pretty(&agent).unwrap();
+    std::fs::write(crosslink_dir.join("agent.json"), agent_json).unwrap();
+
+    // Must succeed even though the .pub is missing.
+    manager.configure_signing(&crosslink_dir).unwrap();
+
+    let allowed_signers = manager.cache_dir.join("trust").join("allowed_signers");
+    assert!(allowed_signers.exists());
+    let content = std::fs::read_to_string(&allowed_signers).unwrap();
+    assert!(
+        !content.contains("no-pub-driver@crosslink"),
+        "should not register when .pub is missing; got:\n{content}"
+    );
+}
+
 #[test]
 fn test_configure_signing_key_file_missing() {
     let (work_dir, _remote_dir) = setup_sync_env();

--- a/crosslink/src/sync/trust.rs
+++ b/crosslink/src/sync/trust.rs
@@ -1,4 +1,5 @@
 use anyhow::{bail, Context, Result};
+use chrono::Utc;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -121,6 +122,12 @@ impl SyncManager {
                             &private_key,
                             Some(&allowed_signers),
                         )?;
+                        register_active_key_as_trusted(
+                            &self.cache_dir,
+                            crosslink_dir,
+                            &private_key,
+                            &allowed_signers,
+                        )?;
                         return Ok(());
                     }
                 }
@@ -138,6 +145,12 @@ impl SyncManager {
                     &self.cache_dir,
                     &driver_key,
                     Some(&allowed_signers),
+                )?;
+                register_active_key_as_trusted(
+                    &self.cache_dir,
+                    crosslink_dir,
+                    &driver_key,
+                    &allowed_signers,
                 )?;
                 return Ok(());
             }
@@ -158,6 +171,12 @@ impl SyncManager {
                         &self.cache_dir,
                         &private_key,
                         Some(&allowed_signers),
+                    )?;
+                    register_active_key_as_trusted(
+                        &self.cache_dir,
+                        crosslink_dir,
+                        &private_key,
+                        &allowed_signers,
                     )?;
                     return Ok(());
                 }
@@ -571,4 +590,118 @@ impl SyncManager {
 
         self.verify_commit_signature(&commit)
     }
+}
+
+/// Ensure the public key paired with `private_key_path` is registered in
+/// `allowed_signers`. Idempotent: a no-op when the key is already trusted.
+///
+/// When a new entry is appended, the file is saved and an **unsigned**
+/// commit is made in the cache worktree. The commit must be unsigned
+/// because the freshly-registered key may not yet be present in any
+/// pre-existing commit's view of `allowed_signers`, so signing this
+/// commit with it would fail `git verify-commit` (the chicken-and-egg
+/// `publish_agent_key` also navigates). Once this commit lands,
+/// subsequent commits signed with the same key verify cleanly.
+///
+/// GH#585: before this call existed, only `crosslink trust approve
+/// <agent>` ever wrote to `allowed_signers`. The driver's own signing
+/// key (selected by `configure_signing`) was never registered, so every
+/// signed hub commit out of a driver workspace failed verification.
+fn register_active_key_as_trusted(
+    cache_dir: &Path,
+    crosslink_dir: &Path,
+    private_key_path: &Path,
+    allowed_signers_path: &Path,
+) -> Result<()> {
+    use crate::signing::{AllowedSignerEntry, AllowedSigners};
+
+    // Resolve the public-key companion file (SSH convention: <key>.pub).
+    let public_key_path = with_pub_extension(private_key_path);
+    let public_key = match crate::signing::read_public_key(&public_key_path) {
+        Ok(k) => k,
+        Err(e) => {
+            tracing::debug!(
+                "skipping allowed_signers self-registration: cannot read pubkey at {}: {e}",
+                public_key_path.display()
+            );
+            return Ok(());
+        }
+    };
+
+    let mut signers = AllowedSigners::load(allowed_signers_path)?;
+    if signers.contains_key(&public_key) {
+        return Ok(()); // Already trusted under some principal — no-op.
+    }
+
+    // Pick a principal: prefer the agent.json identity for visibility,
+    // fall back to a generic role+host label when none is configured.
+    let principal = AgentConfig::load(crosslink_dir)?.map_or_else(
+        || "driver@crosslink".to_string(),
+        |c| format!("{}@crosslink", c.agent_id),
+    );
+
+    signers.add_entry(AllowedSignerEntry {
+        principal: principal.clone(),
+        public_key,
+        metadata_comment: Some(format!(
+            "self-registered as workspace signing key at {}",
+            Utc::now().format("%Y-%m-%d %H:%M:%S UTC")
+        )),
+    });
+    signers.save(allowed_signers_path)?;
+
+    // Commit unsigned; best-effort. If the commit fails (e.g. nothing
+    // staged because of a race), the on-disk file is still correct for
+    // local verification, and the next push will pick up any residue.
+    if let Err(e) = commit_allowed_signers_unsigned(cache_dir, &principal) {
+        tracing::warn!(
+            "registered '{principal}' in allowed_signers on disk but commit failed: {e} \
+             (run `crosslink sync` to recover)"
+        );
+    }
+
+    Ok(())
+}
+
+/// Compute the conventional public-key path for an SSH private key
+/// (`<path>` → `<path>.pub`), preserving any unusual filename shape.
+fn with_pub_extension(private_key_path: &Path) -> PathBuf {
+    let mut s = private_key_path.as_os_str().to_owned();
+    s.push(".pub");
+    PathBuf::from(s)
+}
+
+/// Stage `trust/allowed_signers` and commit it without signing.
+///
+/// Used only by [`register_active_key_as_trusted`]. Unsigned commit is
+/// required because the just-added key isn't yet visible in any earlier
+/// commit's `allowed_signers` view — signing this commit would create
+/// the very verify-commit failure the parent function is meant to fix.
+fn commit_allowed_signers_unsigned(cache_dir: &Path, principal: &str) -> Result<()> {
+    let run = |args: &[&str]| -> Result<()> {
+        let output = Command::new("git")
+            .current_dir(cache_dir)
+            .args(args)
+            .output()
+            .with_context(|| format!("failed to spawn git {args:?}"))?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            // `nothing to commit` is benign: the file content matched a
+            // previous staged state. Treat it as success.
+            if !stderr.contains("nothing to commit") {
+                bail!("git {args:?} failed: {}", stderr.trim());
+            }
+        }
+        Ok(())
+    };
+
+    run(&["add", "trust/allowed_signers"])?;
+    run(&[
+        "-c",
+        "commit.gpgsign=false",
+        "commit",
+        "-m",
+        &format!("trust: register signing key for '{principal}'"),
+    ])?;
+    Ok(())
 }


### PR DESCRIPTION
## Summary

Closes GH#585. In a driver workspace, `crosslink trust approve <agent-id>` registered only the **agent's** key in `allowed_signers`. The driver's own SSH signing key — which `configure_signing` correctly set as the cache worktree's `user.signingkey` — was never added. Every signed hub commit from that workspace was therefore correctly signed by the driver's key but failed `git verify-commit` because the verifier didn't trust that key. `crosslink sync` immediately reported "N invalid signature(s) in last N commit(s)" after the very first `trust approve`. The natural diagnostic (`crosslink integrity sign-backfill`) reported "no unsigned entries — nothing to do" because the commits ARE signed, just not trusted.

## Fix (Option B from the issue — the author's recommendation)

Self-healing invariant in `configure_signing`. After any of its three branches (agent worktree, driver workspace, driver-fallback-to-agent) selects a key and calls `signing::configure_git_ssh_signing`, it now also calls `register_active_key_as_trusted` which:

1. Reads the `<key>.pub` companion of the just-selected private key.
2. Loads `allowed_signers` and dedupes via the new `AllowedSigners::contains_key` (compares by `<type> <base64>` body — matches across different principals and trailing comments).
3. Idempotent: returns early when the key is already trusted under any principal.
4. Appends a new entry using the `agent.json` identity as the principal (`<agent_id>@crosslink`, mirroring `trust approve`'s format), falling back to `driver@crosslink` when no `agent.json` exists.
5. Commits **unsigned** — chicken-and-egg: the new key may not yet be in any earlier commit's `allowed_signers` view, so signing this commit would re-trigger the very verify-commit failure we're fixing. Same navigation as `publish_agent_key`.

**Why Option B over A** (which was the smaller-diff alternative — just patch `trust approve`): Option B covers both the fresh-bootstrap case AND the driver-key-rotation / re-init case the author flagged as B's structural advantage. Every signing-key selection self-heals.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --lib --bin crosslink --tests` — clean on touched files (pre-existing tests.rs warnings at lines 1086/1087/2538/2548 are unrelated)
- [x] `cargo test --bin crosslink` — **2850 passed** (2842 baseline + 8 new)
- [x] **8 new tests**: 5 for `AllowedSigners::contains_key` (exact, trailing-comment-ignored, rejects different body/type, empty signers); 3 for `configure_signing` (registers driver key with explicit `user.signingkey` override in the test repo so the test doesn't leak the host's real signingkey; idempotency across 3 successive calls; graceful no-op when `.pub` is missing)
- [x] Manual: reproduce the GH#585 sequence (`init` → `agent init` → `trust approve <agent>` → `quick "test"` → `sync`) on a fresh repo, confirm `sync` now reports "all N recent commit(s) are signed" instead of "1 invalid signature(s)"
- [x] Manual: simulate key rotation — change `user.signingkey` in the main repo, re-run any command that triggers `configure_signing`, confirm the new key gets added to `allowed_signers` without needing a manual edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)