### PR TITLE
fix(sync): close hub corruption windows from concurrent writers

### DIFF
--- a/.design/hub-v3-per-agent-refs.md
+++ b/.design/hub-v3-per-agent-refs.md
@@ -1,0 +1,102 @@
+# Feature: Hub v3 — Per-Agent Refs and Pure Event Sourcing
+
+## Summary
+
+Restructure the hub from a single shared `crosslink/hub` branch containing mutable files into per-agent git refs carrying append-only event logs only. Each agent writes exclusively to its own ref (`refs/crosslink/agents/<agent-id>`), making every push a guaranteed fast-forward. All shared state — issues, display IDs, locks — is derived deterministically from the union of agent event logs via the existing OrderingKey reduction. The mutable files that have caused every recorded hub corruption incident (`meta/counters.json`, `locks.json`, V1 flat issue JSON) are eliminated, and with them the rebase-retry, conflict-recovery, and dirty-state-repair machinery they require. Git remains the only infrastructure; GitHub (or any git remote) remains a dumb transport whose sole consistency primitive — atomic compare-and-swap on ref updates — is the only one this design needs.
+
+## Motivation
+
+Twelve distinct hub corruption classes were fixed across v0.5.1–v0.5.2 (GH#427, GH#428, GH#430, GH#443, GH#450, GH#451, GH#528, GH#574, GH#602, GH#604, CL-372, plus TUI corruption GH#447). A 2026-06 audit found five further live defects (non-unique `atomic_write` temp names, live-holder lock force-steal, disjoint lock domains between compaction and the write path, double-mint display ID window in rebase-retry, silent issue drop in hydration dedup). Every incident traces to one of two structural causes:
+
+1. **Mutable shared files on a multi-writer branch.** `counters.json` and `locks.json` require linearizable read-modify-write; git provides optimistic concurrency with seconds of latency. The conflict pressure this creates is what the rebase-retry and `clean_dirty_state` machinery exists to manage, and that machinery has itself caused corruption.
+2. **A single shared worktree mutated by concurrent local processes.** Git's index is not safe under concurrent mutation; the recovery code that commits "whatever is in the working tree" turns transient races into durable corruption.
+
+The append-only event-log half of the current design (V2 path) has not been implicated in any incident. Hub v3 keeps it and removes everything else.
+
+## Requirements
+
+- REQ-1: Each agent writes events exclusively to its own ref `refs/crosslink/agents/<agent-id>`, containing a single append-only NDJSON event log (`events.log`) plus the agent's public key and metadata. Pushes to this ref MUST always be fast-forward; any non-fast-forward push outcome is a hard error (indicates identity collision or history tampering), never silently rebased.
+- REQ-2: Writes use git plumbing (`hash-object`, `mktree`, `commit-tree`, `update-ref`) against the local repository object store — no shared worktree, no index, no checkout. The `.crosslink/.hub-cache/` worktree is eliminated.
+- REQ-3: Reads fetch `refs/crosslink/*` via an explicit refspec into `refs/crosslink-remote/*` tracking refs and materialize state in memory using the existing `OrderingKey` `(timestamp, agent_id, agent_seq)` total order and compaction reduction rules. Materialized state hydrates SQLite exactly as today.
+- REQ-4: `meta/counters.json` is eliminated. Display IDs are assigned solely by the deterministic reduction, preserving the existing `CheckpointState.display_id_map` freeze semantics: once a checkpoint's watermark covers an `IssueCreated` event, its display ID is frozen; late-arriving events with earlier OrderingKeys receive IDs above the frozen maximum. Before checkpoint coverage, the CLI shows the locally computed ID marked provisional (suffix `~`), or the short UUID where no local computation is possible.
+- REQ-5: `locks.json` and `sync/locks.rs` are eliminated. Locks are pure T1 `LockClaimed`/`LockReleased` events resolved first-claim-wins by OrderingKey (current V2 semantics). The claim-confirm protocol is: emit claim → push own ref → fetch all agent refs → verify self is the deterministic winner → proceed or back off. Confirm timeout remains 30 seconds (design doc v2 section 8).
+- REQ-6: Lock enforcement model is unchanged and documented: (a) cooperative gate — `lock_check`/PreToolUse hooks read materialized state and block work on `LockedByOther`; (b) stampede resolution — first-claim-wins yields exactly one winner per issue deterministically, with no state in which two agents both verify ownership; (c) rogue-agent backstop — signed events + `allowed_signers` attribution, `trust revoke`, worktree isolation, and the merge gate. No hub data structure is treated as enforcement against a non-cooperating agent.
+- REQ-7: The checkpoint is a pure cache on `refs/crosslink/checkpoint`, written by whichever process compacts, pushed with `--force-with-lease`. Concurrent compactions are harmless: both produce the same deterministic state for the same event set; the lease loser refetches and either fast-forwards or discards its identical result. `checkpoint/compaction.lock` (cross-machine lease) is retained only as a politeness optimization to avoid duplicate work.
+- REQ-8: Local same-machine concurrency is serialized by exactly one mandatory lock: a per-repository `flock` (or lock-file with live-holder respect, per #750) held across any hub read-modify-write sequence. There are no other lock domains.
+- REQ-9: Migration: `crosslink migrate hub-v3` performs a one-shot conversion — replay the current materialized hub state into a genesis checkpoint on `refs/crosslink/checkpoint` plus per-agent genesis refs seeded from existing `agents/{id}/events.log` files. The old `crosslink/hub` branch is left untouched (read-only escape hatch) and deleted only by explicit `crosslink migrate hub-v3 --finalize`. Mixed-version operation is refused: v3 clients detect a v2 hub and prompt to migrate; v2 clients detect the v3 marker ref and refuse with an upgrade message.
+- REQ-10: All v2 conflict machinery is deleted, not deprecated: `recover_from_push_conflict`, rebase-retry loops, `clean_dirty_state` conflict-marker repair, `hub_health_check` worktree repair, `reconcile_display_counter`, `dedup_issue_files` display-ID collision handling, V1 layout support, and the `verify_cache_worktree` walk-up guard (no worktree remains to walk up from).
+- REQ-11: Event log growth is bounded by the existing prune path: once a checkpoint watermark covers events, agents MAY rewrite their own ref to drop covered events (single-writer ref, so rewrite is safe; readers treat the checkpoint as authoritative below its watermark).
+- REQ-12: Remote compatibility: works against any git remote supporting custom refs (GitHub, GitLab, Gitea, bare SSH). Crosslink configures its own fetch/push refspecs; no reliance on default branch refspecs or remote UI visibility.
+- REQ-13: Extension point (non-goal for v3.0): an optional coordination server MAY later grant sub-second lock claims, recorded as ordinary events for durability. The git path remains the source of truth and the only required infrastructure.
+
+## Acceptance Criteria
+
+- [ ] AC-1: Two agents on separate clones create issues concurrently for 100 iterations; zero push conflicts occur, zero rebases are executed, and after mutual fetch + compaction both materialize identical state including identical display IDs. (REQ-1, REQ-3, REQ-4)
+- [ ] AC-2: `kill -9` during any write sequence leaves the local repo and remote refs in a state from which the next command proceeds with no repair step and no data loss — verified by a crash-injection harness over the plumbing write path. (REQ-2)
+- [ ] AC-3: Ten agents race `lock claim` on one issue; exactly one verifies ownership after confirm; the other nine receive `LockedByOther` naming the winner. Repeated 50 times with shuffled timing. (REQ-5, REQ-6)
+- [ ] AC-4: An agent's push to its own ref that would be non-fast-forward (simulated by moving the remote ref) fails hard with a diagnostic naming the ref — no automatic rebase, no force. (REQ-1)
+- [ ] AC-5: Two machines compact concurrently from the same event set; both checkpoints are byte-identical; the force-with-lease loser recovers without error or state change. (REQ-7)
+- [ ] AC-6: `crosslink migrate hub-v3` on a populated v2 hub preserves every issue, comment, label, dependency, relation, milestone, time entry, and display ID, verified by full-state diff against pre-migration hydration. Old branch remains readable until `--finalize`. (REQ-9)
+- [ ] AC-7: A v0.5.x client pointed at a v3 hub refuses with an upgrade message; a v3 client pointed at a v2 hub prompts to migrate and performs no writes. (REQ-9)
+- [ ] AC-8: After prune, an agent's ref contains only post-watermark events, and a fresh clone materializes correct full state from checkpoint + remaining events. (REQ-11)
+- [ ] AC-9: Daemon, TUI, `serve`, and a foreground CLI command run simultaneously against one repository under a write-heavy loop with no corruption and no lock-steal, serialized only by the single REQ-8 lock. (REQ-8)
+- [ ] AC-10: `grep -r "recover_from_push_conflict\|clean_dirty_state\|reconcile_display_counter" src/` returns nothing; net diffstat of the migration PR series is negative. (REQ-10)
+- [ ] AC-11: Full smoke suite passes against a GitHub remote and a bare local remote, exercising the custom refspecs. (REQ-12)
+
+## Architecture
+
+### Ref layout
+
+```
+refs/crosslink/agents/<agent-id>     one writer (that agent); append-only events.log + identity
+refs/crosslink/checkpoint            any compactor; force-with-lease; pure cache of reduction
+refs/crosslink/meta                  hub version marker, allowed_signers (driver-written, CAS)
+```
+
+Fetch refspec: `+refs/crosslink/*:refs/crosslink-remote/*`. Push refspec per agent: `refs/crosslink/agents/<id>:refs/crosslink/agents/<id>` (no `+`; fast-forward enforced by the remote — this is the CAS).
+
+### Write path (replaces SharedWriter commit/push/rebase machinery)
+
+1. Acquire the single local lock (REQ-8).
+2. Append event(s) to the in-memory log; build the new `events.log` blob via `hash-object -w`.
+3. `mktree` → `commit-tree` with parent = current own-ref tip → `update-ref refs/crosslink/agents/<id>`.
+4. Push own ref. Success is unconditional under correct operation; failure is diagnostic, never triggers rebase.
+5. Release lock. Fetch + materialize opportunistically (or on next read).
+
+No index, no worktree, no `git add`, no working-tree files to corrupt or recover.
+
+### Read path
+
+Fetch `refs/crosslink/*` → load checkpoint → stream events above its watermark from each agent ref (via `cat-file`) → reduce with existing compaction rules → hydrate SQLite. The reduction code (`compaction.rs` reducer, `CheckpointState`, `OrderingKey`) is reused nearly verbatim; only its I/O changes from worktree files to object-store reads.
+
+### Display IDs without a counter
+
+The existing `display_id_map` + watermark freeze in `CheckpointState` already implements deterministic, stable-once-frozen assignment. v3 makes it the only path by deleting the `counters.json` fast path. UX cost: an issue created offline shows `#~42` (provisional) until its event is covered by a pushed checkpoint — in connected operation this is seconds. UUIDs remain the true identity throughout, as today.
+
+### Locks and the enforcement model
+
+First-claim-wins by OrderingKey, exactly one winner, computed identically by every reader — this is current V2 compaction semantics promoted to the only semantics. The claim-confirm round trip bounds the mutual-exclusion window to push+fetch latency (single-digit seconds), identical to v2's effective window but without the v2 defect where rebase-merge of `locks.json` lets two claimants both verify ownership. Enforcement against rogue agents remains layered (hook gate, signed attribution, revocation, merge gate) per REQ-6; this is explicitly documented as the trust boundary.
+
+### What gets deleted
+
+`sync/locks.rs`; `recover_from_push_conflict`; the rebase-retry loop in `shared_writer/core.rs`; `clean_dirty_state` conflict repair; `hub_health_check`; `verify_cache_worktree`; V1 layout support and `issue_rel_path` dual-format handling; `reconcile_display_counter`; `dedup_issue_files`; `meta/counters.json` and `locks.json` schemas; the hub-cache worktree lifecycle (`init_cache`, gitignore self-heal, walk-up guards). Estimated net diffstat strongly negative.
+
+### Migration sequencing
+
+1. PR 1: read-side abstraction — materialization reads through a `HubSource` trait (worktree-file impl + object-store impl), proving the reducer against both.
+2. PR 2: plumbing write path behind `hub_v3` config flag; dual-write soak in this repository.
+3. PR 3: `crosslink migrate hub-v3` + version detection/refusal logic.
+4. PR 4: flip default, delete v2 machinery (REQ-10), `--finalize`.
+
+### Risks
+
+- **Ref proliferation**: one ref per agent ever registered. Mitigated by archiving refs for agents inactive past a threshold (`crosslink prune` extension).
+- **Plumbing portability**: `commit-tree`/`update-ref` are stable plumbing, but Windows path/quoting needs the same care the current code already takes; covered by existing CI matrix.
+- **Provisional display IDs**: visible UX change in offline-heavy workflows; mitigated by the `~` marker and immediate stabilization on first sync.
+- **Migration correctness**: AC-6 full-state diff is the gate; old branch retained until explicit finalize makes rollback trivial.
+
+## Open Questions
+
+- OQ-1: Should agent refs live under `refs/crosslink/*` (hidden from host UIs, requires explicit refspec) or `refs/heads/crosslink/agents/*` (visible as branches, fetched by default, more clutter)? Recommendation: `refs/crosslink/*`; revisit if a popular host refuses custom ref namespaces.
+- OQ-2: Knowledge base (`crosslink/knowledge` branch) is out of scope here — it is human-edited markdown where git merge semantics are appropriate. Confirm it stays on its current branch model.
+- OQ-3: Minimum supported git version for the plumbing path (notably `update-ref --create-reflog` behavior); propose git >= 2.30 and document it.

--- a/crosslink/src/commands/compact.rs
+++ b/crosslink/src/commands/compact.rs
@@ -14,7 +14,12 @@ pub fn run(crosslink_dir: &Path, db: &Database, force: bool) -> Result<()> {
     let agent = crate::identity::AgentConfig::load(crosslink_dir)?
         .ok_or_else(|| anyhow::anyhow!("No agent configured. Run 'crosslink agent init' first."))?;
 
-    match crate::compaction::compact(&cache_dir, &agent.agent_id, force)? {
+    // Acquire the hub write lock before compaction and hold it through
+    // hydration — prevents a concurrent write_commit_push from racing
+    // compaction's materialized-file writes (#750).
+    let hub_lock = sync.acquire_lock()?;
+
+    match crate::compaction::compact(&cache_dir, &agent.agent_id, force, &hub_lock)? {
         Some(result) => {
             println!("Compaction complete.");
             if result.events_processed > 0 {

--- a/crosslink/src/commands/integrity_drift.rs
+++ b/crosslink/src/commands/integrity_drift.rs
@@ -404,7 +404,7 @@ mod tests {
     use super::*;
     use crate::sync::HUB_CACHE_DIR;
 
-    /// Minimal cache_dir setup: an empty `issues/` directory under
+    /// Minimal `cache_dir` setup: an empty `issues/` directory under
     /// `crosslink_dir/.hub-cache/`. Enough to satisfy
     /// `hydrate_to_sqlite`'s "no JSON files" early-return.
     fn setup_empty_cache(crosslink_dir: &std::path::Path) {

--- a/crosslink/src/compaction.rs
+++ b/crosslink/src/compaction.rs
@@ -157,17 +157,36 @@ pub struct CompactionResult {
 /// Reads all agent event logs, applies reduction rules in deterministic order,
 /// writes checkpoint state and materializes issue/lock files.
 ///
-/// Uses a filesystem lock file (`checkpoint/compaction.lock`) for mutual
-/// exclusion. The lock is created atomically with `create_new(true)` so that
-/// concurrent compaction attempts safely fail rather than racing.
+/// # Two-lock model
 ///
-/// If `force` is false, returns `None` when the lock is held by another agent.
-/// If `force` is true, stale or self-owned locks are removed before retrying.
+/// Compaction uses two complementary locks:
+///
+/// - `_hub_lock` (`HubWriteLock`) — same-machine process mutex over all git
+///   operations in the hub cache worktree. **Mandatory**: callers must hold this
+///   lock before calling `compact`. This parameter is proof of that requirement;
+///   the compiler enforces it at the call site.
+/// - `CompactionLockGuard` (`checkpoint/compaction.lock`) — cross-machine lease
+///   advisory lock written to the hub branch. Advisory because a new machine
+///   starting up may not yet have the hub cache initialized, but it still
+///   prevents two compaction runs from racing on a shared git clone.
+///
+/// Holding only the `CompactionLockGuard` without the `HubWriteLock` would allow
+/// a concurrent `write_commit_push` from another process on the same machine to
+/// mutate the worktree while compaction is writing materialized files — the exact
+/// race this fix closes.
+///
+/// If `force` is false, returns `None` when the compaction lease is held by another agent.
+/// If `force` is true, stale or self-owned leases are removed before retrying.
 ///
 /// # Errors
 ///
 /// Returns an error if lock acquisition, checkpoint I/O, or event log reading fails.
-pub fn compact(cache_dir: &Path, agent_id: &str, force: bool) -> Result<Option<CompactionResult>> {
+pub fn compact(
+    cache_dir: &Path,
+    agent_id: &str,
+    force: bool,
+    _hub_lock: &crate::sync::HubWriteLock,
+) -> Result<Option<CompactionResult>> {
     // Acquire filesystem lock — this is the real mutual exclusion mechanism.
     let Some(_lock_guard) = CompactionLockGuard::try_acquire(cache_dir, agent_id, force)? else {
         return Ok(None);
@@ -825,13 +844,36 @@ mod tests {
         .unwrap();
     }
 
+    /// Acquire a `HubWriteLock` for tests.
+    ///
+    /// Uses the standard `.hub-write-lock` path inside `cache_dir` so tests
+    /// exercise the same lock path as production code.
+    fn test_hub_lock(cache_dir: &Path) -> crate::sync::HubWriteLock {
+        let lock_path = cache_dir.join(".hub-write-lock");
+        crate::sync::acquire_hub_lock(&lock_path).expect("failed to acquire hub write lock in test")
+    }
+
+    /// Convenience wrapper: acquire the hub write lock and run compaction.
+    ///
+    /// All test call sites use this instead of calling `compact` directly so
+    /// the `_hub_lock` proof-of-lock parameter is satisfied without duplicating
+    /// the lock acquisition at every call site.
+    fn compact_t(
+        cache_dir: &Path,
+        agent_id: &str,
+        force: bool,
+    ) -> Result<Option<CompactionResult>> {
+        let lock = test_hub_lock(cache_dir);
+        compact(cache_dir, agent_id, force, &lock)
+    }
+
     #[test]
     fn test_compact_empty() {
         let dir = tempfile::tempdir().unwrap();
         let cache_dir = dir.path();
         setup_cache(cache_dir);
 
-        let result = compact(cache_dir, "agent-1", false).unwrap().unwrap();
+        let result = compact_t(cache_dir, "agent-1", false).unwrap().unwrap();
         assert_eq!(result.events_processed, 0);
         assert_eq!(result.issues_materialized, 0);
     }
@@ -859,7 +901,7 @@ mod tests {
         );
         append_event(&log_path, &env).unwrap();
 
-        let result = compact(cache_dir, "agent-1", false).unwrap().unwrap();
+        let result = compact_t(cache_dir, "agent-1", false).unwrap().unwrap();
         assert_eq!(result.events_processed, 1);
         assert_eq!(result.issues_materialized, 1);
 
@@ -920,7 +962,7 @@ mod tests {
         append_event(&log_path, &e2).unwrap();
 
         // First compaction
-        compact(cache_dir, "agent-1", true).unwrap();
+        compact_t(cache_dir, "agent-1", true).unwrap();
 
         // Delete watermark to force full re-compaction
         let wm_path = cache_dir.join("checkpoint/watermark.json");
@@ -929,7 +971,7 @@ mod tests {
         }
 
         // Second compaction — IDs should be the same
-        compact(cache_dir, "agent-1", true).unwrap();
+        compact_t(cache_dir, "agent-1", true).unwrap();
 
         let state = read_checkpoint(cache_dir).unwrap();
         assert_eq!(state.display_id_map[&uuid1], 1);
@@ -977,7 +1019,7 @@ mod tests {
         append_event(&log_path, &e1).unwrap();
         append_event(&log_path, &e2).unwrap();
 
-        compact(cache_dir, "agent-1", true).unwrap();
+        compact_t(cache_dir, "agent-1", true).unwrap();
 
         let state = read_checkpoint(cache_dir).unwrap();
         assert_eq!(state.issues.len(), 1);
@@ -1017,7 +1059,7 @@ mod tests {
         append_event(&log1, &e1).unwrap();
         append_event(&log2, &e2).unwrap();
 
-        compact(cache_dir, "agent-1", true).unwrap();
+        compact_t(cache_dir, "agent-1", true).unwrap();
 
         let state = read_checkpoint(cache_dir).unwrap();
         assert_eq!(state.locks[&1].agent_id, "agent-1"); // First in order wins
@@ -1052,7 +1094,7 @@ mod tests {
         append_event(&log, &e1).unwrap();
         append_event(&log, &e2).unwrap();
 
-        compact(cache_dir, "agent-1", true).unwrap();
+        compact_t(cache_dir, "agent-1", true).unwrap();
 
         let state = read_checkpoint(cache_dir).unwrap();
         assert!(state.locks.is_empty());
@@ -1113,7 +1155,7 @@ mod tests {
         append_event(&log1, &e_update1).unwrap();
         append_event(&log2, &e_update2).unwrap();
 
-        compact(cache_dir, "agent-1", true).unwrap();
+        compact_t(cache_dir, "agent-1", true).unwrap();
 
         let state = read_checkpoint(cache_dir).unwrap();
         let issue = &state.issues[&uuid];
@@ -1179,7 +1221,7 @@ mod tests {
         append_event(&log, &e_add2).unwrap();
         append_event(&log, &e_remove).unwrap();
 
-        compact(cache_dir, "agent-1", true).unwrap();
+        compact_t(cache_dir, "agent-1", true).unwrap();
 
         let state = read_checkpoint(cache_dir).unwrap();
         assert!(state.issues[&uuid].labels.is_empty());
@@ -1223,7 +1265,7 @@ mod tests {
         append_event(&log, &e1).unwrap();
         append_event(&log, &e2).unwrap();
 
-        compact(cache_dir, "agent-1", true).unwrap();
+        compact_t(cache_dir, "agent-1", true).unwrap();
 
         let state = read_checkpoint(cache_dir).unwrap();
         assert!(state.issues[&blocked].blockers.contains(&blocker));
@@ -1275,7 +1317,7 @@ mod tests {
         append_event(&log, &e2).unwrap();
         append_event(&log, &e3).unwrap();
 
-        compact(cache_dir, "agent-1", true).unwrap();
+        compact_t(cache_dir, "agent-1", true).unwrap();
 
         let state = read_checkpoint(cache_dir).unwrap();
         assert!(state.issues[&uuid_a].related.contains(&uuid_b));
@@ -1401,7 +1443,7 @@ mod tests {
 
         append_event(&log, &env).unwrap();
 
-        let result = compact(cache_dir, "agent-1", true).unwrap().unwrap();
+        let result = compact_t(cache_dir, "agent-1", true).unwrap().unwrap();
         assert!(result.skew_warnings > 0);
     }
 
@@ -1431,7 +1473,7 @@ mod tests {
 
         append_event(&log, &env).unwrap();
 
-        let result = compact(cache_dir, "agent-1", true).unwrap().unwrap();
+        let result = compact_t(cache_dir, "agent-1", true).unwrap().unwrap();
         assert!(result.unsigned_warnings > 0);
     }
 
@@ -1472,7 +1514,7 @@ mod tests {
         append_event(&log, &e2).unwrap();
 
         // Compact to create watermark
-        compact(cache_dir, "agent-1", true).unwrap();
+        compact_t(cache_dir, "agent-1", true).unwrap();
 
         // Prune should remove events at/below watermark
         let pruned = prune_events(cache_dir, "agent-1").unwrap();
@@ -1534,7 +1576,7 @@ mod tests {
         append_event(&log2, &e_label1).unwrap();
         append_event(&log1, &e_label2).unwrap();
 
-        compact(cache_dir, "agent-1", true).unwrap();
+        compact_t(cache_dir, "agent-1", true).unwrap();
 
         let state = read_checkpoint(cache_dir).unwrap();
         let issue = &state.issues[&uuid];
@@ -1581,7 +1623,7 @@ mod tests {
         append_event(&log, &e1).unwrap();
         append_event(&log, &e2).unwrap();
 
-        compact(cache_dir, "agent-1", true).unwrap();
+        compact_t(cache_dir, "agent-1", true).unwrap();
 
         let state = read_checkpoint(cache_dir).unwrap();
         assert_eq!(
@@ -1607,7 +1649,7 @@ mod tests {
         std::fs::write(&lock_path, content.to_string()).unwrap();
 
         // Try to compact as agent-1 without force — should fail
-        let result = compact(cache_dir, "agent-1", false).unwrap();
+        let result = compact_t(cache_dir, "agent-1", false).unwrap();
         assert!(result.is_none());
 
         // Lock file should still exist
@@ -1631,7 +1673,7 @@ mod tests {
         std::fs::write(&lock_path, content.to_string()).unwrap();
 
         // Force should override the stale lock
-        let result = compact(cache_dir, "agent-1", true).unwrap();
+        let result = compact_t(cache_dir, "agent-1", true).unwrap();
         assert!(result.is_some());
 
         // Lock file should be cleaned up after compaction
@@ -1741,7 +1783,7 @@ mod tests {
             },
         );
         append_event(&log, &env).unwrap();
-        compact(cache_dir, "agent-1", true).unwrap();
+        compact_t(cache_dir, "agent-1", true).unwrap();
 
         // Read back the materialized issue.json
         let path = cache_dir
@@ -1798,7 +1840,7 @@ mod tests {
         append_event(&log, &e1).unwrap();
         append_event(&log, &e2).unwrap();
 
-        compact(cache_dir, "agent-1", true).unwrap();
+        compact_t(cache_dir, "agent-1", true).unwrap();
 
         let state = read_checkpoint(cache_dir).unwrap();
         assert_eq!(state.issues[&child].parent_uuid, Some(parent));
@@ -1841,7 +1883,7 @@ mod tests {
         append_event(&log, &e1).unwrap();
         append_event(&log, &e2).unwrap();
 
-        compact(cache_dir, "agent-1", true).unwrap();
+        compact_t(cache_dir, "agent-1", true).unwrap();
 
         let state = read_checkpoint(cache_dir).unwrap();
         assert_eq!(
@@ -1884,7 +1926,7 @@ mod tests {
         append_event(&log_a, &e1).unwrap();
         append_event(&log_b, &e2).unwrap();
 
-        compact(cache_dir, "agent-a", true).unwrap();
+        compact_t(cache_dir, "agent-a", true).unwrap();
 
         let state = read_checkpoint(cache_dir).unwrap();
         // Lock should still be held by agent-a since agent-b cannot release it
@@ -1935,7 +1977,7 @@ mod tests {
         append_event(&log, &e2).unwrap();
         append_event(&log, &e3).unwrap();
 
-        compact(cache_dir, "agent-1", true).unwrap();
+        compact_t(cache_dir, "agent-1", true).unwrap();
 
         let state = read_checkpoint(cache_dir).unwrap();
         let lock = state.locks.get(&1).unwrap();
@@ -1966,7 +2008,7 @@ mod tests {
             append_event(&log, &e).unwrap();
         }
 
-        compact(cache_dir, "agent-a", true).unwrap();
+        compact_t(cache_dir, "agent-a", true).unwrap();
 
         let state = read_checkpoint(cache_dir).unwrap();
         // agent-c has the earliest timestamp (now - 1), but agent-a has (now - 3)
@@ -2008,7 +2050,7 @@ mod tests {
         append_event(&log_a, &e1).unwrap();
         append_event(&log_b, &e2).unwrap();
 
-        compact(cache_dir, "agent-alpha", true).unwrap();
+        compact_t(cache_dir, "agent-alpha", true).unwrap();
 
         let state = read_checkpoint(cache_dir).unwrap();
         // "agent-alpha" < "agent-beta" lexicographically, so alpha wins
@@ -2048,7 +2090,7 @@ mod tests {
         append_event(&log_a, &e1).unwrap();
         append_event(&log_b, &e2).unwrap();
 
-        let result = compact(cache_dir, "agent-a", true).unwrap().unwrap();
+        let result = compact_t(cache_dir, "agent-a", true).unwrap().unwrap();
         assert_eq!(result.locks_materialized, 2);
 
         let state = read_checkpoint(cache_dir).unwrap();
@@ -2094,7 +2136,7 @@ mod tests {
         append_event(&log_a, &e1).unwrap();
         append_event(&log_b, &e2).unwrap();
 
-        compact(cache_dir, "agent-a", true).unwrap();
+        compact_t(cache_dir, "agent-a", true).unwrap();
 
         let state = read_checkpoint(cache_dir).unwrap();
         let lock = state.locks.get(&1).unwrap();
@@ -2137,7 +2179,7 @@ mod tests {
         append_event(&log, &e1).unwrap();
         append_event(&log, &e2).unwrap();
 
-        compact(cache_dir, "agent-1", true).unwrap();
+        compact_t(cache_dir, "agent-1", true).unwrap();
 
         // Lock should be absent from checkpoint and disk
         let state = read_checkpoint(cache_dir).unwrap();
@@ -2163,7 +2205,7 @@ mod tests {
         );
         append_event(&log, &e).unwrap();
 
-        let result = compact(cache_dir, "agent-1", true).unwrap().unwrap();
+        let result = compact_t(cache_dir, "agent-1", true).unwrap().unwrap();
         assert_eq!(result.events_processed, 1);
         assert_eq!(result.locks_materialized, 0);
 
@@ -2193,7 +2235,7 @@ mod tests {
         e1.timestamp = now - Duration::seconds(3);
         append_event(&log, &e1).unwrap();
 
-        compact(cache_dir, "agent-1", true).unwrap();
+        compact_t(cache_dir, "agent-1", true).unwrap();
 
         // Verify lock is held
         let state = read_checkpoint(cache_dir).unwrap();
@@ -2211,7 +2253,7 @@ mod tests {
         e2.timestamp = now - Duration::seconds(1);
         append_event(&log, &e2).unwrap();
 
-        compact(cache_dir, "agent-1", true).unwrap();
+        compact_t(cache_dir, "agent-1", true).unwrap();
 
         // Lock should be gone
         let state = read_checkpoint(cache_dir).unwrap();
@@ -2267,7 +2309,7 @@ mod tests {
         append_event(&log_b, &e2).unwrap();
         append_event(&log_a, &e3).unwrap();
 
-        compact(cache_dir, "agent-a", true).unwrap();
+        compact_t(cache_dir, "agent-a", true).unwrap();
 
         let state = read_checkpoint(cache_dir).unwrap();
         // Lock should be gone — agent-a won and then released
@@ -2331,7 +2373,7 @@ mod tests {
         append_event(&log_a, &e3).unwrap();
         append_event(&log_b, &e4).unwrap();
 
-        compact(cache_dir, "agent-a", true).unwrap();
+        compact_t(cache_dir, "agent-a", true).unwrap();
 
         let state = read_checkpoint(cache_dir).unwrap();
         let lock = state.locks.get(&1).unwrap();
@@ -2400,7 +2442,7 @@ mod tests {
         append_event(&log_b, &e3).unwrap();
         append_event(&log_a, &e4).unwrap();
 
-        compact(cache_dir, "agent-a", true).unwrap();
+        compact_t(cache_dir, "agent-a", true).unwrap();
 
         let state = read_checkpoint(cache_dir).unwrap();
         assert_eq!(state.locks.len(), 2);
@@ -2484,7 +2526,7 @@ mod tests {
         e.timestamp = claim_time;
         append_event(&log, &e).unwrap();
 
-        compact(cache_dir, "agent-1", true).unwrap();
+        compact_t(cache_dir, "agent-1", true).unwrap();
 
         let state = read_checkpoint(cache_dir).unwrap();
         let lock = state.locks.get(&1).unwrap();
@@ -2735,7 +2777,7 @@ mod tests {
         append_event(&log, &e2).unwrap();
         append_event(&log, &e3).unwrap();
 
-        compact(cache_dir, "agent-1", true).unwrap();
+        compact_t(cache_dir, "agent-1", true).unwrap();
 
         let state = read_checkpoint(cache_dir).unwrap();
         assert!(
@@ -2796,7 +2838,7 @@ mod tests {
         append_event(&log, &e3).unwrap();
         append_event(&log, &e4).unwrap();
 
-        compact(cache_dir, "agent-1", true).unwrap();
+        compact_t(cache_dir, "agent-1", true).unwrap();
 
         let state = read_checkpoint(cache_dir).unwrap();
         assert!(
@@ -2848,7 +2890,7 @@ mod tests {
         append_event(&log, &e_create).unwrap();
         append_event(&log, &e_update).unwrap();
 
-        compact(cache_dir, "agent-1", true).unwrap();
+        compact_t(cache_dir, "agent-1", true).unwrap();
 
         let state = read_checkpoint(cache_dir).unwrap();
         let issue = &state.issues[&uuid];
@@ -2964,7 +3006,7 @@ mod tests {
         std::fs::create_dir_all(cache_dir.join("issues")).unwrap();
         std::fs::create_dir_all(cache_dir.join("locks")).unwrap();
 
-        let result = compact(cache_dir, "agent-1", false).unwrap().unwrap();
+        let result = compact_t(cache_dir, "agent-1", false).unwrap().unwrap();
         assert_eq!(result.events_processed, 0);
         assert_eq!(result.issues_materialized, 0);
     }
@@ -3118,11 +3160,11 @@ mod tests {
         append_event(&log, &env).unwrap();
 
         // First compaction sets watermark
-        let r1 = compact(cache_dir, "agent-1", true).unwrap().unwrap();
+        let r1 = compact_t(cache_dir, "agent-1", true).unwrap().unwrap();
         assert_eq!(r1.events_processed, 1);
 
         // Second compaction with no new events should hit the early return
-        let r2 = compact(cache_dir, "agent-1", true).unwrap().unwrap();
+        let r2 = compact_t(cache_dir, "agent-1", true).unwrap().unwrap();
         assert_eq!(r2.events_processed, 0);
         assert_eq!(r2.issues_materialized, 0);
     }
@@ -3175,7 +3217,7 @@ mod tests {
         append_event(&log, &env).unwrap();
 
         // Should succeed, skipping the stray file
-        let result = compact(cache_dir, "agent-1", true).unwrap().unwrap();
+        let result = compact_t(cache_dir, "agent-1", true).unwrap().unwrap();
         assert_eq!(result.events_processed, 1);
         assert_eq!(result.issues_materialized, 1);
     }
@@ -3230,7 +3272,7 @@ mod tests {
         append_event(&log, &e2).unwrap();
         append_event(&log, &e3).unwrap();
 
-        compact(cache_dir, "agent-1", true).unwrap();
+        compact_t(cache_dir, "agent-1", true).unwrap();
 
         let state = read_checkpoint(cache_dir).unwrap();
         assert_eq!(
@@ -3278,7 +3320,7 @@ mod tests {
         append_event(&log, &e1).unwrap();
         append_event(&log, &e2).unwrap();
 
-        compact(cache_dir, "agent-1", true).unwrap();
+        compact_t(cache_dir, "agent-1", true).unwrap();
 
         let state = read_checkpoint(cache_dir).unwrap();
         assert_eq!(
@@ -3424,7 +3466,7 @@ mod tests {
         );
         e1.timestamp = Utc::now() - Duration::seconds(10);
         append_event(&log, &e1).unwrap();
-        compact(cache_dir, "agent-1", true).unwrap();
+        compact_t(cache_dir, "agent-1", true).unwrap();
 
         // Now simulate a legacy migration scenario:
         // Read the current checkpoint, strip the embedded watermark, write it back
@@ -3458,7 +3500,7 @@ mod tests {
         // 1. Find no embedded watermark (state.watermark = None)
         // 2. Fall back to legacy watermark.json (lines 186, 188 covered)
         // 3. Process only the new event (incremental)
-        let result = compact(cache_dir, "agent-1", true).unwrap().unwrap();
+        let result = compact_t(cache_dir, "agent-1", true).unwrap().unwrap();
         assert_eq!(
             result.events_processed, 1,
             "Only the new event should be processed"
@@ -3500,7 +3542,7 @@ mod tests {
         );
         e_claim.timestamp = now - Duration::seconds(5);
         append_event(&log, &e_claim).unwrap();
-        compact(cache_dir, "agent-1", true).unwrap();
+        compact_t(cache_dir, "agent-1", true).unwrap();
         assert!(
             lock_path.exists(),
             "Lock file should exist after claim compaction"
@@ -3516,7 +3558,7 @@ mod tests {
         );
         e_release.timestamp = now - Duration::seconds(2);
         append_event(&log, &e_release).unwrap();
-        compact(cache_dir, "agent-1", true).unwrap();
+        compact_t(cache_dir, "agent-1", true).unwrap();
 
         // The lock file should have been deleted by the materialize function (line 556)
         assert!(

--- a/crosslink/src/findings.rs
+++ b/crosslink/src/findings.rs
@@ -123,10 +123,10 @@ pub fn similarity_score(a: &Finding, b: &Finding) -> f64 {
     }
 
     // Title Jaccard
-    score += 0.3 * jaccard_similarity(&a.title, &b.title);
+    score = 0.3f64.mul_add(jaccard_similarity(&a.title, &b.title), score);
 
     // Description Jaccard
-    score += 0.2 * jaccard_similarity(&a.description, &b.description);
+    score = 0.2f64.mul_add(jaccard_similarity(&a.description, &b.description), score);
 
     score
 }

--- a/crosslink/src/shared_writer/core.rs
+++ b/crosslink/src/shared_writer/core.rs
@@ -285,15 +285,21 @@ impl SharedWriter {
         message: &str,
     ) -> Result<PushOutcome> {
         // Serialize access to the hub cache via SyncManager's lock (#372)
-        let _lock_guard = self.sync.acquire_lock()?;
+        let lock_guard = self.sync.acquire_lock()?;
 
         let envelope = self.create_envelope(event);
         let log_path = self.event_log_path();
         crate::events::append_event(&log_path, &envelope)?;
 
         for attempt in 0..MAX_RETRIES {
-            // Run compaction (force=true since we own the write path)
-            let _ = crate::compaction::compact(&self.cache_dir, &self.agent.agent_id, true)?;
+            // Run compaction (force=true since we own the write path).
+            // Pass &lock_guard as proof we hold the hub write lock (#750).
+            let _ = crate::compaction::compact(
+                &self.cache_dir,
+                &self.agent.agent_id,
+                true,
+                &lock_guard,
+            )?;
 
             // Stage event log + compaction output
             let rel_log = format!("agents/{}/events.log", self.agent.agent_id);

--- a/crosslink/src/shared_writer/mutations.rs
+++ b/crosslink/src/shared_writer/mutations.rs
@@ -874,7 +874,10 @@ impl SharedWriter {
         let mut issue = crate::issue_file::read_issue_file(&path)?;
         issue.display_id = None;
         let json = serde_json::to_string_pretty(&issue)?;
-        std::fs::write(&path, json)?;
+        // Use atomic_write to avoid the open-truncate-write race (#604, #750).
+        // std::fs::write would truncate the file before writing; a crash mid-write
+        // leaves a zero-byte or partial JSON that breaks all subsequent reads.
+        crate::utils::atomic_write(&path, json.as_bytes())?;
 
         // Revert the counter bump (the remote never saw it)
         let mut counters = self.read_counters()?;

--- a/crosslink/src/shared_writer/tests.rs
+++ b/crosslink/src/shared_writer/tests.rs
@@ -14,6 +14,15 @@ use std::path::Path;
 use tempfile::tempdir;
 use uuid::Uuid;
 
+/// Acquire a `HubWriteLock` for use in tests that call `compact` directly.
+///
+/// Uses the standard `.hub-write-lock` path so the lock path matches what
+/// production code uses when the cache dir is treated as a hub worktree.
+fn hub_lock_for_test(cache_dir: &Path) -> crate::sync::HubWriteLock {
+    let lock_path = cache_dir.join(".hub-write-lock");
+    crate::sync::acquire_hub_lock(&lock_path).expect("failed to acquire hub write lock for test")
+}
+
 fn make_issue(display_id: i64, title: &str) -> IssueFile {
     IssueFile {
         uuid: Uuid::new_v4(),
@@ -477,15 +486,16 @@ mod lock_v2_tests {
         append_event(&cache.join("agents/agent-b/events.log"), &e2).unwrap();
 
         // Run compaction
-        let result = crate::compaction::compact(cache, "agent-a", true)
+        let lock = hub_lock_for_test(cache);
+        let result = crate::compaction::compact(cache, "agent-a", true, &lock)
             .unwrap()
             .unwrap();
         assert_eq!(result.locks_materialized, 1);
 
         // Read checkpoint -- agent-a should win (earlier timestamp)
         let state = read_checkpoint(cache).unwrap();
-        let lock = state.locks.get(&1).unwrap();
-        assert_eq!(lock.agent_id, "agent-a");
+        let lock_entry = state.locks.get(&1).unwrap();
+        assert_eq!(lock_entry.agent_id, "agent-a");
     }
 
     #[test]
@@ -688,7 +698,8 @@ mod lock_v2_tests {
         };
         append_event(&cache.join("agents/agent-b/events.log"), &e3).unwrap();
 
-        let result = crate::compaction::compact(cache, "agent-a", true)
+        let hub_lock = hub_lock_for_test(cache);
+        let result = crate::compaction::compact(cache, "agent-a", true, &hub_lock)
             .unwrap()
             .unwrap();
         assert_eq!(result.locks_materialized, 1);
@@ -761,7 +772,8 @@ mod lock_v2_tests {
         };
         append_event(&cache.join("agents/agent-a/events.log"), &e3).unwrap();
 
-        crate::compaction::compact(cache, "agent-a", true).unwrap();
+        let hub_lock = hub_lock_for_test(cache);
+        crate::compaction::compact(cache, "agent-a", true, &hub_lock).unwrap();
 
         let state = read_checkpoint(cache).unwrap();
         assert!(state.locks.is_empty());
@@ -834,7 +846,8 @@ mod lock_v2_tests {
             };
             append_event(&cache.join("agents/agent-b/events.log"), &e2).unwrap();
 
-            crate::compaction::compact(cache, compactor, true).unwrap();
+            let hub_lock = hub_lock_for_test(cache);
+            crate::compaction::compact(cache, compactor, true, &hub_lock).unwrap();
 
             let state = read_checkpoint(cache).unwrap();
             assert_eq!(

--- a/crosslink/src/sync/cache.rs
+++ b/crosslink/src/sync/cache.rs
@@ -56,7 +56,15 @@ fn try_create_lock(lock_path: &Path) -> std::io::Result<HubWriteLock> {
 /// Blocks up to 30 seconds, checking for stale locks via PID liveness.
 /// Returns an RAII guard that releases the lock on drop.
 pub fn acquire_hub_lock(lock_path: &Path) -> Result<HubWriteLock> {
-    let max_wait = Duration::from_secs(30);
+    acquire_hub_lock_with_timeout(lock_path, Duration::from_secs(30))
+}
+
+/// Inner implementation of lock acquisition with a configurable timeout.
+///
+/// Separated from [`acquire_hub_lock`] so tests can pass a short timeout
+/// without waiting 30 seconds. Production callers use [`acquire_hub_lock`]
+/// which hard-codes the 30-second budget.
+fn acquire_hub_lock_with_timeout(lock_path: &Path, max_wait: Duration) -> Result<HubWriteLock> {
     let poll_interval = Duration::from_millis(100);
     let start = std::time::Instant::now();
 
@@ -86,7 +94,29 @@ pub fn acquire_hub_lock(lock_path: &Path) -> Result<HubWriteLock> {
                 }
 
                 if start.elapsed() > max_wait {
-                    // Force-remove after timeout
+                    // On timeout, only force-remove the lock when the holder is
+                    // confirmed dead (or when the PID content is unreadable/absent).
+                    // If the holder is a live process, bail instead of stealing the
+                    // lock — stealing would allow two processes to mutate the hub
+                    // worktree concurrently, which is the exact bug this lock prevents.
+                    if holder_alive {
+                        bail!(
+                            "hub write lock held by live process for >30s ({}); \
+                             waiting aborted to avoid concurrent worktree mutation — \
+                             retry, or remove the lock file if the process is hung: {}",
+                            std::fs::read_to_string(lock_path)
+                                .ok()
+                                .and_then(|c| c.trim().parse::<u32>().ok())
+                                .map_or_else(
+                                    || "<unknown PID>".to_string(),
+                                    |pid| format!("PID {pid}")
+                                ),
+                            lock_path.display()
+                        );
+                    }
+                    // Holder is dead (or PID was unreadable) — force-remove the stale
+                    // lock and try to acquire. This mirrors the not-alive fast path
+                    // above but is reached only after the wait budget is exhausted.
                     let _ = std::fs::remove_file(lock_path);
                     match try_create_lock(lock_path) {
                         Ok(guard) => return Ok(guard),
@@ -130,23 +160,37 @@ impl SyncManager {
             return Ok(());
         }
         let gitignore_path = self.cache_dir.join(".gitignore");
-        let entry = ".hub-write-lock";
 
-        let needs_write = std::fs::read_to_string(&gitignore_path).map_or(true, |content| {
-            !content.lines().any(|line| line.trim() == entry)
-        });
+        // Entries that must appear in the hub cache .gitignore:
+        //   .hub-write-lock  — PID lock file created/deleted on every sync (#528)
+        //   .*.tmp           — orphaned temp files from atomic_write crashes;
+        //                      covers both old fixed-name (.{basename}.tmp) and
+        //                      new unique-name (.{basename}.XXXXXX.tmp) forms.
+        let required_entries = [".hub-write-lock", ".*.tmp"];
 
-        if needs_write {
+        let existing_content = std::fs::read_to_string(&gitignore_path).unwrap_or_default();
+
+        let missing: Vec<&str> = required_entries
+            .iter()
+            .copied()
+            .filter(|entry| !existing_content.lines().any(|line| line.trim() == *entry))
+            .collect();
+
+        if !missing.is_empty() {
             use std::io::Write;
             let mut f = std::fs::OpenOptions::new()
                 .create(true)
                 .append(true)
                 .open(&gitignore_path)?;
-            writeln!(f, "{entry}")?;
+            for entry in &missing {
+                writeln!(f, "{entry}")?;
+            }
         }
 
-        // Untrack the lock file if git is currently tracking it
-        let _ = self.git_in_cache(&["rm", "--cached", "-f", entry]);
+        // Untrack any of these files if git is currently tracking them.
+        for entry in &required_entries {
+            let _ = self.git_in_cache(&["rm", "--cached", "-f", entry]);
+        }
 
         Ok(())
     }
@@ -851,5 +895,60 @@ impl SyncManager {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    /// Verify that when the lock file contains a live PID (our own process),
+    /// `acquire_hub_lock_with_timeout` returns an error that names the PID
+    /// and does NOT remove the lock file.
+    ///
+    /// This tests Fix 2: before the fix, the timeout branch would force-remove
+    /// the lock regardless of holder liveness, allowing concurrent worktree
+    /// mutation.
+    #[test]
+    fn test_acquire_hub_lock_live_holder_bails_without_stealing() {
+        let dir = tempdir().unwrap();
+        let lock_path = dir.path().join(".hub-write-lock");
+
+        // Write our own PID into the lock file — the current process is
+        // definitely alive, so the liveness check must return true.
+        {
+            use std::io::Write;
+            let mut f = std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&lock_path)
+                .expect("failed to create lock file");
+            writeln!(f, "{}", std::process::id()).unwrap();
+        }
+
+        // Use a short timeout (300 ms > 2 × poll_interval=100 ms) so the
+        // test completes quickly.
+        let timeout = Duration::from_millis(300);
+        let err = match acquire_hub_lock_with_timeout(&lock_path, timeout) {
+            Err(e) => e,
+            Ok(_guard) => panic!("expected acquire to fail when a live process holds the lock"),
+        };
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains(&std::process::id().to_string()),
+            "error should include holder PID, got: {msg}"
+        );
+        assert!(
+            msg.contains("live process"),
+            "error should mention live process, got: {msg}"
+        );
+
+        // Lock file must still exist — we did not steal it.
+        assert!(
+            lock_path.exists(),
+            "lock file was removed by the acquire attempt (lock was stolen)"
+        );
     }
 }

--- a/crosslink/src/sync/mod.rs
+++ b/crosslink/src/sync/mod.rs
@@ -32,7 +32,13 @@ const OLD_BRANCH: &str = "crosslink/locks";
 /// Re-export from `signing` module. Use `SignatureVerification` for new code.
 pub use crate::signing::SignatureVerification;
 
-/// Deprecated alias — use `SignatureVerification` instead.
+/// Same-machine hub write lock guard. Re-exported so `compaction::compact`
+/// can require it as proof that the caller holds the process mutex.
+pub use self::cache::HubWriteLock;
+// acquire_hub_lock is re-exported for test helpers in compaction and shared_writer.
+// In production code, callers acquire the lock via SyncManager::acquire_lock().
+#[cfg(test)]
+pub use self::cache::acquire_hub_lock;
 pub use self::core::SyncManager;
 pub use self::locks::LockMode;
 

--- a/crosslink/src/sync/tests.rs
+++ b/crosslink/src/sync/tests.rs
@@ -882,7 +882,7 @@ fn test_read_tracker_remote_single_non_origin_remote() {
     let crosslink_dir = dir.path().join(".crosslink");
     std::fs::create_dir_all(&crosslink_dir).unwrap();
     // hook-config.json exists but has no tracker_remote field
-    std::fs::write(crosslink_dir.join("hook-config.json"), r#"{}"#).unwrap();
+    std::fs::write(crosslink_dir.join("hook-config.json"), "{}").unwrap();
 
     let remote = read_tracker_remote(&crosslink_dir);
     assert_eq!(

--- a/crosslink/src/utils.rs
+++ b/crosslink/src/utils.rs
@@ -119,28 +119,78 @@ pub fn is_windows_reserved_name(name: &str) -> bool {
     )
 }
 
-/// Atomically write content to a file by writing to a temporary file first,
-/// then renaming. This prevents corrupted files from interrupted writes.
+/// Atomically write content to a file using a unique temp file + fsync + rename.
+///
+/// Uses [`tempfile::Builder`] to create a uniquely-named temp file in the same
+/// directory as `path`, which prevents two concurrent writers from corrupting
+/// each other's temp file (the old fixed-name `.{basename}.tmp` approach). The
+/// file is fsynced before the rename so a crash between write and rename does
+/// not leave a half-populated target. On Unix, the parent directory is also
+/// fsynced after the rename so the directory entry itself is durable; that step
+/// is best-effort (WARN on failure) because some filesystems (e.g. BTRFS)
+/// reject directory fsync without degrading data safety.
+///
+/// Orphaned `.{basename}.XXXXXX.tmp` files can be left if the process crashes
+/// between temp-file creation and `persist`. The hub cache `.gitignore` covers
+/// `/.*.tmp` so these are never committed (see `ensure_hub_gitignore`).
 ///
 /// # Errors
 ///
-/// Returns an error if writing the temporary file or renaming it fails.
+/// Returns an error if creating the temp file, writing, fsyncing, or persisting fails.
 pub fn atomic_write(path: &std::path::Path, content: &[u8]) -> anyhow::Result<()> {
     use anyhow::Context;
+    use std::io::Write;
+
     let parent = path.parent().unwrap_or_else(|| std::path::Path::new("."));
-    let tmp_path = parent.join(format!(
-        ".{}.tmp",
-        path.file_name().and_then(|n| n.to_str()).unwrap_or("file")
-    ));
-    std::fs::write(&tmp_path, content)
-        .with_context(|| format!("Failed to write temp file: {}", tmp_path.display()))?;
-    std::fs::rename(&tmp_path, path).with_context(|| {
-        format!(
-            "Failed to rename {} to {}",
-            tmp_path.display(),
-            path.display()
+    let basename = path.file_name().and_then(|n| n.to_str()).unwrap_or("file");
+
+    let mut tmp = tempfile::Builder::new()
+        .prefix(&format!(".{basename}."))
+        .suffix(".tmp")
+        .tempfile_in(parent)
+        .with_context(|| format!("Failed to create temp file in {}", parent.display()))?;
+
+    tmp.as_file_mut()
+        .write_all(content)
+        .with_context(|| format!("Failed to write temp file for {}", path.display()))?;
+
+    tmp.as_file()
+        .sync_all()
+        .with_context(|| format!("Failed to fsync temp file for {}", path.display()))?;
+
+    tmp.persist(path).map_err(|e| {
+        anyhow::anyhow!(
+            "Failed to rename temp file to {}: {}",
+            path.display(),
+            e.error
         )
     })?;
+
+    // Best-effort: fsync the parent directory so the rename itself is durable.
+    // Failure here is not fatal — the file-level fsync above already ensures
+    // the content is durable; directory-entry durability depends on the FS.
+    #[cfg(unix)]
+    {
+        match std::fs::File::open(parent) {
+            Ok(dir) => {
+                if let Err(e) = dir.sync_all() {
+                    tracing::warn!(
+                        "failed to fsync parent dir {} after atomic write: {}",
+                        parent.display(),
+                        e
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "failed to open parent dir {} for fsync: {}",
+                    parent.display(),
+                    e
+                );
+            }
+        }
+    }
+
     Ok(())
 }
 
@@ -632,5 +682,61 @@ mod tests {
     #[test]
     fn test_parse_date_rejects_invalid_day() {
         assert!(parse_due_date("2026-02-31").is_err());
+    }
+
+    /// Two threads concurrently writing to the same target path must not
+    /// interleave bytes. After all iterations, the file must parse as the
+    /// complete JSON content of exactly one writer.
+    ///
+    /// This exercises the fix for the fixed-name temp file race where two
+    /// concurrent `atomic_write` calls would share the same `.{name}.tmp`
+    /// path and corrupt each other's content before the rename.
+    #[test]
+    fn test_atomic_write_concurrent_no_interleaving() {
+        use std::sync::Arc;
+
+        let dir = tempdir().unwrap();
+        let target = Arc::new(dir.path().join("shared.json"));
+
+        // Two JSON payloads that are distinguishable and large enough to
+        // expose byte-level interleaving if it occurs.
+        let payload_a = serde_json::json!({"writer": "A", "data": "a".repeat(4096)})
+            .to_string()
+            .into_bytes();
+        let payload_b = serde_json::json!({"writer": "B", "data": "b".repeat(4096)})
+            .to_string()
+            .into_bytes();
+
+        let payload_a = Arc::new(payload_a);
+        let payload_b = Arc::new(payload_b);
+
+        const ITERATIONS: usize = 50;
+
+        for _ in 0..ITERATIONS {
+            let path_a = Arc::clone(&target);
+            let path_b = Arc::clone(&target);
+            let pa = Arc::clone(&payload_a);
+            let pb = Arc::clone(&payload_b);
+
+            let t_a = std::thread::spawn(move || {
+                atomic_write(&path_a, &pa).expect("atomic_write A failed");
+            });
+            let t_b = std::thread::spawn(move || {
+                atomic_write(&path_b, &pb).expect("atomic_write B failed");
+            });
+
+            t_a.join().expect("thread A panicked");
+            t_b.join().expect("thread B panicked");
+
+            // The file must be valid JSON whose content is wholly A or wholly B.
+            let raw = std::fs::read(&*target).expect("target file missing");
+            let v: serde_json::Value =
+                serde_json::from_slice(&raw).expect("file is not valid JSON (interleaved bytes)");
+            let writer = v["writer"].as_str().expect("missing writer field");
+            assert!(
+                writer == "A" || writer == "B",
+                "unexpected writer field: {writer}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Four fixes for hub-sync corruption vectors found in an audit of the hub system (crosslink issue #750), plus the hub v3 design doc for the longer-term per-agent-refs migration.

1. **`utils::atomic_write` non-unique temp name** — used a fixed `.{basename}.tmp` path, so two concurrent writers to the same target (`counters.json`, checkpoint state) interleaved bytes in the same temp file and the rename published garbage JSON. Now uses `tempfile::Builder` for unique names, fsyncs before persist, best-effort parent-dir fsync. Hub cache gitignore self-heal extended to `.*.tmp` so crash-orphaned temps are never committed.
2. **Live-holder lock steal** — `acquire_hub_lock` force-removed the write lock after 30s even when the holder PID was alive, letting two processes mutate the hub worktree concurrently after any slow (>30s) hub operation. Now bails with an actionable error naming the holder PID; only dead/unreadable holders are removed.
3. **Disjoint lock domains** — `compaction::compact` materialized files under only `checkpoint/compaction.lock`, disjoint from the `.hub-write-lock` serializing git operations, so standalone `crosslink compact` could race a concurrent `write_commit_push`. `compact()` now requires `&HubWriteLock` as compile-time proof the caller holds the process mutex; `commands/compact.rs` acquires it and holds it through re-hydration. Doc comment explains the two-lock model (cross-machine lease vs. same-machine mutex).
4. **Non-atomic `rewrite_as_offline`** — wrote issue JSON via `std::fs::write` (open-truncate-write), the same crash-truncation class fixed in GH#604. Now uses `atomic_write`.

Also includes `.design/hub-v3-per-agent-refs.md`: the architecture for eliminating these failure classes structurally (per-agent refs, always-fast-forward pushes, pure event sourcing, removal of `counters.json`/`locks.json`, 4-PR migration plan).

## Notes for review

- Three pre-existing pedantic clippy findings were fixed to keep the `-D warnings` gate clean: `mul_add` in `findings.rs` (negligible float-rounding change to review similarity scores), doc backticks in `integrity_drift.rs`, raw string in `sync/tests.rs`. Flag if you would rather these revert.
- A stale "Deprecated alias" doc comment in `sync/mod.rs` (mis-attached on develop, leftover from a deleted alias) was replaced with a correct doc for the new `HubWriteLock` re-export.

## Testing

- `cargo fmt --check` clean, `cargo clippy --all-targets -- -D warnings` clean.
- `cargo test --lib`: 1906 passed, 0 failed.
- New regression tests: concurrent `atomic_write` to one target across 50 iterations (no byte interleaving), and live-holder lock acquisition timing out with the holder PID in the error and the lock file intact.

Generated with [Claude Code](https://claude.com/claude-code)