### PR TITLE
feat(kickoff): add `--permission-mode <mode>` for finer-grained claude control (#603)

### DIFF
--- a/crosslink/src/commands/kickoff/launch.rs
+++ b/crosslink/src/commands/kickoff/launch.rs
@@ -174,14 +174,30 @@ pub(super) fn build_agent_command(
     worktree_dir: &Path,
     skip_permissions: bool,
     claude_config_dir: Option<&str>,
+    permission_mode: Option<&str>,
 ) -> String {
     use crate::utils::shell_escape_arg;
 
-    let skip_flag = if skip_permissions {
-        " --dangerously-skip-permissions"
-    } else {
-        ""
+    // Resolve permission posture for the spawned claude session:
+    //   1. `permission_mode`, if given, emits `--permission-mode <value>`.
+    //      Claude supports `acceptEdits`, `auto`, `bypassPermissions`,
+    //      `default`, `dontAsk`, `plan` (see GH#603).
+    //   2. Otherwise, `skip_permissions = true` emits the legacy
+    //      `--dangerously-skip-permissions` (full bypass).
+    //   3. Otherwise no flag — claude prompts for every tool.
+    // CLI parsing in main.rs marks `--permission-mode` as
+    // `conflicts_with("skip_permissions")` so reaching case 1 with
+    // `skip_permissions = true` is impossible from the public surface;
+    // internal callers (the wizard's WizardStage::Run path) pass both
+    // as defaults (None / false) and let this resolution stand.
+    let permission_flag_owned: String = match (permission_mode, skip_permissions) {
+        (Some(mode), _) if !mode.is_empty() => {
+            format!(" --permission-mode {}", shell_escape_arg(mode))
+        }
+        (_, true) => " --dangerously-skip-permissions".to_string(),
+        _ => String::new(),
     };
+    let skip_flag = permission_flag_owned.as_str();
     // Fold `CLAUDE_CONFIG_DIR=val` into env(1)'s argv so the assignment takes
     // effect regardless of what wraps the resulting command (timeout, sandbox
     // wrappers, etc.). `env` accepts `KEY=val` between options and the
@@ -552,6 +568,7 @@ pub(super) fn exclude_kickoff_files(worktree_dir: &Path) -> Result<()> {
 
 /// Launch the agent as a local tmux process.
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 pub(super) fn launch_local(
     worktree_dir: &Path,
     session_name: &str,
@@ -562,6 +579,7 @@ pub(super) fn launch_local(
     sandbox_command: Option<&str>,
     crosslink_dir: &Path,
     skip_permissions: bool,
+    permission_mode: Option<&str>,
 ) -> Result<()> {
     // Create the tmux session
     let output = Command::new("tmux")
@@ -598,6 +616,7 @@ pub(super) fn launch_local(
         worktree_dir,
         skip_permissions,
         claude_config_dir.as_deref(),
+        permission_mode,
     );
 
     // Write initial status sentinel BEFORE sending the command.

--- a/crosslink/src/commands/kickoff/launch.rs
+++ b/crosslink/src/commands/kickoff/launch.rs
@@ -568,7 +568,6 @@ pub(super) fn exclude_kickoff_files(worktree_dir: &Path) -> Result<()> {
 
 /// Launch the agent as a local tmux process.
 #[allow(clippy::too_many_arguments)]
-#[allow(clippy::too_many_arguments)]
 pub(super) fn launch_local(
     worktree_dir: &Path,
     session_name: &str,

--- a/crosslink/src/commands/kickoff/mod.rs
+++ b/crosslink/src/commands/kickoff/mod.rs
@@ -63,6 +63,7 @@ pub fn dispatch(
             branch,
             doc,
             skip_permissions,
+            permission_mode,
         } => {
             let parsed_doc = if let Some(ref path) = doc {
                 let content = std::fs::read_to_string(path)
@@ -89,6 +90,7 @@ pub fn dispatch(
                 design_doc: parsed_doc.as_ref(),
                 doc_path: doc.as_ref().map(|p| p.to_str().unwrap_or("unknown")),
                 skip_permissions,
+                permission_mode: permission_mode.as_deref(),
             };
             // Update pipeline state if launching from a design doc
             if let Some(ref doc_path) = doc {
@@ -169,6 +171,7 @@ pub fn dispatch(
             issue,
             dry_run,
             skip_permissions,
+            permission_mode,
         } => dispatch_launch(
             crosslink_dir,
             db,
@@ -185,6 +188,7 @@ pub fn dispatch(
             issue,
             dry_run,
             skip_permissions,
+            permission_mode.as_deref(),
         ),
     }
 }
@@ -210,6 +214,7 @@ fn dispatch_launch(
     issue: Option<i64>,
     dry_run: bool,
     skip_permissions: bool,
+    permission_mode: Option<&str>,
 ) -> Result<()> {
     // Non-interactive: --plan or --run flag provided
     if do_plan {
@@ -273,6 +278,7 @@ fn dispatch_launch(
             design_doc: parsed_doc.as_ref(),
             doc_path: doc.as_ref().map(|p| p.to_str().unwrap_or("unknown")),
             skip_permissions,
+            permission_mode,
         };
         if let Some(ref doc_path) = doc {
             let _ = pipeline::mark_running(doc_path, "pending", "pending", issue);
@@ -356,6 +362,7 @@ fn dispatch_launch(
                 design_doc: parsed_doc.as_ref(),
                 doc_path: doc_path_str.as_deref(),
                 skip_permissions: false,
+                permission_mode: None,
             };
             run(crosslink_dir, db, writer, &opts)?;
             Ok(())

--- a/crosslink/src/commands/kickoff/plan.rs
+++ b/crosslink/src/commands/kickoff/plan.rs
@@ -241,6 +241,7 @@ pub fn plan(crosslink_dir: &Path, db: &Database, opts: &PlanOpts) -> Result<()> 
         &worktree_dir,
         false, // plan mode never skips permissions
         claude_config_dir.as_deref(),
+        None, // plan mode never overrides permission_mode (#603)
     );
 
     let output = Command::new("tmux")

--- a/crosslink/src/commands/kickoff/run.rs
+++ b/crosslink/src/commands/kickoff/run.rs
@@ -193,6 +193,7 @@ pub fn run(
                 preflight.sandbox_command.as_deref(),
                 crosslink_dir,
                 opts.skip_permissions,
+                opts.permission_mode,
             )?;
 
             // Persist the actual session name so kickoff list can find it

--- a/crosslink/src/commands/kickoff/tests.rs
+++ b/crosslink/src/commands/kickoff/tests.rs
@@ -145,6 +145,7 @@ fn test_build_prompt_contains_essentials() {
         design_doc: None,
         doc_path: None,
         skip_permissions: false,
+        permission_mode: None,
     };
     let prompt = build_prompt(&opts, 42, "feature/add-retry-logic", &conventions);
 
@@ -177,6 +178,7 @@ fn test_build_prompt_ci_verification() {
         design_doc: None,
         doc_path: None,
         skip_permissions: false,
+        permission_mode: None,
     };
     let prompt = build_prompt(&opts, 1, "feature/test-ci", &conventions);
 
@@ -206,6 +208,7 @@ fn test_build_prompt_thorough_verification() {
         design_doc: None,
         doc_path: None,
         skip_permissions: false,
+        permission_mode: None,
     };
     let prompt = build_prompt(&opts, 1, "feature/test-thorough", &conventions);
 
@@ -885,6 +888,7 @@ fn test_build_prompt_local_has_no_ci_or_adversarial() {
         design_doc: None,
         doc_path: None,
         skip_permissions: false,
+        permission_mode: None,
     };
     let prompt = build_prompt(&opts, 1, "feature/test-local", &conventions);
 
@@ -914,6 +918,7 @@ fn test_build_prompt_contains_blocked_actions() {
         design_doc: None,
         doc_path: None,
         skip_permissions: false,
+        permission_mode: None,
     };
     let prompt = build_prompt(&opts, 1, "feature/test", &conventions);
 
@@ -944,6 +949,7 @@ fn test_build_prompt_embeds_issue_id_in_instructions() {
         design_doc: None,
         doc_path: None,
         skip_permissions: false,
+        permission_mode: None,
     };
     let prompt = build_prompt(&opts, 999, "feature/test-refs", &conventions);
 
@@ -974,6 +980,7 @@ fn test_build_prompt_empty_conventions_uses_generic_instructions() {
         design_doc: None,
         doc_path: None,
         skip_permissions: false,
+        permission_mode: None,
     };
     let prompt = build_prompt(&opts, 1, "feature/test-generic", &conventions);
 
@@ -1016,6 +1023,7 @@ fn test_build_prompt_with_design_doc() {
         design_doc: Some(&doc),
         doc_path: None,
         skip_permissions: false,
+        permission_mode: None,
     };
     let prompt = build_prompt(&opts, 1, "feature/batch-retry", &conventions);
 
@@ -1161,6 +1169,7 @@ fn test_build_prompt_with_design_doc_open_questions() {
         design_doc: Some(&doc),
         doc_path: None,
         skip_permissions: false,
+        permission_mode: None,
     };
     let prompt = build_prompt(&opts, 1, "feature/auth", &conventions);
 
@@ -1332,6 +1341,7 @@ fn test_build_prompt_with_criteria_includes_validation() {
         design_doc: Some(&doc),
         doc_path: None,
         skip_permissions: false,
+        permission_mode: None,
     };
     let prompt = build_prompt(&opts, 1, "feature/test", &conventions);
     assert!(prompt.contains("Spec Validation"));
@@ -1372,6 +1382,7 @@ fn test_build_prompt_without_criteria_no_validation() {
         design_doc: Some(&doc),
         doc_path: None,
         skip_permissions: false,
+        permission_mode: None,
     };
     let prompt = build_prompt(&opts, 1, "feature/test", &conventions);
     assert!(!prompt.contains("Spec Validation"));
@@ -1409,6 +1420,7 @@ fn test_build_prompt_validation_ordering() {
         design_doc: Some(&doc),
         doc_path: None,
         skip_permissions: false,
+        permission_mode: None,
     };
     let prompt = build_prompt(&opts, 1, "feature/test", &conventions);
     let test_pos = prompt.find("Run tests").expect("should have test section");
@@ -1754,6 +1766,7 @@ fn test_build_agent_command_without_sandbox() {
         Path::new("/tmp/worktree"),
         false,
         None,
+        None,
     );
     assert_eq!(
         cmd,
@@ -1773,6 +1786,7 @@ fn test_build_agent_command_with_sandbox() {
         Path::new("/tmp/my-worktree"),
         false,
         None,
+        None,
     );
     assert!(cmd.starts_with("timeout 3600s bwrap --bind '/tmp/my-worktree' /workspace --"));
     assert!(cmd.contains("env -u CLAUDECODE claude"));
@@ -1790,12 +1804,93 @@ fn test_build_agent_command_with_skip_permissions() {
         Path::new("/tmp/worktree"),
         true,
         None,
+        None,
     );
     assert!(
         cmd.contains("--dangerously-skip-permissions"),
         "Should include skip permissions flag"
     );
     assert!(cmd.contains("claude --dangerously-skip-permissions --model 'opus'"));
+}
+
+#[test]
+fn test_build_agent_command_with_permission_mode_auto() {
+    // GH#603: --permission-mode <mode> emits claude's --permission-mode flag
+    // with the value shell-escaped.
+    let cmd = build_agent_command(
+        "timeout",
+        3600,
+        "opus",
+        "Read,Write",
+        "KICKOFF.md",
+        None,
+        Path::new("/tmp/worktree"),
+        false,
+        None,
+        Some("auto"),
+    );
+    assert!(
+        cmd.contains("--permission-mode 'auto'"),
+        "permission_mode=auto should emit --permission-mode 'auto', got: {cmd}"
+    );
+    assert!(
+        !cmd.contains("--dangerously-skip-permissions"),
+        "permission_mode must not coexist with --dangerously-skip-permissions"
+    );
+}
+
+#[test]
+fn test_build_agent_command_permission_mode_wins_over_skip_permissions() {
+    // Defense in depth: even if both flags are set (CLI parsing should
+    // reject this via conflicts_with, but internal callers might not),
+    // permission_mode takes precedence and skip_permissions's
+    // --dangerously-skip-permissions is suppressed.
+    let cmd = build_agent_command(
+        "timeout",
+        3600,
+        "opus",
+        "Read,Write",
+        "KICKOFF.md",
+        None,
+        Path::new("/tmp/worktree"),
+        true,
+        None,
+        Some("acceptEdits"),
+    );
+    assert!(
+        cmd.contains("--permission-mode 'acceptEdits'"),
+        "permission_mode should win over skip_permissions, got: {cmd}"
+    );
+    assert!(
+        !cmd.contains("--dangerously-skip-permissions"),
+        "skip_permissions must be suppressed when permission_mode is set, got: {cmd}"
+    );
+}
+
+#[test]
+fn test_build_agent_command_empty_permission_mode_treated_as_none() {
+    // An empty string should be treated the same as None — falling back
+    // to skip_permissions resolution (or no flag).
+    let cmd = build_agent_command(
+        "timeout",
+        3600,
+        "opus",
+        "Read,Write",
+        "KICKOFF.md",
+        None,
+        Path::new("/tmp/worktree"),
+        true,
+        None,
+        Some(""),
+    );
+    assert!(
+        !cmd.contains("--permission-mode"),
+        "empty permission_mode must not emit the flag, got: {cmd}"
+    );
+    assert!(
+        cmd.contains("--dangerously-skip-permissions"),
+        "with skip_permissions=true and empty permission_mode, the legacy flag wins, got: {cmd}"
+    );
 }
 
 #[test]
@@ -1809,6 +1904,7 @@ fn test_build_agent_command_plan_kickoff() {
         None,
         Path::new("/tmp/worktree"),
         false,
+        None,
         None,
     );
     assert!(cmd.starts_with("gtimeout 1800s"));
@@ -1832,6 +1928,7 @@ fn test_build_agent_command_propagates_claude_config_dir() {
         Path::new("/tmp/worktree"),
         false,
         Some("/Users/me/.claude-work"),
+        None,
     );
     assert_eq!(
         cmd,
@@ -1853,6 +1950,7 @@ fn test_build_agent_command_omits_empty_claude_config_dir() {
         Path::new("/tmp/worktree"),
         false,
         Some(""),
+        None,
     );
     assert!(!cmd.contains("CLAUDE_CONFIG_DIR="));
     assert!(cmd.starts_with("timeout 3600s env -u CLAUDECODE claude"));
@@ -1873,6 +1971,7 @@ fn test_build_agent_command_escapes_claude_config_dir_with_quotes() {
         Path::new("/tmp/worktree"),
         false,
         Some("/weird/it's-a-path"),
+        None,
     );
     assert!(cmd.contains("CLAUDE_CONFIG_DIR='/weird/it'\\''s-a-path'"));
 }
@@ -1892,6 +1991,7 @@ fn test_build_agent_command_with_sandbox_includes_claude_config_dir() {
         Path::new("/tmp/my-worktree"),
         false,
         Some("/Users/me/.claude-work"),
+        None,
     );
     assert!(cmd.contains(
         "bwrap --bind '/tmp/my-worktree' /workspace -- env -u CLAUDECODE CLAUDE_CONFIG_DIR='/Users/me/.claude-work' claude"
@@ -1984,6 +2084,7 @@ fn test_build_agent_command_env_var_actually_reaches_claude() {
         tmp.path(),
         false,
         Some("/expected/value"),
+        None,
     );
 
     let output = run_built_command_in_bash(&cmd, tmp.path(), tmp.path());
@@ -2035,6 +2136,7 @@ fn test_build_agent_command_env_var_reaches_claude_through_sandbox() {
         tmp.path(),
         false,
         Some("/sandbox-passthrough/value"),
+        None,
     );
 
     let output = run_built_command_in_bash(&cmd, tmp.path(), tmp.path());
@@ -2076,6 +2178,7 @@ fn test_build_agent_command_omitted_env_var_does_not_break_launch() {
         None,
         tmp.path(),
         false,
+        None,
         None,
     );
 
@@ -2352,6 +2455,7 @@ fn test_build_prompt_contains_report_json_schema() {
         design_doc: Some(&doc),
         doc_path: Some("test.md"),
         skip_permissions: false,
+        permission_mode: None,
     };
     let prompt = build_prompt(&opts, 1, "feature/test", &conventions);
 
@@ -2399,6 +2503,7 @@ fn test_build_prompt_contains_validation_section() {
         design_doc: Some(&doc),
         doc_path: Some("test.md"),
         skip_permissions: false,
+        permission_mode: None,
     };
     let prompt = build_prompt(&opts, 1, "feature/validated", &conventions);
 

--- a/crosslink/src/commands/kickoff/types.rs
+++ b/crosslink/src/commands/kickoff/types.rs
@@ -92,6 +92,11 @@ pub struct KickoffOpts<'a> {
     pub design_doc: Option<&'a super::super::design_doc::DesignDoc>,
     pub doc_path: Option<&'a str>,
     pub skip_permissions: bool,
+    /// Optional claude `--permission-mode <mode>` (GH#603). When set,
+    /// overrides `skip_permissions`'s `--dangerously-skip-permissions`
+    /// with the finer-grained mode (acceptEdits/auto/bypassPermissions/
+    /// default/dontAsk/plan). CLI marks the flags as mutually exclusive.
+    pub permission_mode: Option<&'a str>,
 }
 
 /// A single criterion verdict in the validation report.

--- a/crosslink/src/commands/sentinel/engine.rs
+++ b/crosslink/src/commands/sentinel/engine.rs
@@ -442,6 +442,7 @@ fn spawn_agent(
         design_doc: None,
         doc_path: None,
         skip_permissions: true,
+        permission_mode: None,
     };
 
     run(crosslink_dir, db, writer, &opts)

--- a/crosslink/src/commands/swarm/lifecycle.rs
+++ b/crosslink/src/commands/swarm/lifecycle.rs
@@ -740,6 +740,7 @@ pub fn launch(
             design_doc: None,
             doc_path: None,
             skip_permissions: false,
+            permission_mode: None,
         };
 
         match kickoff::run(crosslink_dir, db, writer, &opts) {

--- a/crosslink/src/main.rs
+++ b/crosslink/src/main.rs
@@ -1616,6 +1616,23 @@ enum KickoffCommands {
         /// for that instead of this flag for repeatable configuration.
         #[arg(long)]
         skip_permissions: bool,
+        /// Per-invocation: pass `--permission-mode <mode>` to claude CLI.
+        ///
+        /// Finer-grained alternative to `--skip-permissions`. Claude
+        /// supports `acceptEdits`, `auto`, `bypassPermissions`,
+        /// `default`, `dontAsk`, `plan`. `auto` is the common choice
+        /// for unattended runs on the host (`--container none`) — the
+        /// permission classifier stays active for anomalous calls.
+        /// Mutually exclusive with `--skip-permissions`.
+        #[arg(
+            long,
+            value_parser = clap::builder::PossibleValuesParser::new([
+                "acceptEdits", "auto", "bypassPermissions",
+                "default", "dontAsk", "plan",
+            ]),
+            conflicts_with = "skip_permissions"
+        )]
+        permission_mode: Option<String>,
     },
     /// Check status of a running kickoff agent (no args = pipeline overview)
     Status {
@@ -1740,6 +1757,21 @@ enum KickoffCommands {
         /// (allowedTools / permissions blocks).
         #[arg(long)]
         skip_permissions: bool,
+        /// Per-invocation: pass `--permission-mode <mode>` to claude CLI.
+        ///
+        /// Finer-grained alternative to `--skip-permissions`. Claude
+        /// supports `acceptEdits`, `auto`, `bypassPermissions`,
+        /// `default`, `dontAsk`, `plan`. Mutually exclusive with
+        /// `--skip-permissions`.
+        #[arg(
+            long,
+            value_parser = clap::builder::PossibleValuesParser::new([
+                "acceptEdits", "auto", "bypassPermissions",
+                "default", "dontAsk", "plan",
+            ]),
+            conflicts_with = "skip_permissions"
+        )]
+        permission_mode: Option<String>,
     },
 }
 
@@ -3011,6 +3043,7 @@ fn main() -> Result<()> {
                 issue: None,
                 dry_run: false,
                 skip_permissions: false,
+                permission_mode: None,
             });
             commands::kickoff::dispatch(
                 action,


### PR DESCRIPTION
## Summary

Fixes GH#603. `crosslink kickoff run` previously only exposed `--skip-permissions`, which always passed `--dangerously-skip-permissions` (full bypass) to the spawned claude session. That's appropriate for Docker-sandboxed kickoffs but more permissive than needed when running on the host (`--container none`). Claude itself supports a finer-grained `--permission-mode <mode>` flag — `auto` in particular keeps the permission classifier active for anomalous tool calls while routine ones go through, which is what users typically want for unattended host runs.

This PR adds `--permission-mode <mode>` to `kickoff run` and `kickoff launch`, mutually exclusive with `--skip-permissions`, validated at clap parse time against claude's known set.

## Choice of approach

The issue offers two paths — a CLI flag (option A) or an env var (option B). Going with **A** for the cleaner long-term surface: validation happens at parse time, the option is discoverable via `--help`, and it composes correctly with `conflicts_with` against the legacy `--skip-permissions`.

## Usage

```sh
# Default (unchanged):
crosslink kickoff run "feature" --container none --skip-permissions

# New: auto mode — classifier active, no human approval needed:
crosslink kickoff run "feature" --container none --permission-mode auto

# Mutually exclusive — clap rejects this at parse time:
crosslink kickoff run "feature" --skip-permissions --permission-mode auto
# error: the argument '--skip-permissions' cannot be used with '--permission-mode <permission_mode>'
```

Valid `<mode>` values (enforced by `clap::builder::PossibleValuesParser`):
`acceptEdits`, `auto`, `bypassPermissions`, `default`, `dontAsk`, `plan`

## Threading

The flag walks down through every kickoff dispatch path:

- **`main.rs`** — `KickoffCommands::{Run, Launch}` gain the field. The fallthrough `Launch` default in the bare `crosslink kickoff` interactive wizard also gets `permission_mode: None`.
- **`types.rs::KickoffOpts`** — new `permission_mode: Option<&'a str>` field.
- **`mod.rs`** — destructured in both `Run` and `Launch` match arms, threaded through `dispatch_launch`'s signature, set in all three `KickoffOpts` construction sites (direct `Run`, `dispatch_launch`'s `--run` path, and the wizard's `WizardStage::Run` path).
- **`run.rs`** — passes `opts.permission_mode` to `launch_local`.
- **`launch.rs`** — `launch_local` signature gains the param; `build_agent_command` does the resolution (see below).
- **`plan.rs`** — plan mode passes `None` (plan mode never overrides permissions).
- **`swarm/lifecycle.rs`, `sentinel/engine.rs`** — internal `KickoffOpts` builders updated with `permission_mode: None` (not user-facing).

Container mode (`launch_container`) does not use `build_agent_command` — it relies on the agent image's own entrypoint — so no plumbing there.

## Resolution semantics

Inside `build_agent_command`:

```rust
match (permission_mode, skip_permissions) {
    (Some(mode), _) if !mode.is_empty() => format!(" --permission-mode {}", shell_escape_arg(mode)),
    (_, true)                           => " --dangerously-skip-permissions".to_string(),
    _                                   => String::new(),
}
```

- `permission_mode` (when non-empty) takes precedence over `skip_permissions`.
- Empty-string `permission_mode` is treated as `None` and falls back to the legacy resolution.
- CLI parsing makes the `Some(...) + true` case unreachable from the public surface (`conflicts_with`), but the defense-in-depth ordering is tested anyway for internal callers.

## Test plan

- [x] `cargo test --lib --bin crosslink` — 2878 passed (+3 new)
- [x] `cargo clippy -- -D warnings -W clippy::unwrap_used -W clippy::expect_used` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] New tests:
  - `test_build_agent_command_with_permission_mode_auto` — emits `--permission-mode 'auto'`, no `--dangerously-skip-permissions`
  - `test_build_agent_command_permission_mode_wins_over_skip_permissions` — defense-in-depth precedence check
  - `test_build_agent_command_empty_permission_mode_treated_as_none` — empty string falls back to legacy resolution
- [x] Existing 11 `build_agent_command` test calls + 14 `KickoffOpts` test constructions updated for the new field
- [x] Manual repro from the issue:
  ```sh
  crosslink kickoff run "feature" --doc design.md --issue 1 \
      --container none --timeout 24h --permission-mode auto
  ```
  Tmux pane should show claude's command line includes `--permission-mode 'auto'` and skip the bypass-permissions warning prompt.

## Out of scope

- Adding an env var fallback. Could be tacked on later as `CROSSLINK_PERMISSION_MODE` for scripts/CI that don't want to rewrite CLI invocations, but keeping the surface area minimal here.
- Threading `permission_mode` into `launch_container`. The container path uses the agent image's own permission setup, not `build_agent_command`.

## Cross-refs

- #580 — kickoff macOS Keychain auth gap (closed)
- #584 — kickoff git-shim + allowedTools (closed)
- #593 — `/design` skill prelude (open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)