### PR TITLE
fix(shared-writer,sync): include stdout in git cache-failure errors (#601)

### DIFF
--- a/crosslink/src/shared_writer/core.rs
+++ b/crosslink/src/shared_writer/core.rs
@@ -1054,8 +1054,19 @@ impl SharedWriter {
             .output()
             .with_context(|| format!("Failed to run git {args:?} in cache"))?;
         if !output.status.success() {
+            // Capture BOTH streams (#601). Some git status messages — most
+            // notably "nothing to commit, working tree clean" — go to
+            // stdout, not stderr. Capturing only stderr produced empty
+            // failure messages and silently disabled the substring-based
+            // no-op guards in the push paths below.
+            let stdout = String::from_utf8_lossy(&output.stdout);
             let stderr = String::from_utf8_lossy(&output.stderr);
-            bail!("git {args:?} in cache failed: {stderr}");
+            bail!(
+                "git {args:?} in cache failed ({}):\nstdout: {}\nstderr: {}",
+                output.status,
+                stdout.trim(),
+                stderr.trim(),
+            );
         }
         Ok(output)
     }
@@ -1157,8 +1168,20 @@ impl SharedWriter {
             .output()
             .with_context(|| format!("Failed to run git commit {args:?} in cache"))?;
         if !output.status.success() {
+            // Capture BOTH streams (#601). `git commit`'s "nothing to
+            // commit, working tree clean" status message goes to stdout,
+            // so capturing only stderr produced empty failure messages.
+            // The substring-based no-op guards in `write_commit_push` and
+            // `emit_compact_push` rely on this message being visible in
+            // the error string they inspect.
+            let stdout = String::from_utf8_lossy(&output.stdout);
             let stderr = String::from_utf8_lossy(&output.stderr);
-            bail!("git commit {args:?} in cache failed: {stderr}");
+            bail!(
+                "git commit {args:?} in cache failed ({}):\nstdout: {}\nstderr: {}",
+                output.status,
+                stdout.trim(),
+                stderr.trim(),
+            );
         }
         Ok(output)
     }

--- a/crosslink/src/shared_writer/tests.rs
+++ b/crosslink/src/shared_writer/tests.rs
@@ -983,6 +983,58 @@ mod integration {
         drop(work_dir);
     }
 
+    // --- git_commit_in_cache_with_args() / git_in_cache() error messages ---
+
+    #[test]
+    fn test_git_commit_in_cache_includes_stdout_on_failure() {
+        // Regression test for #601: when `git commit` exits non-zero because
+        // there is nothing staged, the diagnostic ("nothing to commit,
+        // working tree clean") goes to stdout, NOT stderr. Capturing only
+        // stderr produced empty failure messages and made the substring
+        // "nothing to commit" guards in write_commit_push dead code.
+        let (work_dir, _remote, crosslink_dir) = setup_shared_writer_env();
+        let writer = SharedWriter::new(&crosslink_dir).unwrap().unwrap();
+
+        // The hub cache is already at a clean commit from init_cache(); a
+        // commit with nothing staged must fail with "nothing to commit".
+        let err = writer
+            .git_commit_in_cache_with_args(&["-m", "no-op"])
+            .expect_err("commit must fail when nothing is staged");
+        let msg = err.to_string();
+
+        assert!(
+            msg.contains("nothing to commit"),
+            "error must surface git's 'nothing to commit' status (which it \
+             writes to stdout) to the caller; got: {msg}"
+        );
+        drop(work_dir);
+    }
+
+    #[test]
+    fn test_git_in_cache_includes_stdout_on_failure() {
+        // Companion to the test above: `git_in_cache` shares the same
+        // stderr-only capture bug (#601). Verify it surfaces stdout content
+        // too. `git rev-parse --verify <nonexistent>` is a clean reproducer
+        // where the actual error message goes to stderr, but we still want
+        // both streams in the bail so callers see the full picture.
+        let (work_dir, _remote, crosslink_dir) = setup_shared_writer_env();
+        let writer = SharedWriter::new(&crosslink_dir).unwrap().unwrap();
+
+        let err = writer
+            .git_in_cache(&["rev-parse", "--verify", "refs/heads/nonexistent-branch"])
+            .expect_err("rev-parse must fail on a missing ref");
+        let msg = err.to_string();
+
+        // The error message should include both stream labels so we know
+        // the new capture path is wired in (rather than the old
+        // stderr-only format).
+        assert!(
+            msg.contains("stdout:") && msg.contains("stderr:"),
+            "error must label both captured streams; got: {msg}"
+        );
+        drop(work_dir);
+    }
+
     // --- create_issue() ---
 
     #[test]

--- a/crosslink/src/sync/core.rs
+++ b/crosslink/src/sync/core.rs
@@ -179,8 +179,17 @@ impl SyncManager {
             .output()
             .with_context(|| format!("Failed to run git commit {args:?} in cache"))?;
         if !output.status.success() {
+            // Capture BOTH streams (#601). `git commit`'s "nothing to
+            // commit" status message goes to stdout, not stderr — without
+            // this, "nothing to commit" failures surfaced as empty errors.
+            let stdout = String::from_utf8_lossy(&output.stdout);
             let stderr = String::from_utf8_lossy(&output.stderr);
-            bail!("git commit {args:?} in cache failed: {stderr}");
+            bail!(
+                "git commit {args:?} in cache failed ({}):\nstdout: {}\nstderr: {}",
+                output.status,
+                stdout.trim(),
+                stderr.trim(),
+            );
         }
         Ok(output)
     }
@@ -198,8 +207,17 @@ impl SyncManager {
             .output()
             .with_context(|| format!("Failed to run git {args:?} in cache"))?;
         if !output.status.success() {
+            // Capture BOTH streams (#601). Some git diagnostics — including
+            // hook output and certain push rejections — go to stdout, not
+            // stderr; capturing only stderr drops those details.
+            let stdout = String::from_utf8_lossy(&output.stdout);
             let stderr = String::from_utf8_lossy(&output.stderr);
-            bail!("git {args:?} in cache failed: {stderr}");
+            bail!(
+                "git {args:?} in cache failed ({}):\nstdout: {}\nstderr: {}",
+                output.status,
+                stdout.trim(),
+                stderr.trim(),
+            );
         }
         Ok(output)
     }


### PR DESCRIPTION
## Summary

Fixes GH#601. `git_{commit_in_cache_with_args,in_cache}` (both in `shared_writer/core.rs` and `sync/core.rs`) captured only `output.stderr` when bailing on a non-zero exit. But `git commit`'s most common failure status — `"nothing to commit, working tree clean"` — is written to **stdout**, leaving stderr empty. The user saw `Error: git commit […] in cache failed:` with nothing after the colon and no way to diagnose what went wrong.

The fix is a single-shape change applied to all four sites: include `output.stdout`, `output.stderr`, and the exit status in the bail message.

## Side effect: four dead-code guards in the push path revive

The push paths in `core.rs` have four substring-matching guards intended to treat "nothing to commit" as a clean no-op:

```rust
if err_str.contains("nothing to commit") || err_str.contains("no changes added") {
    return Ok(PushOutcome::Pushed);
}
```

…at lines 318, 416, 506, 976. They never fired on `main`, because `err_str` was built from empty stderr. After this fix, the substring lives in `err_str` and the guards do what they were written to do — so future no-op commit paths that don't have a per-callsite short-circuit (like the one added for #600) still degrade cleanly instead of bubbling a noisy empty error.

## New bail format

```
git commit ["-m", "..."] in cache failed (exit status: 1):
stdout: On branch crosslink/hub
nothing to commit, working tree clean
stderr:
```

Same treatment applied to all four sites (`{commit_,}in_cache` × `{shared_writer,sync}`) — the same stdout-vs-stderr trap would mask any future failure whose diagnostic lands on stdout (pre-commit hook output, server-side push rejections that bubble back through stdout, etc.).

## Out of scope

The issue notes an optional defense-in-depth: detect the no-op explicitly via `git diff --cached --quiet` before invoking `git commit`. Skipped here because:

1. The issue explicitly marks it optional.
2. The substring guards now fire correctly (the side effect above), which is the same outcome the defense-in-depth provides.
3. It adds an extra git invocation on every write-path call.

Worth a separate PR if the team wants structural robustness against git's wording changing across versions/locales.

## Test plan

- [x] `cargo test --lib --bin crosslink` — 2866 passed (2 new regression tests)
- [x] `cargo clippy --lib --bin crosslink --tests -- -D warnings` — clean
- [x] New tests:
  - `test_git_commit_in_cache_includes_stdout_on_failure` — asserts the "nothing to commit" string surfaces in the bail message
  - `test_git_in_cache_includes_stdout_on_failure` — asserts both `stdout:` and `stderr:` labels appear in non-commit git errors too
- [x] Manual repro from the issue: `crosslink issue create "a" -q; crosslink issue create "b" -q; crosslink issue block L2 L1` twice. With #605 (the #600 fix) merged this hits the per-callsite short-circuit; without it, the second call now reports a meaningful error including `"nothing to commit, working tree clean"` rather than an empty `failed: `.

## Related

- #600 (PR #605) — user-facing manifestation. Closed by per-callsite idempotency. This PR closes the underlying diagnostic-loss bug, which would have masked any similar future failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)