### PR TITLE
feat(hub): migrate hub-v3 command, RefHubSource read path, version detection

### DIFF
--- a/crosslink/src/commands/migrate_hub_v3.rs
+++ b/crosslink/src/commands/migrate_hub_v3.rs
@@ -1,0 +1,1760 @@
+//! `crosslink migrate hub-v3` — one-shot conversion of a v2 hub into the v3
+//! per-agent-ref layout (`.design/hub-v3-per-agent-refs.md`, REQ-9).
+//!
+//! # Flow (Phase A — `migrate hub-v3`)
+//!
+//! 1. Preflight: init + fetch the hub cache, hold the hub write lock for the
+//!    whole migration, refuse cleanly on no-cache / already-migrated / pending
+//!    offline promotions.
+//! 2. Force a compaction so v2 state is fully reduced and the watermark embedded.
+//! 3. Build the GENESIS [`CheckpointState`] FROM THE FILES (authoritative
+//!    materialized state) — independent of the event reducer.
+//! 4. Record pre-existing tips of every `refs/crosslink/*` ref (for rollback),
+//!    seed per-agent refs from each v2 `events.log`, commit the genesis
+//!    checkpoint, and write the meta marker.
+//! 5. AC-6 verification gate: reduce a fresh [`RefHubSource`] and compare it
+//!    field-complete against the files + invariants.
+//! 6. On any failure: roll back every `refs/crosslink/*` ref to its recorded
+//!    pre-migration tip (the v2 branch is never touched).
+//! 7. On success: push all created/updated refs and print the cutover next step.
+//!
+//! # Flow (Phase B — `migrate hub-v3 --finalize --yes-delete-v2`)
+//!
+//! Re-verifies, then deletes the legacy `crosslink/hub` branch local + remote
+//! and stamps `HubMeta.finalized_at`. This is the only hard stop for already
+//! deployed v2 binaries.
+//!
+//! # Deterministic UUIDs
+//!
+//! V1 inline comments and time entries carry an `i64` id but no uuid. The
+//! genesis builder derives a stable uuid via
+//! `Uuid::from_bytes(sha256(canonical)[0..16])` where `canonical` is
+//! `"crosslink-hub-v3:<kind>:<issue_uuid>:<i64-id>"`. The scheme is stable
+//! across re-runs (no randomness) and disjoint across kinds.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{bail, Context, Result};
+use chrono::Utc;
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use crate::checkpoint::{
+    CheckpointState, CompactComment, CompactIssue, CompactMilestone, CompactTimeEntry,
+};
+use crate::compaction;
+use crate::events::OrderingKey;
+use crate::hub_source::RefHubSource;
+use crate::hub_v3::{
+    self, agent_ref_name, read_hub_meta, HubMeta, HubVersion, PushOutcome, CHECKPOINT_REF, META_REF,
+};
+use crate::issue_file::{
+    read_all_issue_files, read_all_milestone_files, read_comment_files, read_counters, IssueFile,
+};
+use crate::sync::SyncManager;
+
+/// Legacy v2 hub branch name (matches `hub_v3::V2_HUB_BRANCH`).
+const V2_HUB_BRANCH: &str = "refs/heads/crosslink/hub";
+
+// ── Public entry points ──────────────────────────────────────────────
+
+/// `crosslink migrate hub-v3 [--finalize --yes-delete-v2]`.
+///
+/// Dispatches to Phase A (migrate) or Phase B (finalize) based on `finalize`.
+///
+/// # Errors
+///
+/// Returns an error if preflight refuses, a git plumbing step fails, or the
+/// AC-6 verification gate fails (after a rollback).
+pub fn hub_v3(crosslink_dir: &Path, finalize: bool, yes_delete_v2: bool) -> Result<()> {
+    let sync = SyncManager::new(crosslink_dir)?;
+    sync.init_cache()?;
+    sync.fetch()?;
+
+    // Hold the hub write lock for the whole migration: it mutates ref state and
+    // must serialize against every other hub read-modify-write (REQ-8).
+    let hub_lock = sync.acquire_lock()?;
+
+    let cache_dir = sync.cache_path().to_path_buf();
+    let remote = sync.remote().to_string();
+
+    if finalize {
+        finalize_migration(&cache_dir, &remote, yes_delete_v2, &hub_lock)
+    } else {
+        migrate_phase_a(crosslink_dir, &cache_dir, &remote, &hub_lock)
+    }
+}
+
+// ── Phase A: migrate ─────────────────────────────────────────────────
+
+fn migrate_phase_a(
+    crosslink_dir: &Path,
+    cache_dir: &Path,
+    remote: &str,
+    hub_lock: &crate::sync::HubWriteLock,
+) -> Result<()> {
+    // Preflight: refuse when there is no hub cache to migrate.
+    if !cache_dir.exists() {
+        bail!(
+            "no hub cache at {} — nothing to migrate (run `crosslink sync` first, \
+             or this repo has no shared hub)",
+            cache_dir.display()
+        );
+    }
+
+    // Idempotent no-op: already migrated. Re-attempt pushing any refs the remote
+    // lacks (re-run is the retry mechanism), then print the marker and exit Ok.
+    match hub_v3::detect_hub_version(cache_dir)? {
+        HubVersion::V3 { .. } => {
+            println!("hub already migrated to v3 — no migration performed.");
+            if let Some(meta) = read_hub_meta(cache_dir)? {
+                print_hub_meta(&meta);
+            }
+            retry_push_missing_refs(cache_dir, remote)?;
+            print_mixed_version_warning();
+            return Ok(());
+        }
+        HubVersion::Absent => {
+            bail!(
+                "no v2 hub detected at {} (neither a crosslink/hub branch nor v3 marker refs) — \
+                 nothing to migrate",
+                cache_dir.display()
+            );
+        }
+        HubVersion::V2Only => {}
+    }
+
+    // Refuse when pending offline issues exist — their display IDs are not yet
+    // claimed, so a genesis built now would freeze provisional state. Sync first.
+    let pending = find_pending_offline(cache_dir)?;
+    if !pending.is_empty() {
+        let names: Vec<String> = pending
+            .iter()
+            .map(|i| format!("  {} (\"{}\")", i.uuid, i.title))
+            .collect();
+        bail!(
+            "refusing to migrate: {} offline issue(s) have no display_id yet (pending promotion). \
+             Run `crosslink sync` to promote and publish them first, then re-run the migration.\n{}",
+            pending.len(),
+            names.join("\n")
+        );
+    }
+
+    // Force a compaction so v2 state is fully reduced and the watermark embedded.
+    let agent_id = crate::identity::AgentConfig::load(crosslink_dir)?
+        .map_or_else(|| "hub-v3-migrate".to_string(), |a| a.agent_id);
+    compaction::compact(cache_dir, &agent_id, true, hub_lock)
+        .context("forced pre-migration compaction failed")?;
+
+    // Build the authoritative genesis state from the files.
+    let genesis = build_genesis_from_files(cache_dir)?;
+
+    // Record the v2 hub tip for provenance and rollback awareness.
+    let v2_tip = git_rev_parse(cache_dir, V2_HUB_BRANCH)?
+        .ok_or_else(|| anyhow::anyhow!("crosslink/hub branch vanished mid-migration"))?;
+
+    // Snapshot every refs/crosslink/* tip for rollback (these are the only refs
+    // the migration touches; the v2 branch is never modified).
+    let pre_tips = snapshot_crosslink_refs(cache_dir)?;
+
+    // Seed agent refs + checkpoint + meta. Any failure here triggers rollback.
+    let seed_result = seed_v3_refs(cache_dir, &genesis, &v2_tip);
+    let seeded = match seed_result {
+        Ok(s) => s,
+        Err(e) => {
+            rollback_refs(cache_dir, &pre_tips)?;
+            return Err(e.context("migration seeding failed; rolled back all refs/crosslink/*"));
+        }
+    };
+
+    // AC-6 verification gate against the freshly written refs.
+    let report = match verify_against_files(cache_dir, &genesis) {
+        Ok(r) => r,
+        Err(e) => {
+            rollback_refs(cache_dir, &pre_tips)?;
+            return Err(e.context(
+                "AC-6 verification gate failed; rolled back all refs/crosslink/* \
+                 (the crosslink/hub branch was never touched)",
+            ));
+        }
+    };
+
+    // Local migration is complete and verified. Push refs (failures are
+    // reported per-ref but do NOT roll back local state — re-run retries pushes).
+    let push_summary = push_v3_refs(cache_dir, remote, &seeded);
+
+    print_phase_a_summary(&seeded, &genesis, &report, &push_summary);
+    print_mixed_version_warning();
+    Ok(())
+}
+
+// ── Genesis construction ─────────────────────────────────────────────
+
+/// Per-issue layout location, used to find inline vs. separate comments.
+struct IssueLayout {
+    /// Inline comments (V1 flat layout) carried on the `IssueFile`.
+    inline_comments: Vec<crate::issue_file::CommentEntry>,
+    /// Directory holding separate comment files (V2 layout), if it exists.
+    comments_dir: Option<PathBuf>,
+}
+
+/// Build the genesis [`CheckpointState`] from the materialized files.
+///
+/// This is the authoritative materialized state, independent of the event
+/// reducer. It reads every issue file (both layouts), comment files / inline
+/// comments, time entries, milestones, and counters, plus the freshly compacted
+/// checkpoint's lock state, and embeds a watermark equal to the max
+/// [`OrderingKey`] across ALL v2 agent logs so v3 readers apply nothing
+/// pre-genesis.
+fn build_genesis_from_files(cache_dir: &Path) -> Result<CheckpointState> {
+    let issues_dir = cache_dir.join("issues");
+    let issue_files = read_all_issue_files(&issues_dir)?;
+
+    let mut issues: BTreeMap<Uuid, CompactIssue> = BTreeMap::new();
+    let mut display_id_map: BTreeMap<Uuid, i64> = BTreeMap::new();
+    let mut max_display_id: i64 = 0;
+    let mut max_comment_id: i64 = 0;
+
+    // Detect duplicate display_id claims across issue files — corrupt v2 state
+    // must be repaired (via integrity), not silently remapped.
+    let mut display_id_owner: BTreeMap<i64, Uuid> = BTreeMap::new();
+
+    for issue in &issue_files {
+        if let Some(did) = issue.display_id {
+            if let Some(prev) = display_id_owner.insert(did, issue.uuid) {
+                bail!(
+                    "duplicate display_id #{did} claimed by two issues ({prev} and {}); \
+                     refusing to migrate — repair the v2 hub first \
+                     (`crosslink integrity` / `crosslink compact`)",
+                    issue.uuid
+                );
+            }
+            display_id_map.insert(issue.uuid, did);
+            max_display_id = max_display_id.max(did);
+        }
+
+        let layout = issue_layout(&issues_dir, issue);
+        let (comments, comment_max) = build_comments(issue.uuid, issue, &layout)?;
+        max_comment_id = max_comment_id.max(comment_max);
+        let time_entries = build_time_entries(issue.uuid, issue);
+
+        let compact = CompactIssue {
+            uuid: issue.uuid,
+            display_id: issue.display_id,
+            title: issue.title.clone(),
+            description: issue.description.clone(),
+            status: issue.status,
+            priority: issue.priority,
+            parent_uuid: issue.parent_uuid,
+            created_by: issue.created_by.clone(),
+            created_at: issue.created_at,
+            updated_at: issue.updated_at,
+            closed_at: issue.closed_at,
+            scheduled_at: issue.scheduled_at,
+            due_at: issue.due_at,
+            labels: issue.labels.iter().cloned().collect(),
+            blockers: issue.blockers.iter().copied().collect(),
+            related: issue.related.iter().copied().collect(),
+            milestone_uuid: issue.milestone_uuid,
+            comments,
+            time_entries,
+        };
+        issues.insert(issue.uuid, compact);
+    }
+
+    // Milestones from meta/milestones/{uuid}.json.
+    let milestones_dir = cache_dir.join("meta").join("milestones");
+    let milestone_files = read_all_milestone_files(&milestones_dir)?;
+    let mut milestones: BTreeMap<Uuid, CompactMilestone> = BTreeMap::new();
+    let mut max_milestone_id: i64 = 0;
+    for ms in &milestone_files {
+        max_milestone_id = max_milestone_id.max(ms.display_id);
+        milestones.insert(
+            ms.uuid,
+            CompactMilestone {
+                uuid: ms.uuid,
+                display_id: Some(ms.display_id),
+                name: ms.name.clone(),
+                description: ms.description.clone(),
+                status: ms.status,
+                created_at: ms.created_at,
+                closed_at: ms.closed_at,
+            },
+        );
+    }
+
+    // Locks from the freshly compacted checkpoint (lock state is event-authoritative).
+    let locks = crate::checkpoint::read_checkpoint(cache_dir)?.locks;
+
+    // Counters: max(counters.json values, on-disk maxima + 1).
+    let counters = read_counters(&cache_dir.join("meta").join("counters.json"))?;
+    let next_display_id = counters.next_display_id.max(max_display_id + 1);
+    let next_comment_id = counters.next_comment_id.max(max_comment_id + 1);
+    let next_milestone_id = counters.next_milestone_id.max(max_milestone_id + 1);
+
+    // Watermark: max OrderingKey across ALL v2 agent logs, so the v3 read path
+    // applies nothing pre-genesis. When no events exist anywhere, synthesize a
+    // genesis-moment sentinel so the watermark is ALWAYS Some — a None watermark
+    // would make reduce() RESET the genesis state to default (see compaction::reduce).
+    let watermark = max_event_ordering_key(cache_dir)?.unwrap_or_else(genesis_sentinel_watermark);
+
+    Ok(CheckpointState {
+        next_display_id,
+        next_comment_id,
+        display_id_map,
+        locks,
+        issues,
+        milestones,
+        deleted_issues: BTreeSet::new(),
+        next_milestone_id,
+        skew_warnings: Vec::new(),
+        compaction_lease: None,
+        unsigned_event_warnings: Vec::new(),
+        watermark: Some(watermark),
+    })
+}
+
+/// Deterministic sentinel watermark used when the v2 hub has NO events at all.
+///
+/// `reduce()` RESETS state to default when the watermark is `None`, so the
+/// genesis watermark must always be `Some`. With zero events, any fixed key
+/// works (there is nothing to compare it against), and it MUST be deterministic
+/// so the two independent genesis builds (write + verify) agree byte-for-byte.
+/// The fixed epoch timestamp + sentinel agent id guarantees stability across
+/// re-runs.
+fn genesis_sentinel_watermark() -> OrderingKey {
+    OrderingKey {
+        timestamp: chrono::DateTime::<Utc>::UNIX_EPOCH,
+        agent_id: "hub-v3-genesis".to_string(),
+        agent_seq: 0,
+    }
+}
+
+/// Resolve the comment layout for an issue: inline (V1) plus an optional
+/// separate comments directory (V2 `issues/{uuid}/comments/`).
+fn issue_layout(issues_dir: &Path, issue: &IssueFile) -> IssueLayout {
+    let v2_comments = issues_dir.join(issue.uuid.to_string()).join("comments");
+    let comments_dir = if v2_comments.is_dir() {
+        Some(v2_comments)
+    } else {
+        None
+    };
+    IssueLayout {
+        inline_comments: issue.comments.clone(),
+        comments_dir,
+    }
+}
+
+/// Build the comment map for an issue and return `(map, max_comment_display_id)`.
+///
+/// V2 comment files carry their own uuid (used directly). V1 inline comments
+/// lack a uuid — a deterministic uuid is derived from the issue uuid + the
+/// comment's i64 id via [`derive_uuid`].
+fn build_comments(
+    issue_uuid: Uuid,
+    issue: &IssueFile,
+    layout: &IssueLayout,
+) -> Result<(BTreeMap<Uuid, CompactComment>, i64)> {
+    let mut map: BTreeMap<Uuid, CompactComment> = BTreeMap::new();
+    let mut max_id: i64 = 0;
+
+    // V2 separate comment files (uuid-keyed natively).
+    if let Some(dir) = &layout.comments_dir {
+        for cf in read_comment_files(dir)? {
+            map.insert(
+                cf.uuid,
+                CompactComment {
+                    display_id: None,
+                    author: cf.author,
+                    content: cf.content,
+                    created_at: cf.created_at,
+                    kind: cf.kind,
+                    trigger_type: cf.trigger_type,
+                    intervention_context: cf.intervention_context,
+                    driver_key_fingerprint: cf.driver_key_fingerprint,
+                    signed_by: cf.signed_by,
+                    signature: cf.signature,
+                },
+            );
+        }
+    }
+
+    // V1 inline comments (derive deterministic uuids from issue uuid + i64 id).
+    let _ = issue; // inline comments already captured on the layout
+    for ce in &layout.inline_comments {
+        max_id = max_id.max(ce.id);
+        let cuuid = derive_uuid("comment", issue_uuid, ce.id);
+        map.entry(cuuid).or_insert_with(|| CompactComment {
+            display_id: Some(ce.id),
+            author: ce.author.clone(),
+            content: ce.content.clone(),
+            created_at: ce.created_at,
+            kind: ce.kind.clone(),
+            trigger_type: ce.trigger_type.clone(),
+            intervention_context: ce.intervention_context.clone(),
+            driver_key_fingerprint: ce.driver_key_fingerprint.clone(),
+            signed_by: ce.signed_by.clone(),
+            signature: ce.signature.clone(),
+        });
+    }
+
+    Ok((map, max_id))
+}
+
+/// Build the time-entry map for an issue. V1 inline time entries carry an i64
+/// id but no uuid — a deterministic uuid is derived from the issue uuid + id.
+fn build_time_entries(issue_uuid: Uuid, issue: &IssueFile) -> BTreeMap<Uuid, CompactTimeEntry> {
+    let mut map: BTreeMap<Uuid, CompactTimeEntry> = BTreeMap::new();
+    for te in &issue.time_entries {
+        let tuuid = derive_uuid("time-entry", issue_uuid, te.id);
+        map.entry(tuuid).or_insert_with(|| CompactTimeEntry {
+            display_id: Some(te.id),
+            started_at: te.started_at,
+            ended_at: te.ended_at,
+            duration_seconds: te.duration_seconds,
+        });
+    }
+    map
+}
+
+/// Derive a deterministic uuid for an inline (uuid-less) V1 sub-entity.
+///
+/// `Uuid::from_bytes(sha256("crosslink-hub-v3:<kind>:<issue_uuid>:<id>")[0..16])`.
+/// No randomness, so the same inputs always yield the same uuid across re-runs.
+fn derive_uuid(kind: &str, issue_uuid: Uuid, id: i64) -> Uuid {
+    let canonical = format!("crosslink-hub-v3:{kind}:{issue_uuid}:{id}");
+    let digest = Sha256::digest(canonical.as_bytes());
+    let mut bytes = [0u8; 16];
+    bytes.copy_from_slice(&digest[0..16]);
+    Uuid::from_bytes(bytes)
+}
+
+/// Compute the maximum [`OrderingKey`] across every v2 agent event log.
+///
+/// Returns `None` when no agent log contains any event.
+fn max_event_ordering_key(cache_dir: &Path) -> Result<Option<OrderingKey>> {
+    let agents_dir = cache_dir.join("agents");
+    let mut max_key: Option<OrderingKey> = None;
+    if !agents_dir.exists() {
+        return Ok(None);
+    }
+    for entry in std::fs::read_dir(&agents_dir)
+        .with_context(|| format!("failed to read agents dir {}", agents_dir.display()))?
+    {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let log_path = entry.path().join("events.log");
+        if !log_path.exists() {
+            continue;
+        }
+        let events = crate::events::read_events(&log_path)?;
+        for ev in &events {
+            let key = OrderingKey::from_envelope(ev);
+            match &max_key {
+                Some(m) if *m >= key => {}
+                _ => max_key = Some(key),
+            }
+        }
+    }
+    Ok(max_key)
+}
+
+// ── Ref seeding ──────────────────────────────────────────────────────
+
+/// Summary of what `seed_v3_refs` created/updated, used for push + reporting.
+struct SeededRefs {
+    /// Agent IDs whose per-agent ref was seeded.
+    agents: Vec<String>,
+    /// Whether the checkpoint ref was written.
+    checkpoint_written: bool,
+    /// Whether the meta ref was written.
+    meta_written: bool,
+}
+
+/// Seed per-agent refs from v2 event logs, commit the genesis checkpoint, and
+/// write the meta marker. The v2 branch is never touched.
+fn seed_v3_refs(cache_dir: &Path, genesis: &CheckpointState, v2_tip: &str) -> Result<SeededRefs> {
+    // 1. Per-agent refs from each v2 agents/<id>/events.log (byte-superset by the
+    //    dual-write parity invariant; child-commit over any existing shadow tip).
+    let agents_dir = cache_dir.join("agents");
+    let mut agents = Vec::new();
+    if agents_dir.exists() {
+        for entry in std::fs::read_dir(&agents_dir)
+            .with_context(|| format!("failed to read agents dir {}", agents_dir.display()))?
+        {
+            let entry = entry?;
+            if !entry.file_type()?.is_dir() {
+                continue;
+            }
+            let Some(agent_id) = entry.file_name().to_str().map(str::to_string) else {
+                continue;
+            };
+            let log_path = entry.path().join("events.log");
+            if !log_path.exists() {
+                continue;
+            }
+            let log_bytes = std::fs::read(&log_path)
+                .with_context(|| format!("failed to read {}", log_path.display()))?;
+            if log_bytes.is_empty() {
+                continue;
+            }
+            hub_v3::commit_log_bytes(
+                cache_dir,
+                &agent_id,
+                &log_bytes,
+                &format!("hub-v3 genesis: seed agent {agent_id} from v2 events.log"),
+            )
+            .with_context(|| format!("failed to seed agent ref for '{agent_id}'"))?;
+            agents.push(agent_id);
+        }
+    }
+    agents.sort();
+
+    // 2. Genesis checkpoint state.json onto CHECKPOINT_REF.
+    let state_bytes = serde_json::to_vec_pretty(genesis)
+        .context("failed to serialize genesis checkpoint state")?;
+    hub_v3::commit_blob_to_ref(
+        cache_dir,
+        CHECKPOINT_REF,
+        "state.json",
+        &state_bytes,
+        "hub-v3 genesis: checkpoint state",
+    )
+    .context("failed to commit genesis checkpoint")?;
+
+    // 3. META_REF: hub.json + allowed_signers (when present).
+    let meta = HubMeta {
+        hub_version: 3,
+        migrated_from_commit: v2_tip.to_string(),
+        migrated_at: Utc::now(),
+        finalized_at: None,
+    };
+    let hub_json = serde_json::to_vec_pretty(&meta).context("failed to serialize HubMeta")?;
+
+    let signers_path = cache_dir.join("trust").join("allowed_signers");
+    let signers_bytes = if signers_path.exists() {
+        Some(
+            std::fs::read(&signers_path)
+                .with_context(|| format!("failed to read {}", signers_path.display()))?,
+        )
+    } else {
+        None
+    };
+
+    let mut files: Vec<(&str, &[u8])> = vec![("hub.json", &hub_json)];
+    if let Some(bytes) = &signers_bytes {
+        files.push(("allowed_signers", bytes));
+    }
+    hub_v3::commit_files_to_ref(cache_dir, META_REF, &files, "hub-v3 genesis: meta marker")
+        .context("failed to commit meta marker")?;
+
+    Ok(SeededRefs {
+        agents,
+        checkpoint_written: true,
+        meta_written: true,
+    })
+}
+
+// ── AC-6 verification gate ───────────────────────────────────────────
+
+/// Per-category counts checked by the verification gate.
+struct VerifyReport {
+    issues: usize,
+    comments: usize,
+    milestones: usize,
+    locks: usize,
+}
+
+/// AC-6 gate: reduce a fresh [`RefHubSource`] over the new refs and compare it
+/// field-complete against the genesis (rebuilt independently from the files),
+/// AND assert the file-level invariants directly to avoid symmetric-bug
+/// blindness.
+fn verify_against_files(cache_dir: &Path, genesis: &CheckpointState) -> Result<VerifyReport> {
+    // Independent re-read of the files (a second genesis build).
+    let rebuilt = build_genesis_from_files(cache_dir)?;
+
+    // reduce(RefHubSource) must yield the genesis state unchanged (the watermark
+    // covers every seeded event, so nothing is re-applied).
+    let source = RefHubSource::new(cache_dir)?;
+    let outcome = compaction::reduce(&source)?;
+    let reduced = &outcome.state;
+
+    // 1. Whole-state field-complete equality, both directions.
+    let genesis_val = serde_json::to_value(genesis).context("serialize genesis")?;
+    let rebuilt_val = serde_json::to_value(&rebuilt).context("serialize rebuilt genesis")?;
+    let reduced_val = serde_json::to_value(reduced).context("serialize reduced state")?;
+    if genesis_val != rebuilt_val {
+        bail!("verification failed: independent file re-read disagrees with genesis state");
+    }
+    if reduced_val != genesis_val {
+        bail!(
+            "verification failed: reduce(RefHubSource) does not equal the genesis state \
+             (events were applied above/around the watermark, or a ref is wrong)"
+        );
+    }
+
+    // 2. Direct invariants against the files (not symmetric with the builder).
+    let issues_dir = cache_dir.join("issues");
+    let issue_files = read_all_issue_files(&issues_dir)?;
+
+    // Issue count equality.
+    if issue_files.len() != reduced.issues.len() {
+        bail!(
+            "verification failed: issue count mismatch (files {}, reduced {})",
+            issue_files.len(),
+            reduced.issues.len()
+        );
+    }
+
+    let mut comment_total = 0usize;
+    let mut display_ids_seen: BTreeSet<i64> = BTreeSet::new();
+    for issue in &issue_files {
+        // Every issue file uuid is present in the reduced state.
+        let Some(reduced_issue) = reduced.issues.get(&issue.uuid) else {
+            bail!(
+                "verification failed: issue {} present on disk but missing from reduced state",
+                issue.uuid
+            );
+        };
+
+        // Per-issue serde_json equality of CompactIssue against the genesis.
+        let g = genesis
+            .issues
+            .get(&issue.uuid)
+            .ok_or_else(|| anyhow::anyhow!("genesis missing issue {}", issue.uuid))?;
+        if serde_json::to_value(g)? != serde_json::to_value(reduced_issue)? {
+            bail!(
+                "verification failed: issue {} differs between genesis and reduced state",
+                issue.uuid
+            );
+        }
+
+        // Display-id uniqueness across issue files.
+        if let Some(did) = issue.display_id {
+            if !display_ids_seen.insert(did) {
+                bail!("verification failed: duplicate display_id #{did} across issue files");
+            }
+        }
+
+        // Comment count per issue matches the comment files / inline comments.
+        let layout = issue_layout(&issues_dir, issue);
+        let on_disk_comments = count_disk_comments(issue, &layout)?;
+        if on_disk_comments != reduced_issue.comments.len() {
+            bail!(
+                "verification failed: comment count mismatch for issue {} (disk {on_disk_comments}, \
+                 reduced {})",
+                issue.uuid,
+                reduced_issue.comments.len()
+            );
+        }
+        comment_total += on_disk_comments;
+    }
+
+    // Milestone count matches the milestone files.
+    let milestones_dir = cache_dir.join("meta").join("milestones");
+    let milestone_files = read_all_milestone_files(&milestones_dir)?;
+    if milestone_files.len() != reduced.milestones.len() {
+        bail!(
+            "verification failed: milestone count mismatch (files {}, reduced {})",
+            milestone_files.len(),
+            reduced.milestones.len()
+        );
+    }
+
+    // next_* >= on-disk maxima.
+    let counters = read_counters(&cache_dir.join("meta").join("counters.json"))?;
+    if reduced.next_display_id < counters.next_display_id
+        || reduced.next_milestone_id < counters.next_milestone_id
+        || reduced.next_comment_id < counters.next_comment_id
+    {
+        bail!("verification failed: next_* counters regressed below counters.json");
+    }
+
+    // Locks equal the compacted checkpoint's locks.
+    let compacted = crate::checkpoint::read_checkpoint(cache_dir)?;
+    if serde_json::to_value(&compacted.locks)? != serde_json::to_value(&reduced.locks)? {
+        bail!("verification failed: lock state differs from the compacted checkpoint");
+    }
+
+    Ok(VerifyReport {
+        issues: reduced.issues.len(),
+        comments: comment_total,
+        milestones: reduced.milestones.len(),
+        locks: reduced.locks.len(),
+    })
+}
+
+/// Count the comments on disk for an issue (V2 files + V1 inline, de-duplicated
+/// the same way the genesis builder does so the counts line up).
+fn count_disk_comments(issue: &IssueFile, layout: &IssueLayout) -> Result<usize> {
+    let mut keys: BTreeSet<Uuid> = BTreeSet::new();
+    if let Some(dir) = &layout.comments_dir {
+        for cf in read_comment_files(dir)? {
+            keys.insert(cf.uuid);
+        }
+    }
+    for ce in &issue.comments {
+        keys.insert(derive_uuid("comment", issue.uuid, ce.id));
+    }
+    Ok(keys.len())
+}
+
+// ── Ref snapshot / rollback ──────────────────────────────────────────
+
+/// Snapshot of a `refs/crosslink/*` ref's tip before migration.
+struct RefTip {
+    name: String,
+    /// `Some(sha)` if the ref existed before migration; `None` if it did not.
+    old_sha: Option<String>,
+}
+
+/// Record the current tip of every `refs/crosslink/*` ref. The set is the union
+/// of refs that exist now and the refs the migration is about to write, so that
+/// a ref created by the migration but absent before is rolled back by deletion.
+fn snapshot_crosslink_refs(cache_dir: &Path) -> Result<Vec<RefTip>> {
+    let mut names: BTreeSet<String> = BTreeSet::new();
+    for r in for_each_ref(cache_dir, "refs/crosslink/*")? {
+        names.insert(r);
+    }
+    // The refs the migration writes (so a newly-created one rolls back to absent).
+    names.insert(CHECKPOINT_REF.to_string());
+    names.insert(META_REF.to_string());
+    // Per-agent refs the migration may create.
+    let agents_dir = cache_dir.join("agents");
+    if agents_dir.exists() {
+        for entry in std::fs::read_dir(&agents_dir)?.flatten() {
+            if entry.file_type().is_ok_and(|t| t.is_dir()) {
+                if let Some(id) = entry.file_name().to_str() {
+                    if let Ok(name) = agent_ref_name(id) {
+                        names.insert(name);
+                    }
+                }
+            }
+        }
+    }
+
+    let mut tips = Vec::with_capacity(names.len());
+    for name in names {
+        let old_sha = git_rev_parse(cache_dir, &name)?;
+        tips.push(RefTip { name, old_sha });
+    }
+    Ok(tips)
+}
+
+/// Restore every recorded ref to its pre-migration tip: refs that existed are
+/// reset to their old sha, refs that did not exist are deleted. The v2 branch
+/// is never in this set, so it is never touched.
+fn rollback_refs(cache_dir: &Path, tips: &[RefTip]) -> Result<()> {
+    for tip in tips {
+        let current = git_rev_parse(cache_dir, &tip.name)?;
+        match (&tip.old_sha, &current) {
+            (Some(old), _) => {
+                // Restore to the old value (idempotent if already there).
+                git_update_ref(cache_dir, &tip.name, old)?;
+            }
+            (None, Some(_)) => {
+                // Did not exist before — delete what the migration created.
+                git_delete_ref(cache_dir, &tip.name)?;
+            }
+            (None, None) => {}
+        }
+    }
+    Ok(())
+}
+
+// ── Push ─────────────────────────────────────────────────────────────
+
+/// Per-ref push results, for reporting.
+struct PushSummary {
+    pushed: Vec<String>,
+    failed: Vec<(String, String)>,
+}
+
+/// Push every created/updated ref. Agent + meta refs use a plain fast-forward
+/// push; the checkpoint ref uses `--force-with-lease` (REQ-7). Failures are
+/// collected, not propagated (re-run is the retry mechanism).
+fn push_v3_refs(cache_dir: &Path, remote: &str, seeded: &SeededRefs) -> PushSummary {
+    let mut summary = PushSummary {
+        pushed: Vec::new(),
+        failed: Vec::new(),
+    };
+
+    let mut record = |name: String, outcome: Result<PushOutcome>| match outcome {
+        Ok(PushOutcome::Pushed) => summary.pushed.push(name),
+        Ok(PushOutcome::NonFastForward) => summary
+            .failed
+            .push((name, "non-fast-forward (remote diverged)".to_string())),
+        Ok(PushOutcome::NoRemote) => {
+            summary
+                .failed
+                .push((name, "remote not available".to_string()));
+        }
+        Ok(PushOutcome::Failed(e)) => summary.failed.push((name, e)),
+        Err(e) => summary.failed.push((name, e.to_string())),
+    };
+
+    for agent_id in &seeded.agents {
+        if let Ok(name) = agent_ref_name(agent_id) {
+            let outcome = hub_v3::push_ref(cache_dir, remote, &name);
+            record(name, outcome);
+        }
+    }
+    if seeded.meta_written {
+        let outcome = hub_v3::push_ref(cache_dir, remote, META_REF);
+        record(META_REF.to_string(), outcome);
+    }
+    if seeded.checkpoint_written {
+        let outcome = hub_v3::push_ref_with_lease(cache_dir, remote, CHECKPOINT_REF, None);
+        record(CHECKPOINT_REF.to_string(), outcome);
+    }
+
+    summary
+}
+
+/// On the already-migrated re-run path, push any v3 ref the remote lacks. This
+/// makes re-run the retry mechanism for an interrupted remote propagation.
+fn retry_push_missing_refs(cache_dir: &Path, remote: &str) -> Result<()> {
+    let local_refs = for_each_ref(cache_dir, "refs/crosslink/*")?;
+    if local_refs.is_empty() {
+        return Ok(());
+    }
+    let remote_shas = ls_remote_crosslink(cache_dir, remote).unwrap_or_default();
+
+    let mut retried = 0usize;
+    for name in &local_refs {
+        let local_sha = git_rev_parse(cache_dir, name)?;
+        let remote_sha = remote_shas.get(name);
+        if local_sha.as_deref() != remote_sha.map(String::as_str) {
+            let outcome = if name == CHECKPOINT_REF {
+                hub_v3::push_ref_with_lease(cache_dir, remote, name, None)
+            } else {
+                hub_v3::push_ref(cache_dir, remote, name)
+            };
+            match outcome {
+                Ok(PushOutcome::Pushed) => {
+                    println!("  re-pushed {name}");
+                    retried += 1;
+                }
+                Ok(PushOutcome::NoRemote) => return Ok(()),
+                Ok(other) => {
+                    tracing::warn!("re-run push of {name} did not complete: {other:?}");
+                }
+                Err(e) => tracing::warn!("re-run push of {name} failed: {e}"),
+            }
+        }
+    }
+    if retried > 0 {
+        println!("re-pushed {retried} ref(s) the remote was missing.");
+    }
+    Ok(())
+}
+
+// ── Phase B: finalize ────────────────────────────────────────────────
+
+fn finalize_migration(
+    cache_dir: &Path,
+    remote: &str,
+    yes_delete_v2: bool,
+    _hub_lock: &crate::sync::HubWriteLock,
+) -> Result<()> {
+    if !yes_delete_v2 {
+        bail!(
+            "`migrate hub-v3 --finalize` is destructive: it deletes the legacy crosslink/hub \
+             branch locally and on the remote. After finalize, already-deployed v2 binaries will \
+             FAIL LOUDLY (the branch they read is gone) — that is the intended hard stop. \
+             Re-run with `--yes-delete-v2` to confirm."
+        );
+    }
+
+    // Precondition: must already be v3.
+    match hub_v3::detect_hub_version(cache_dir)? {
+        HubVersion::V3 { v2_branch_present } => {
+            if !v2_branch_present {
+                println!("crosslink/hub branch already deleted — finalize is a no-op.");
+                if let Some(meta) = read_hub_meta(cache_dir)? {
+                    print_hub_meta(&meta);
+                }
+                return Ok(());
+            }
+        }
+        HubVersion::V2Only | HubVersion::Absent => {
+            bail!("refusing to finalize: hub is not v3 (run `crosslink migrate hub-v3` first)");
+        }
+    }
+
+    // Resolve the main repo root NOW, while the cache worktree still exists.
+    // After the worktree is removed, all ref operations must run from the repo
+    // root (which shares the same object store + ref namespace).
+    let repo_root = git_main_repo_root(cache_dir)?;
+
+    // Re-verify the AC-6 gate against the current refs/files: v2 and v3 must
+    // still agree. (fetch already ran in the dispatcher.)
+    let genesis = build_genesis_from_files(cache_dir)?;
+    verify_against_files(cache_dir, &genesis)
+        .context("refusing to finalize: AC-6 re-verification failed; v2 and v3 no longer agree")?;
+
+    // Stamp HubMeta.finalized_at (new commit on META_REF preserving provenance)
+    // BEFORE removing the worktree, while ref reads from cache_dir still work.
+    let mut meta = read_hub_meta(cache_dir)?
+        .ok_or_else(|| anyhow::anyhow!("v3 meta marker missing during finalize"))?;
+    meta.finalized_at = Some(Utc::now());
+    let hub_json = serde_json::to_vec_pretty(&meta).context("serialize finalized HubMeta")?;
+
+    // Preserve allowed_signers if the meta ref currently carries it.
+    let signers = read_meta_allowed_signers(cache_dir)?;
+    let mut files: Vec<(&str, &[u8])> = vec![("hub.json", &hub_json)];
+    if let Some(bytes) = &signers {
+        files.push(("allowed_signers", bytes));
+    }
+    hub_v3::commit_files_to_ref(
+        cache_dir,
+        META_REF,
+        &files,
+        "hub-v3 finalize: stamp finalized_at",
+    )
+    .context("failed to update meta marker with finalized_at")?;
+
+    // Now delete the local crosslink/hub branch + cache worktree, and push the
+    // deletion to the remote. All subsequent ref ops run from `repo_root`.
+    delete_v2_branch_local(cache_dir, &repo_root)?;
+    push_v2_branch_deletion(&repo_root, remote)?;
+
+    // Push the updated meta ref (best-effort, re-run retries) from the repo root.
+    match hub_v3::push_ref(&repo_root, remote, META_REF) {
+        Ok(PushOutcome::Pushed | PushOutcome::NoRemote) => {}
+        Ok(other) => tracing::warn!("finalize: meta ref push did not complete: {other:?}"),
+        Err(e) => tracing::warn!("finalize: meta ref push failed: {e}"),
+    }
+
+    println!("Finalized hub-v3 migration:");
+    println!("  deleted crosslink/hub branch (local + remote)");
+    println!(
+        "  HubMeta.finalized_at = {}",
+        meta.finalized_at.unwrap_or_else(Utc::now)
+    );
+    println!();
+    println!(
+        "Note: any already-deployed v0.5.x / v2 binary will now FAIL LOUDLY when it tries to \
+         read the deleted crosslink/hub branch. This is the intended hard cutover."
+    );
+    Ok(())
+}
+
+/// Read `allowed_signers` from the current `META_REF` tip, if present.
+fn read_meta_allowed_signers(cache_dir: &Path) -> Result<Option<Vec<u8>>> {
+    let Some(tip) = git_rev_parse(cache_dir, META_REF)? else {
+        return Ok(None);
+    };
+    let spec = format!("{tip}:allowed_signers");
+    git_cat_file_blob_optional(cache_dir, &spec)
+}
+
+/// Delete the local crosslink/hub branch. The branch is checked out in the hub
+/// cache worktree, so the worktree must be removed first (`git worktree remove`).
+/// `repo_root` is the main repository that owns the branch and object store.
+fn delete_v2_branch_local(cache_dir: &Path, repo_root: &Path) -> Result<()> {
+    // Remove the cache worktree from the main repo (force: it may hold the lock
+    // file and runtime artifacts). Best-effort: if it is already gone, continue.
+    let worktree = cache_dir.to_string_lossy().to_string();
+    let _ = run_git(repo_root, &["worktree", "remove", "--force", &worktree]);
+    // Prune any stale worktree administrative entries.
+    let _ = run_git(repo_root, &["worktree", "prune"]);
+    run_git(repo_root, &["branch", "-D", "crosslink/hub"])
+        .context("failed to delete local crosslink/hub branch")?;
+    Ok(())
+}
+
+/// Push the crosslink/hub branch deletion to the remote. `repo_root` is the
+/// main repository (the cache worktree has already been removed by this point).
+fn push_v2_branch_deletion(repo_root: &Path, remote: &str) -> Result<()> {
+    let output = Command::new("git")
+        .current_dir(repo_root)
+        .args(["push", remote, ":refs/heads/crosslink/hub"])
+        .output()
+        .context("failed to run git push to delete crosslink/hub on the remote")?;
+    if output.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    // A remote that doesn't have the branch (or no remote) is not fatal here —
+    // the local deletion already happened and re-run can retry.
+    if stderr.contains("remote ref does not exist")
+        || stderr.contains("Could not read from remote")
+        || stderr.contains("does not appear to be a git repository")
+        || stderr.contains("No such remote")
+    {
+        tracing::warn!("remote crosslink/hub deletion skipped: {}", stderr.trim());
+        return Ok(());
+    }
+    bail!(
+        "failed to delete crosslink/hub on remote '{remote}': {}",
+        stderr.trim()
+    );
+}
+
+// ── Pending-offline detection ────────────────────────────────────────
+
+/// Find issue files that have no `display_id` (pending offline promotion).
+///
+/// Mirrors the signal `shared_writer::offline::find_offline_issues` keys on
+/// (`display_id.is_none()`), but reads the hub-cache files directly — the
+/// migration must refuse before any agent/SQLite context is required.
+fn find_pending_offline(cache_dir: &Path) -> Result<Vec<IssueFile>> {
+    let issues_dir = cache_dir.join("issues");
+    let all = read_all_issue_files(&issues_dir)?;
+    Ok(all.into_iter().filter(|i| i.display_id.is_none()).collect())
+}
+
+// ── Output helpers ───────────────────────────────────────────────────
+
+fn print_hub_meta(meta: &HubMeta) {
+    println!("  hub_version: {}", meta.hub_version);
+    println!("  migrated_from_commit: {}", meta.migrated_from_commit);
+    println!("  migrated_at: {}", meta.migrated_at.to_rfc3339());
+    if let Some(f) = meta.finalized_at {
+        println!("  finalized_at: {}", f.to_rfc3339());
+    }
+}
+
+fn print_phase_a_summary(
+    seeded: &SeededRefs,
+    genesis: &CheckpointState,
+    report: &VerifyReport,
+    push: &PushSummary,
+) {
+    println!("hub-v3 migration complete (verified).");
+    println!();
+    println!("  agents seeded:       {}", seeded.agents.len());
+    println!("  issues in genesis:   {}", genesis.issues.len());
+    println!("  comments in genesis: {}", report.comments);
+    println!("  milestones:          {}", genesis.milestones.len());
+    println!("  locks:               {}", genesis.locks.len());
+    println!();
+    println!(
+        "  verification checked: issues={} comments={} milestones={} locks={}",
+        report.issues, report.comments, report.milestones, report.locks
+    );
+    println!();
+    println!("  refs pushed: {}", push.pushed.len());
+    for name in &push.pushed {
+        println!("    {name}");
+    }
+    if !push.failed.is_empty() {
+        println!(
+            "  refs NOT pushed ({}) — local migration is complete; re-run `crosslink migrate \
+             hub-v3` to retry pushing:",
+            push.failed.len()
+        );
+        for (name, why) in &push.failed {
+            println!("    {name}: {why}");
+        }
+    }
+    println!();
+    println!(
+        "Next: soak/cutover. The old crosslink/hub branch is left intact as a read-only escape \
+         hatch. When you are confident the v3 refs are correct, run \
+         `crosslink migrate hub-v3 --finalize --yes-delete-v2` to delete it."
+    );
+}
+
+fn print_mixed_version_warning() {
+    println!();
+    println!(
+        "WARNING: until you finalize, already-deployed v2 binaries keep operating the \
+         crosslink/hub branch and their writes are NOT reflected in v3. Avoid mixed-version \
+         operation, or finish the cutover."
+    );
+}
+
+// ── Private git plumbing ─────────────────────────────────────────────
+
+fn git_rev_parse(repo_dir: &Path, ref_name: &str) -> Result<Option<String>> {
+    let output = Command::new("git")
+        .current_dir(repo_dir)
+        .args(["rev-parse", "--verify", "--quiet", ref_name])
+        .output()
+        .with_context(|| format!("failed to run git rev-parse for '{ref_name}'"))?;
+    if output.status.success() {
+        let sha = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if sha.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(sha))
+    } else {
+        Ok(None)
+    }
+}
+
+fn git_update_ref(repo_dir: &Path, ref_name: &str, sha: &str) -> Result<()> {
+    let output = Command::new("git")
+        .current_dir(repo_dir)
+        .args(["update-ref", ref_name, sha])
+        .output()
+        .with_context(|| format!("failed to run git update-ref for '{ref_name}'"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!(
+            "git update-ref {ref_name} -> {sha} failed: {}",
+            stderr.trim()
+        );
+    }
+    Ok(())
+}
+
+fn git_delete_ref(repo_dir: &Path, ref_name: &str) -> Result<()> {
+    let output = Command::new("git")
+        .current_dir(repo_dir)
+        .args(["update-ref", "-d", ref_name])
+        .output()
+        .with_context(|| format!("failed to run git update-ref -d for '{ref_name}'"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("git update-ref -d {ref_name} failed: {}", stderr.trim());
+    }
+    Ok(())
+}
+
+fn for_each_ref(repo_dir: &Path, pattern: &str) -> Result<Vec<String>> {
+    let output = Command::new("git")
+        .current_dir(repo_dir)
+        .args(["for-each-ref", "--format=%(refname)", pattern])
+        .output()
+        .with_context(|| format!("failed to run git for-each-ref for '{pattern}'"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("git for-each-ref failed for '{pattern}': {}", stderr.trim());
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(stdout
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(str::to_string)
+        .collect())
+}
+
+/// `git ls-remote <remote> refs/crosslink/*` → map of refname → sha.
+fn ls_remote_crosslink(repo_dir: &Path, remote: &str) -> Result<BTreeMap<String, String>> {
+    let output = Command::new("git")
+        .current_dir(repo_dir)
+        .args(["ls-remote", remote, "refs/crosslink/*"])
+        .output()
+        .with_context(|| format!("failed to run git ls-remote for '{remote}'"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("git ls-remote failed for '{remote}': {}", stderr.trim());
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut map = BTreeMap::new();
+    for line in stdout.lines() {
+        if let Some((sha, name)) = line.split_once('\t') {
+            map.insert(name.trim().to_string(), sha.trim().to_string());
+        }
+    }
+    Ok(map)
+}
+
+fn git_cat_file_blob_optional(repo_dir: &Path, blob_spec: &str) -> Result<Option<Vec<u8>>> {
+    let output = Command::new("git")
+        .current_dir(repo_dir)
+        .args(["cat-file", "blob", blob_spec])
+        .output()
+        .with_context(|| format!("failed to run git cat-file for '{blob_spec}'"))?;
+    if output.status.success() {
+        return Ok(Some(output.stdout));
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if stderr.contains("does not exist")
+        || stderr.contains("Not a valid object name")
+        || stderr.contains("not found")
+    {
+        return Ok(None);
+    }
+    bail!("git cat-file failed for '{blob_spec}': {}", stderr.trim())
+}
+
+fn run_git(repo_dir: &Path, args: &[&str]) -> Result<std::process::Output> {
+    let output = Command::new("git")
+        .current_dir(repo_dir)
+        .args(args)
+        .output()
+        .with_context(|| format!("failed to run git {args:?}"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("git {args:?} failed: {}", stderr.trim());
+    }
+    Ok(output)
+}
+
+/// Resolve the main (non-worktree) repository root that owns `repo_dir`'s
+/// object store. Works whether `repo_dir` is the cache worktree or already the
+/// main repo. Uses `git rev-parse --git-common-dir` and strips a trailing
+/// `/.git`.
+fn git_main_repo_root(repo_dir: &Path) -> Result<PathBuf> {
+    let output = Command::new("git")
+        .current_dir(repo_dir)
+        .args(["rev-parse", "--path-format=absolute", "--git-common-dir"])
+        .output()
+        .context("failed to run git rev-parse --git-common-dir")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("git rev-parse --git-common-dir failed: {}", stderr.trim());
+    }
+    let common = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let common_path = PathBuf::from(&common);
+    let root = if common_path.file_name().and_then(|n| n.to_str()) == Some(".git") {
+        common_path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or(common_path)
+    } else {
+        common_path
+    };
+    Ok(root)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::Database;
+    use crate::identity::{AgentConfig, AgentRole};
+    use crate::shared_writer::SharedWriter;
+    use std::process::Command;
+    use tempfile::TempDir;
+
+    /// Build a realistic populated v2 hub in a temp repo with a bare remote.
+    ///
+    /// Returns `(work_dir, remote_dir, crosslink_dir, cache_dir)`. The hub is
+    /// populated with issues (labels, comments, deps, relations, scheduling),
+    /// a milestone, and a lock, all via the real `SharedWriter` write path so
+    /// the v2 event logs + materialized files are authentic. A second agent's
+    /// events.log + issue file are written directly so two agent refs seed.
+    fn setup_v2_hub() -> (TempDir, TempDir, std::path::PathBuf, std::path::PathBuf) {
+        let remote_dir = tempfile::tempdir().unwrap();
+        let work_dir = tempfile::tempdir().unwrap();
+
+        run(remote_dir.path(), &["init", "--bare", "-b", "main"]);
+        run(work_dir.path(), &["init", "-b", "main"]);
+        let wp = work_dir.path().to_path_buf();
+        run(&wp, &["config", "user.email", "test@test.local"]);
+        run(&wp, &["config", "user.name", "Test"]);
+        run(&wp, &["config", "commit.gpgsign", "false"]);
+        run(
+            &wp,
+            &[
+                "remote",
+                "add",
+                "origin",
+                remote_dir.path().to_str().unwrap(),
+            ],
+        );
+        std::fs::write(wp.join("README.md"), "# test\n").unwrap();
+        run(&wp, &["add", "."]);
+        run(&wp, &["commit", "-m", "init", "--no-gpg-sign"]);
+        run(&wp, &["push", "-u", "origin", "main"]);
+
+        let crosslink_dir = wp.join(".crosslink");
+        std::fs::create_dir_all(&crosslink_dir).unwrap();
+        std::fs::write(
+            crosslink_dir.join("hook-config.json"),
+            r#"{"remote":"origin","layout":"v2"}"#,
+        )
+        .unwrap();
+
+        write_agent(&crosslink_dir, "alpha");
+
+        let sync = SyncManager::new(&crosslink_dir).unwrap();
+        sync.init_cache().unwrap();
+        let cache_dir = sync.cache_path().to_path_buf();
+
+        // Populate via the real write path.
+        let db = Database::open(&crosslink_dir.join("issues.db")).unwrap();
+        let writer = SharedWriter::new(&crosslink_dir).unwrap().unwrap();
+
+        let i1 = writer
+            .create_issue(&db, "First issue", Some("desc one"), "high", None, None)
+            .unwrap();
+        let i2 = writer
+            .create_issue(&db, "Second issue", None, "medium", None, None)
+            .unwrap();
+        writer.add_label(&db, i1, "bug").unwrap();
+        writer.add_label(&db, i1, "urgent").unwrap();
+        writer.add_comment(&db, i1, "a note", "note").unwrap();
+        writer.add_comment(&db, i1, "a plan", "plan").unwrap();
+        writer.add_blocker(&db, i1, i2).unwrap();
+        writer.add_relation(&db, i1, i2).unwrap();
+        writer
+            .create_milestone(&db, "v1.0", Some("first release"))
+            .unwrap();
+        writer.claim_lock_v2(i2, Some("feature/x")).unwrap();
+
+        // Second agent: write an events.log + issue file directly so the
+        // migration seeds a second agent ref.
+        write_second_agent(&cache_dir);
+
+        // Force a compaction to materialize everything consistently.
+        let lock = sync.acquire_lock().unwrap();
+        crate::compaction::compact(&cache_dir, "alpha", true, &lock).unwrap();
+        drop(lock);
+
+        (work_dir, remote_dir, crosslink_dir, cache_dir)
+    }
+
+    fn write_agent(crosslink_dir: &Path, id: &str) {
+        let agent = AgentConfig {
+            agent_id: id.to_string(),
+            machine_id: "test-machine".to_string(),
+            description: Some("test".to_string()),
+            role: AgentRole::Driver,
+            ssh_key_path: None,
+            ssh_fingerprint: None,
+            ssh_public_key: None,
+        };
+        std::fs::write(
+            crosslink_dir.join("agent.json"),
+            serde_json::to_string_pretty(&agent).unwrap(),
+        )
+        .unwrap();
+    }
+
+    /// Write a beta agent events.log plus a matching issue file directly into
+    /// the cache so the migration seeds a second agent ref and the issue is
+    /// part of the genesis.
+    fn write_second_agent(cache_dir: &Path) {
+        use crate::events::{append_event, Event, EventEnvelope};
+        let uuid = Uuid::parse_str("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb").unwrap();
+        let now = Utc::now();
+        let env = EventEnvelope {
+            agent_id: "beta".to_string(),
+            agent_seq: 1,
+            timestamp: now - chrono::Duration::seconds(120),
+            event: Event::IssueCreated {
+                uuid,
+                title: "Beta issue".to_string(),
+                description: None,
+                priority: "low".to_string(),
+                labels: vec![],
+                parent_uuid: None,
+                created_by: "beta".to_string(),
+                display_id: Some(3),
+                scheduled_at: None,
+                due_at: None,
+            },
+            signed_by: None,
+            signature: None,
+        };
+        let log_path = cache_dir.join("agents").join("beta").join("events.log");
+        append_event(&log_path, &env).unwrap();
+
+        // Materialize the issue file (V2 layout) so the file-derived genesis
+        // includes it. compact() will also produce it, but writing it here makes
+        // the fixture explicit and robust.
+        let issue = crate::issue_file::IssueFile {
+            uuid,
+            display_id: Some(3),
+            title: "Beta issue".to_string(),
+            description: None,
+            status: crate::models::IssueStatus::Open,
+            priority: crate::models::Priority::Low,
+            parent_uuid: None,
+            created_by: "beta".to_string(),
+            created_at: now - chrono::Duration::seconds(120),
+            updated_at: now - chrono::Duration::seconds(120),
+            closed_at: None,
+            scheduled_at: None,
+            due_at: None,
+            labels: vec![],
+            comments: vec![],
+            blockers: vec![],
+            related: vec![],
+            milestone_uuid: None,
+            time_entries: vec![],
+        };
+        let dir = cache_dir.join("issues").join(uuid.to_string());
+        std::fs::create_dir_all(&dir).unwrap();
+        crate::issue_file::write_issue_file(&dir.join("issue.json"), &issue).unwrap();
+    }
+
+    fn run(dir: &std::path::Path, args: &[&str]) {
+        let out = Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    fn rev(dir: &Path, name: &str) -> Option<String> {
+        git_rev_parse(dir, name).unwrap()
+    }
+
+    // ── Test 1: happy path + idempotent re-run ───────────────────────
+
+    #[test]
+    fn migrate_happy_path_and_rerun_is_noop() {
+        let (_w, _r, crosslink_dir, cache_dir) = setup_v2_hub();
+
+        hub_v3(&crosslink_dir, false, false).unwrap();
+
+        // v3 refs exist.
+        assert!(rev(&cache_dir, CHECKPOINT_REF).is_some());
+        assert!(rev(&cache_dir, META_REF).is_some());
+        assert!(rev(&cache_dir, &agent_ref_name("alpha").unwrap()).is_some());
+        assert!(rev(&cache_dir, &agent_ref_name("beta").unwrap()).is_some());
+
+        // HubMeta is correct.
+        let meta = read_hub_meta(&cache_dir).unwrap().unwrap();
+        assert_eq!(meta.hub_version, 3);
+        assert!(!meta.migrated_from_commit.is_empty());
+        assert!(meta.finalized_at.is_none());
+
+        // Detected as V3 with the v2 branch still present.
+        assert_eq!(
+            hub_v3::detect_hub_version(&cache_dir).unwrap(),
+            HubVersion::V3 {
+                v2_branch_present: true
+            }
+        );
+
+        // Snapshot tips, re-run, confirm idempotent no-op (tips unchanged).
+        let cp = rev(&cache_dir, CHECKPOINT_REF);
+        let mt = rev(&cache_dir, META_REF);
+        let al = rev(&cache_dir, &agent_ref_name("alpha").unwrap());
+        hub_v3(&crosslink_dir, false, false).unwrap();
+        assert_eq!(cp, rev(&cache_dir, CHECKPOINT_REF));
+        assert_eq!(mt, rev(&cache_dir, META_REF));
+        assert_eq!(al, rev(&cache_dir, &agent_ref_name("alpha").unwrap()));
+
+        // v2 branch is untouched.
+        assert!(rev(&cache_dir, V2_HUB_BRANCH).is_some());
+    }
+
+    // ── Test 2: genesis equals files ─────────────────────────────────
+
+    #[test]
+    fn genesis_equals_files_via_refhubsource() {
+        let (_w, _r, crosslink_dir, cache_dir) = setup_v2_hub();
+        hub_v3(&crosslink_dir, false, false).unwrap();
+
+        let genesis = build_genesis_from_files(&cache_dir).unwrap();
+        let source = RefHubSource::new(&cache_dir).unwrap();
+        let reduced = crate::compaction::reduce(&source).unwrap().state;
+
+        assert_eq!(reduced.issues.len(), genesis.issues.len());
+        assert_eq!(reduced.milestones.len(), genesis.milestones.len());
+
+        // Per-issue full CompactIssue serde equality.
+        for (uuid, g) in &genesis.issues {
+            let r = reduced
+                .issues
+                .get(uuid)
+                .expect("issue present after reduce");
+            assert_eq!(
+                serde_json::to_value(g).unwrap(),
+                serde_json::to_value(r).unwrap(),
+                "issue {uuid} must match"
+            );
+        }
+
+        // Comment count spot-check: at least one issue has 2 comments.
+        let with_comments = genesis
+            .issues
+            .values()
+            .filter(|i| i.comments.len() == 2)
+            .count();
+        assert!(with_comments >= 1, "expected an issue with 2 comments");
+    }
+
+    // ── Test 3: watermark correctness ────────────────────────────────
+
+    #[test]
+    fn new_event_above_watermark_is_applied_pre_genesis_is_not() {
+        let (_w, _r, crosslink_dir, cache_dir) = setup_v2_hub();
+        hub_v3(&crosslink_dir, false, false).unwrap();
+
+        let genesis = build_genesis_from_files(&cache_dir).unwrap();
+
+        // Baseline: reduce equals genesis (no double-application of pre-genesis
+        // events such as the label-add already folded into the genesis state).
+        let base = crate::compaction::reduce(&RefHubSource::new(&cache_dir).unwrap())
+            .unwrap()
+            .state;
+        assert_eq!(
+            serde_json::to_value(&genesis).unwrap(),
+            serde_json::to_value(&base).unwrap(),
+            "reduce must equal genesis (pre-genesis events not re-applied)"
+        );
+
+        // Append a NEW event ABOVE the watermark to the alpha ref and confirm it
+        // IS applied by reduce.
+        use crate::events::{Event, EventEnvelope};
+        let new_uuid = Uuid::new_v4();
+        let env = EventEnvelope {
+            agent_id: "alpha".to_string(),
+            agent_seq: 9999,
+            timestamp: Utc::now() + chrono::Duration::seconds(60),
+            event: Event::IssueCreated {
+                uuid: new_uuid,
+                title: "Post-genesis issue".to_string(),
+                description: None,
+                priority: "medium".to_string(),
+                labels: vec![],
+                parent_uuid: None,
+                created_by: "alpha".to_string(),
+                display_id: None,
+                scheduled_at: None,
+                due_at: None,
+            },
+            signed_by: None,
+            signature: None,
+        };
+        // Read current alpha log, append the new line, commit it onto the ref.
+        let tip = rev(&cache_dir, &agent_ref_name("alpha").unwrap()).unwrap();
+        let mut bytes = git_cat_file_blob_optional(&cache_dir, &format!("{tip}:events.log"))
+            .unwrap()
+            .unwrap();
+        bytes.extend_from_slice(serde_json::to_string(&env).unwrap().as_bytes());
+        bytes.push(b'\n');
+        hub_v3::commit_log_bytes(&cache_dir, "alpha", &bytes, "test: post-genesis event").unwrap();
+
+        let after = crate::compaction::reduce(&RefHubSource::new(&cache_dir).unwrap())
+            .unwrap()
+            .state;
+        assert!(
+            after.issues.contains_key(&new_uuid),
+            "event above watermark must be applied"
+        );
+        // The new issue is the only difference vs genesis.
+        assert_eq!(after.issues.len(), genesis.issues.len() + 1);
+    }
+
+    // ── Test 4: rollback on verification failure ─────────────────────
+
+    #[test]
+    fn rollback_restores_all_refs_when_verify_fails() {
+        let (_w, _r, _crosslink_dir, cache_dir) = setup_v2_hub();
+
+        // Snapshot pre-migration crosslink ref tips (including any dual-write
+        // shadow refs — here none exist, all should roll back to absent).
+        let pre = snapshot_crosslink_refs(&cache_dir).unwrap();
+
+        // Build genesis, then TAMPER it so verification will fail (drop an issue).
+        let mut genesis = build_genesis_from_files(&cache_dir).unwrap();
+        let victim = *genesis.issues.keys().next().unwrap();
+        genesis.issues.remove(&victim);
+
+        let v2_tip = git_rev_parse(&cache_dir, V2_HUB_BRANCH).unwrap().unwrap();
+        let pre_tips = snapshot_crosslink_refs(&cache_dir).unwrap();
+        // Seed with the tampered genesis: refs get created.
+        seed_v3_refs(&cache_dir, &genesis, &v2_tip).unwrap();
+        assert!(rev(&cache_dir, CHECKPOINT_REF).is_some());
+
+        // Verification must fail (tampered genesis disagrees with files).
+        let result = verify_against_files(&cache_dir, &genesis);
+        assert!(result.is_err(), "tampered genesis must fail verification");
+
+        // Roll back and assert all refs restored to pre-migration tips.
+        rollback_refs(&cache_dir, &pre_tips).unwrap();
+        for tip in &pre {
+            assert_eq!(
+                rev(&cache_dir, &tip.name),
+                tip.old_sha,
+                "ref {} must be restored to its pre-migration tip",
+                tip.name
+            );
+        }
+        // v2 branch untouched.
+        assert!(rev(&cache_dir, V2_HUB_BRANCH).is_some());
+    }
+
+    // ── Test 5: duplicate display_id refusal ─────────────────────────
+
+    #[test]
+    fn duplicate_display_id_refuses_migration() {
+        let (_w, _r, crosslink_dir, cache_dir) = setup_v2_hub();
+
+        // Write a second issue file claiming an already-used display_id (#1).
+        let dup_uuid = Uuid::new_v4();
+        let issue = crate::issue_file::IssueFile {
+            uuid: dup_uuid,
+            display_id: Some(1),
+            title: "Dup id".to_string(),
+            description: None,
+            status: crate::models::IssueStatus::Open,
+            priority: crate::models::Priority::Medium,
+            parent_uuid: None,
+            created_by: "alpha".to_string(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            closed_at: None,
+            scheduled_at: None,
+            due_at: None,
+            labels: vec![],
+            comments: vec![],
+            blockers: vec![],
+            related: vec![],
+            milestone_uuid: None,
+            time_entries: vec![],
+        };
+        let dir = cache_dir.join("issues").join(dup_uuid.to_string());
+        std::fs::create_dir_all(&dir).unwrap();
+        crate::issue_file::write_issue_file(&dir.join("issue.json"), &issue).unwrap();
+
+        let err = hub_v3(&crosslink_dir, false, false).unwrap_err();
+        assert!(
+            err.to_string().contains("duplicate display_id"),
+            "must refuse on duplicate display_id, got: {err}"
+        );
+        // Nothing created.
+        assert!(rev(&cache_dir, CHECKPOINT_REF).is_none());
+        assert!(rev(&cache_dir, META_REF).is_none());
+    }
+
+    // ── Test 6: no-events hub ────────────────────────────────────────
+
+    #[test]
+    fn no_events_hub_migrates_with_synthesized_watermark() {
+        let remote_dir = tempfile::tempdir().unwrap();
+        let work_dir = tempfile::tempdir().unwrap();
+        run(remote_dir.path(), &["init", "--bare", "-b", "main"]);
+        let wp = work_dir.path().to_path_buf();
+        run(&wp, &["init", "-b", "main"]);
+        run(&wp, &["config", "user.email", "t@t.local"]);
+        run(&wp, &["config", "user.name", "T"]);
+        run(&wp, &["config", "commit.gpgsign", "false"]);
+        run(
+            &wp,
+            &[
+                "remote",
+                "add",
+                "origin",
+                remote_dir.path().to_str().unwrap(),
+            ],
+        );
+        std::fs::write(wp.join("README.md"), "# t\n").unwrap();
+        run(&wp, &["add", "."]);
+        run(&wp, &["commit", "-m", "init", "--no-gpg-sign"]);
+        run(&wp, &["push", "-u", "origin", "main"]);
+
+        let crosslink_dir = wp.join(".crosslink");
+        std::fs::create_dir_all(&crosslink_dir).unwrap();
+        std::fs::write(
+            crosslink_dir.join("hook-config.json"),
+            r#"{"remote":"origin","layout":"v2"}"#,
+        )
+        .unwrap();
+        write_agent(&crosslink_dir, "alpha");
+        let sync = SyncManager::new(&crosslink_dir).unwrap();
+        sync.init_cache().unwrap();
+        let cache_dir = sync.cache_path().to_path_buf();
+
+        hub_v3(&crosslink_dir, false, false).unwrap();
+
+        // Watermark must be Some (synthesized), so reduce returns genesis unchanged.
+        let cp = crate::checkpoint::read_checkpoint(&cache_dir);
+        let _ = cp; // checkpoint dir form differs; read via the ref source below.
+        let genesis = build_genesis_from_files(&cache_dir).unwrap();
+        assert!(
+            genesis.watermark.is_some(),
+            "no-events genesis must have a watermark"
+        );
+        let reduced = crate::compaction::reduce(&RefHubSource::new(&cache_dir).unwrap())
+            .unwrap()
+            .state;
+        assert_eq!(
+            serde_json::to_value(&genesis).unwrap(),
+            serde_json::to_value(&reduced).unwrap(),
+            "no-events reduce must equal genesis"
+        );
+        assert!(reduced.issues.is_empty());
+    }
+
+    // ── Test 7: finalize ─────────────────────────────────────────────
+
+    #[test]
+    fn finalize_requires_confirmation_then_deletes_v2() {
+        let (_w, _r, crosslink_dir, cache_dir) = setup_v2_hub();
+        hub_v3(&crosslink_dir, false, false).unwrap();
+
+        // Without --yes-delete-v2 → refusal.
+        let err = hub_v3(&crosslink_dir, true, false).unwrap_err();
+        assert!(
+            err.to_string().contains("yes-delete-v2"),
+            "finalize without confirmation must refuse, got: {err}"
+        );
+        // v2 branch still present.
+        assert!(rev(&cache_dir, V2_HUB_BRANCH).is_some());
+
+        // With confirmation → v2 branch gone local + remote, finalized_at set.
+        let repo_root = wp_of(&crosslink_dir);
+        hub_v3(&crosslink_dir, true, true).unwrap();
+
+        // Local branch deleted (probe from the main repo root — cache worktree removed).
+        assert!(
+            rev(&repo_root, V2_HUB_BRANCH).is_none(),
+            "local v2 branch must be gone"
+        );
+
+        // Remote branch deleted.
+        let ls = Command::new("git")
+            .current_dir(&repo_root)
+            .args(["ls-remote", "--heads", "origin", "crosslink/hub"])
+            .output()
+            .unwrap();
+        assert!(
+            String::from_utf8_lossy(&ls.stdout).trim().is_empty(),
+            "remote crosslink/hub must be deleted"
+        );
+
+        // HubMeta.finalized_at is set.
+        let meta = read_hub_meta(&repo_root).unwrap().unwrap();
+        assert!(meta.finalized_at.is_some(), "finalized_at must be stamped");
+
+        // Old-binary simulation: SyncManager fetch now fails loudly because the
+        // branch is gone. A fresh SyncManager re-init will try to fetch
+        // crosslink/hub; the branch is absent on the remote.
+        let ls2 = Command::new("git")
+            .current_dir(&repo_root)
+            .args(["fetch", "origin", "crosslink/hub"])
+            .output()
+            .unwrap();
+        assert!(
+            !ls2.status.success(),
+            "fetching the deleted crosslink/hub branch must fail (old-binary hard stop)"
+        );
+        let stderr = String::from_utf8_lossy(&ls2.stderr);
+        assert!(
+            stderr.contains("crosslink/hub") || stderr.contains("couldn't find remote ref"),
+            "fetch error should reference the missing branch: {stderr}"
+        );
+    }
+
+    fn wp_of(crosslink_dir: &Path) -> std::path::PathBuf {
+        crosslink_dir.parent().unwrap().to_path_buf()
+    }
+
+    // ── Test 8: warn wiring ──────────────────────────────────────────
+
+    #[test]
+    fn warn_detects_migrated_hub_for_v2_operation() {
+        let (_w, _r, crosslink_dir, cache_dir) = setup_v2_hub();
+        hub_v3(&crosslink_dir, false, false).unwrap();
+
+        // No tracing-capture harness exists in this crate's tests, so assert the
+        // detection behavior the warn path keys on: a migrated hub reports V3.
+        assert!(matches!(
+            hub_v3::detect_hub_version(&cache_dir).unwrap(),
+            HubVersion::V3 { .. }
+        ));
+        // The warn function must run without panicking on a migrated hub.
+        hub_v3::warn_if_migrated_v2_operation(&cache_dir);
+    }
+}

--- a/crosslink/src/commands/mod.rs
+++ b/crosslink/src/commands/mod.rs
@@ -29,6 +29,7 @@ pub mod lifecycle;
 pub mod list;
 pub mod locks_cmd;
 pub mod migrate;
+pub mod migrate_hub_v3;
 pub mod milestone;
 pub mod mission_control;
 pub mod next;

--- a/crosslink/src/hub_source.rs
+++ b/crosslink/src/hub_source.rs
@@ -396,6 +396,261 @@ impl HubSource for ObjectStoreSource {
     }
 }
 
+// ── RefHubSource ─────────────────────────────────────────────────────
+
+/// Reads the hub-v3 per-agent ref namespace — the production v3 read path.
+///
+/// Unlike [`ObjectStoreSource`], which reads a single HUB-LAYOUT commit (with
+/// `agents/<id>/events.log` nested inside one tree), `RefHubSource` reads the v3
+/// layout where each agent owns its own ref
+/// (`refs/crosslink/agents/<id>`) carrying `events.log` at the TREE ROOT, the
+/// checkpoint lives on its own ref ([`crate::hub_v3::CHECKPOINT_REF`]) with
+/// `state.json` at the root, and trust metadata lives on
+/// [`crate::hub_v3::META_REF`].
+///
+/// # Pinned-commit consistency
+///
+/// Mirrors `ObjectStoreSource`'s torn-view protection: the constructor resolves
+/// the checkpoint tip, the meta tip, and EVERY agent ref tip to concrete SHAs
+/// once, and all subsequent reads address those SHAs explicitly. A concurrent
+/// push to any ref after construction cannot change what this source reads —
+/// it still sees the tips pinned at construction.
+///
+/// # Composition (REQ-3)
+///
+/// `reduce(&RefHubSource)` materializes the genesis checkpoint plus every event
+/// above its watermark, exactly as the worktree path does — this composition is
+/// the entire v3 read path.
+///
+/// # PR3 of hub v3 — see `.design/hub-v3-per-agent-refs.md` REQ-3
+#[derive(Debug)]
+// Production read path wired up by the migrate verify step (part 2) and #754;
+// the bin's duplicate module tree flags it as dead code until then.
+#[allow(dead_code)]
+pub struct RefHubSource {
+    /// Path to the local git repository.
+    repo_path: PathBuf,
+    /// Pinned checkpoint commit SHA, or `None` when no checkpoint ref exists
+    /// (tolerated: treated as the default checkpoint).
+    checkpoint_sha: Option<String>,
+    /// Pinned meta commit SHA, or `None` when no meta ref exists.
+    meta_sha: Option<String>,
+    /// Pinned `(agent_id, agent_ref_tip_sha)` pairs, enumerated once at
+    /// construction. All `read_events` calls address these SHAs, never the
+    /// moving refs.
+    agent_tips: Vec<(String, String)>,
+    /// Temp dir holding the extracted `allowed_signers` file, if any. Owned so
+    /// the path returned by `allowed_signers_file()` lives as long as `&self`.
+    _allowed_signers_dir: Option<tempfile::TempDir>,
+    /// Path to the extracted `allowed_signers` file, if any.
+    allowed_signers_path: Option<PathBuf>,
+}
+
+// Production read path: see the dead_code note on the struct.
+#[allow(dead_code)]
+impl RefHubSource {
+    /// Construct a `RefHubSource` pinned to the current tips of the v3 refs in
+    /// `repo_dir`.
+    ///
+    /// Resolves the checkpoint ref (optional), the meta ref (optional), and
+    /// enumerates every `refs/crosslink/agents/*` ref, pinning each to its tip
+    /// SHA. The `allowed_signers` blob from the meta ref is extracted into a
+    /// temp file once here so `allowed_signers_file()` runs no git commands.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if git plumbing (`for-each-ref`, `rev-parse`,
+    /// `cat-file`) fails.
+    pub fn new(repo_dir: &Path) -> Result<Self> {
+        let checkpoint_sha = git_rev_parse_optional(repo_dir, crate::hub_v3::CHECKPOINT_REF)?;
+        let meta_sha = git_rev_parse_optional(repo_dir, crate::hub_v3::META_REF)?;
+
+        // Enumerate agent refs and pin each tip.
+        let mut agent_tips = Vec::new();
+        for ref_name in for_each_ref(repo_dir, &format!("{}*", crate::hub_v3::AGENT_REF_PREFIX))? {
+            let Some(agent_id) = ref_name.strip_prefix(crate::hub_v3::AGENT_REF_PREFIX) else {
+                continue;
+            };
+            // Resolve the tip explicitly so the read is pinned, not ref-relative.
+            let Some(sha) = git_rev_parse_optional(repo_dir, &ref_name)? else {
+                continue;
+            };
+            agent_tips.push((agent_id.to_string(), sha));
+        }
+
+        // Extract allowed_signers from the meta tip, if present, into an owned
+        // temp dir (same lifetime pattern as ObjectStoreSource).
+        let (allowed_signers_dir, allowed_signers_path) = match &meta_sha {
+            Some(sha) => extract_meta_allowed_signers(repo_dir, sha)?,
+            None => (None, None),
+        };
+
+        Ok(Self {
+            repo_path: repo_dir.to_path_buf(),
+            checkpoint_sha,
+            meta_sha,
+            agent_tips,
+            _allowed_signers_dir: allowed_signers_dir,
+            allowed_signers_path,
+        })
+    }
+
+    /// The pinned checkpoint commit SHA, or `None` if no checkpoint ref exists.
+    #[must_use]
+    pub fn checkpoint_sha(&self) -> Option<&str> {
+        self.checkpoint_sha.as_deref()
+    }
+
+    /// The pinned meta commit SHA, or `None` if no meta ref exists.
+    #[must_use]
+    pub fn meta_sha(&self) -> Option<&str> {
+        self.meta_sha.as_deref()
+    }
+}
+
+impl HubSource for RefHubSource {
+    fn agent_ids(&self) -> Result<Vec<String>> {
+        Ok(self.agent_tips.iter().map(|(id, _)| id.clone()).collect())
+    }
+
+    fn read_events(
+        &self,
+        agent_id: &str,
+        after: Option<&OrderingKey>,
+    ) -> Result<Vec<EventEnvelope>> {
+        // Find the pinned tip for this agent.
+        let Some((_, sha)) = self.agent_tips.iter().find(|(id, _)| id == agent_id) else {
+            return Ok(Vec::new());
+        };
+
+        // events.log is at the TREE ROOT of each agent's own ref.
+        let bytes = git_cat_file_blob(&self.repo_path, sha, "events.log").with_context(|| {
+            format!("failed to read events.log for agent '{agent_id}' from pinned tip {sha}")
+        })?;
+
+        let Some(bytes) = bytes else {
+            // Tip exists but has no events.log (unexpected for a v3 agent ref;
+            // treat as empty rather than erroring on a structurally-odd ref).
+            return Ok(Vec::new());
+        };
+
+        let events = read_events_from_bytes(&bytes).with_context(|| {
+            format!("failed to parse events.log for agent '{agent_id}' from pinned tip {sha}")
+        })?;
+
+        if let Some(wm) = after {
+            Ok(events
+                .into_iter()
+                .filter(|e| OrderingKey::from_envelope(e) > *wm)
+                .collect())
+        } else {
+            Ok(events)
+        }
+    }
+
+    fn read_checkpoint(&self) -> Result<CheckpointState> {
+        let Some(sha) = &self.checkpoint_sha else {
+            // No checkpoint ref → default checkpoint (no watermark, full reduce).
+            return Ok(CheckpointState::default());
+        };
+
+        // state.json is at the TREE ROOT of the checkpoint ref.
+        let bytes = git_cat_file_blob(&self.repo_path, sha, "state.json").with_context(|| {
+            format!("failed to read state.json from pinned checkpoint tip {sha}")
+        })?;
+
+        bytes.map_or_else(
+            || Ok(CheckpointState::default()),
+            |b| {
+                CheckpointState::from_slice(&b).with_context(|| {
+                    format!("failed to parse state.json from pinned checkpoint tip {sha}")
+                })
+            },
+        )
+    }
+
+    fn read_legacy_watermark(&self) -> Result<Option<OrderingKey>> {
+        // v3 has no legacy watermark file: the watermark lives embedded in the
+        // checkpoint's CheckpointState (read via read_checkpoint). There is no
+        // standalone watermark.json on any v3 ref, so this is unconditionally None.
+        Ok(None)
+    }
+
+    fn allowed_signers_file(&self) -> Result<Option<PathBuf>> {
+        Ok(self.allowed_signers_path.clone())
+    }
+}
+
+/// Extract `allowed_signers` from the `META_REF` tip tree (TREE ROOT) into an
+/// owned temp dir. Mirrors [`extract_allowed_signers`] but reads the meta ref's
+/// root path rather than `trust/allowed_signers`.
+// Production read path: see the dead_code note on RefHubSource.
+#[allow(dead_code)]
+fn extract_meta_allowed_signers(
+    repo_path: &Path,
+    meta_sha: &str,
+) -> Result<(Option<tempfile::TempDir>, Option<PathBuf>)> {
+    let bytes = git_cat_file_blob(repo_path, meta_sha, "allowed_signers")
+        .with_context(|| format!("failed to read allowed_signers from meta tip {meta_sha}"))?;
+
+    let Some(bytes) = bytes else {
+        return Ok((None, None));
+    };
+
+    let dir = tempfile::tempdir().context("failed to create temp dir for allowed_signers")?;
+    let path = dir.path().join("allowed_signers");
+    std::fs::write(&path, &bytes)
+        .with_context(|| format!("failed to write allowed_signers to {}", path.display()))?;
+
+    Ok((Some(dir), Some(path)))
+}
+
+/// Run `git rev-parse --verify --quiet <ref>`; `Some(sha)` if it resolves,
+/// `None` if absent.
+// Production read path: see the dead_code note on RefHubSource.
+#[allow(dead_code)]
+fn git_rev_parse_optional(repo_path: &Path, ref_name: &str) -> Result<Option<String>> {
+    let output = Command::new("git")
+        .current_dir(repo_path)
+        .args(["rev-parse", "--verify", "--quiet", ref_name])
+        .output()
+        .with_context(|| format!("failed to run git rev-parse for '{ref_name}'"))?;
+
+    if output.status.success() {
+        let sha = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if sha.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(sha))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Enumerate refs matching `pattern` via `git for-each-ref --format=%(refname)`.
+// Production read path: see the dead_code note on RefHubSource.
+#[allow(dead_code)]
+fn for_each_ref(repo_path: &Path, pattern: &str) -> Result<Vec<String>> {
+    let output = Command::new("git")
+        .current_dir(repo_path)
+        .args(["for-each-ref", "--format=%(refname)", pattern])
+        .output()
+        .with_context(|| format!("failed to run git for-each-ref for '{pattern}'"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("git for-each-ref failed for '{pattern}': {}", stderr.trim());
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(stdout
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(str::to_string)
+        .collect())
+}
+
 // ── Private git helpers ──────────────────────────────────────────────
 
 /// Run `git rev-parse --verify <ref>` and return the resolved SHA.
@@ -1165,6 +1420,291 @@ mod tests {
         assert!(
             msg.contains("no longer exists"),
             "checkpoint read should describe the vanished object store, got: {msg}"
+        );
+    }
+
+    // ── RefHubSource v3-layout tests ─────────────────────────────────
+
+    /// Initialize a git repo (object store only; commits get identity from
+    /// `commit_log_bytes`/`commit_blob_to_ref` env vars, so no user config is
+    /// strictly required, but configure one for parity with other helpers).
+    fn ref_repo_init(path: &Path) {
+        run_git(path, &["init"]);
+        run_git(path, &["config", "user.email", "test@crosslink.test"]);
+        run_git(path, &["config", "user.name", "Test"]);
+    }
+
+    /// Serialize a set of events to the canonical NDJSON byte image (identical
+    /// to `events::append_event` output) for committing onto an agent ref.
+    fn log_bytes(events: &[EventEnvelope]) -> Vec<u8> {
+        let tmp = tempfile::tempdir().unwrap();
+        let log_path = tmp.path().join("events.log");
+        for ev in events {
+            crate::events::append_event(&log_path, ev).unwrap();
+        }
+        std::fs::read(&log_path).unwrap()
+    }
+
+    #[test]
+    fn ref_hub_source_reduces_genesis_plus_post_watermark_events() {
+        let repo_tmp = tempfile::tempdir().unwrap();
+        let repo = repo_tmp.path();
+        ref_repo_init(repo);
+
+        let now = Utc::now();
+        let uuid_pre = Uuid::new_v4();
+        let uuid_post1 = Uuid::new_v4();
+        let uuid_post2 = Uuid::new_v4();
+
+        // agent-1: one pre-watermark event, one post-watermark event.
+        let mut e_pre = make_issue_created("agent-1", 1, uuid_pre);
+        e_pre.timestamp = now - Duration::seconds(60);
+        let mut e_post1 = make_issue_created("agent-1", 2, uuid_post1);
+        e_post1.timestamp = now - Duration::seconds(10);
+
+        // agent-2: one post-watermark event.
+        let mut e_post2 = make_issue_created("agent-2", 1, uuid_post2);
+        e_post2.timestamp = now - Duration::seconds(5);
+
+        // Commit each agent's full log onto its own ref (events.log at root).
+        crate::hub_v3::commit_log_bytes(
+            repo,
+            "agent-1",
+            &log_bytes(&[e_pre.clone(), e_post1]),
+            "agent-1 log",
+        )
+        .unwrap();
+        crate::hub_v3::commit_log_bytes(repo, "agent-2", &log_bytes(&[e_post2]), "agent-2 log")
+            .unwrap();
+
+        // Build a genesis checkpoint whose watermark covers e_pre only, and
+        // which already contains uuid_pre as reduced state.
+        let wm = OrderingKey::from_envelope(&e_pre);
+        let mut state = CheckpointState {
+            watermark: Some(wm),
+            ..Default::default()
+        };
+        state.issues.insert(
+            uuid_pre,
+            crate::checkpoint::CompactIssue {
+                uuid: uuid_pre,
+                display_id: Some(1),
+                title: format!("Issue {uuid_pre}"),
+                description: None,
+                status: crate::models::IssueStatus::Open,
+                priority: crate::models::Priority::Medium,
+                parent_uuid: None,
+                created_by: "agent-1".to_string(),
+                created_at: e_pre.timestamp,
+                updated_at: e_pre.timestamp,
+                closed_at: None,
+                scheduled_at: None,
+                due_at: None,
+                labels: std::collections::BTreeSet::new(),
+                blockers: std::collections::BTreeSet::new(),
+                related: std::collections::BTreeSet::new(),
+                milestone_uuid: None,
+                comments: std::collections::BTreeMap::new(),
+                time_entries: std::collections::BTreeMap::new(),
+            },
+        );
+        state.display_id_map.insert(uuid_pre, 1);
+        state.next_display_id = 2;
+        let state_bytes = serde_json::to_vec(&state).unwrap();
+        crate::hub_v3::commit_blob_to_ref(
+            repo,
+            crate::hub_v3::CHECKPOINT_REF,
+            "state.json",
+            &state_bytes,
+            "genesis checkpoint",
+        )
+        .unwrap();
+
+        // reduce(&RefHubSource) = genesis state ⊕ post-watermark events.
+        let source = RefHubSource::new(repo).unwrap();
+        let outcome = crate::compaction::reduce(&source).unwrap();
+
+        // Exactly the two post-watermark events were processed.
+        assert_eq!(
+            outcome.events_processed, 2,
+            "only post-watermark events apply"
+        );
+        // Genesis issue plus both post-watermark issues are present.
+        assert!(
+            outcome.state.issues.contains_key(&uuid_pre),
+            "genesis issue retained"
+        );
+        assert!(
+            outcome.state.issues.contains_key(&uuid_post1),
+            "post-wm issue 1 applied"
+        );
+        assert!(
+            outcome.state.issues.contains_key(&uuid_post2),
+            "post-wm issue 2 applied"
+        );
+        assert_eq!(outcome.state.issues.len(), 3);
+    }
+
+    #[test]
+    fn ref_hub_source_no_checkpoint_defaults_and_reduces_all() {
+        let repo_tmp = tempfile::tempdir().unwrap();
+        let repo = repo_tmp.path();
+        ref_repo_init(repo);
+
+        let uuid1 = Uuid::new_v4();
+        let mut e1 = make_issue_created("agent-1", 1, uuid1);
+        e1.timestamp = Utc::now() - Duration::seconds(5);
+        crate::hub_v3::commit_log_bytes(repo, "agent-1", &log_bytes(&[e1]), "log").unwrap();
+
+        // No checkpoint ref → default checkpoint (no watermark) → full reduce.
+        let source = RefHubSource::new(repo).unwrap();
+        assert!(source.checkpoint_sha().is_none());
+        let outcome = crate::compaction::reduce(&source).unwrap();
+        assert_eq!(outcome.events_processed, 1);
+        assert!(outcome.state.issues.contains_key(&uuid1));
+    }
+
+    #[test]
+    fn ref_hub_source_pinned_to_tips_at_construction() {
+        let repo_tmp = tempfile::tempdir().unwrap();
+        let repo = repo_tmp.path();
+        ref_repo_init(repo);
+
+        let uuid1 = Uuid::new_v4();
+        let mut e1 = make_issue_created("agent-1", 1, uuid1);
+        e1.timestamp = Utc::now() - Duration::seconds(20);
+        crate::hub_v3::commit_log_bytes(repo, "agent-1", &log_bytes(&[e1.clone()]), "log1")
+            .unwrap();
+
+        // Pin at construction.
+        let source = RefHubSource::new(repo).unwrap();
+
+        // Move the agent ref forward AFTER construction.
+        let uuid2 = Uuid::new_v4();
+        let mut e2 = make_issue_created("agent-1", 2, uuid2);
+        e2.timestamp = Utc::now() - Duration::seconds(5);
+        crate::hub_v3::commit_log_bytes(repo, "agent-1", &log_bytes(&[e1, e2]), "log2").unwrap();
+
+        // The pinned source still reads the old tip: uuid2 must NOT appear.
+        let outcome = crate::compaction::reduce(&source).unwrap();
+        assert!(outcome.state.issues.contains_key(&uuid1));
+        assert!(
+            !outcome.state.issues.contains_key(&uuid2),
+            "pinned source must not see the post-construction ref move"
+        );
+    }
+
+    #[test]
+    fn ref_hub_source_vanished_commit_hard_errors() {
+        let repo_tmp = tempfile::tempdir().unwrap();
+        let repo = repo_tmp.path();
+        ref_repo_init(repo);
+
+        let uuid1 = Uuid::new_v4();
+        let mut e1 = make_issue_created("agent-1", 1, uuid1);
+        e1.timestamp = Utc::now() - Duration::seconds(5);
+        crate::hub_v3::commit_log_bytes(repo, "agent-1", &log_bytes(&[e1]), "log").unwrap();
+
+        let source = RefHubSource::new(repo).unwrap();
+
+        // Destroy the object store after pinning.
+        std::fs::remove_dir_all(repo.join(".git").join("objects")).unwrap();
+        std::fs::create_dir_all(repo.join(".git").join("objects")).unwrap();
+
+        let err = source
+            .read_events("agent-1", None)
+            .expect_err("vanished agent-ref commit must hard-error, not read empty");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("no longer exists"),
+            "vanished commit must describe the pruned object store, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn ref_hub_source_reads_allowed_signers_from_meta() {
+        let repo_tmp = tempfile::tempdir().unwrap();
+        let repo = repo_tmp.path();
+        ref_repo_init(repo);
+
+        // No meta ref → no allowed_signers.
+        let source = RefHubSource::new(repo).unwrap();
+        assert!(source.allowed_signers_file().unwrap().is_none());
+
+        // Commit a meta ref carrying allowed_signers (TREE ROOT).
+        crate::hub_v3::commit_files_to_ref(
+            repo,
+            crate::hub_v3::META_REF,
+            &[("hub.json", b"{}\n"), ("allowed_signers", b"# signers\n")],
+            "meta",
+        )
+        .unwrap();
+        let source = RefHubSource::new(repo).unwrap();
+        let path = source
+            .allowed_signers_file()
+            .unwrap()
+            .expect("allowed_signers must be extracted from the meta ref");
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(contents, "# signers\n");
+    }
+
+    /// Keystone equivalence test: a populated WORKTREE hub and the same logs
+    /// committed to v3 refs must reduce to byte-identical state when both start
+    /// from a default checkpoint.
+    #[test]
+    fn worktree_and_ref_hub_reduce_to_identical_state() {
+        // Build a worktree hub with two agents' logs.
+        let hub_tmp = tempfile::tempdir().unwrap();
+        let hub_dir = hub_tmp.path();
+        setup_hub_layout(hub_dir);
+
+        let now = Utc::now();
+        let uuid1 = Uuid::new_v4();
+        let uuid2 = Uuid::new_v4();
+        let uuid3 = Uuid::new_v4();
+
+        let mut e1 = make_issue_created("agent-1", 1, uuid1);
+        e1.timestamp = now - Duration::seconds(30);
+        let mut e2 = make_issue_created("agent-1", 2, uuid2);
+        e2.timestamp = now - Duration::seconds(20);
+        let mut e3 = make_issue_created("agent-2", 1, uuid3);
+        e3.timestamp = now - Duration::seconds(25);
+        let mut e4 = make_envelope(
+            "agent-2",
+            2,
+            Event::LabelAdded {
+                issue_uuid: uuid1,
+                label: "bug".to_string(),
+            },
+        );
+        e4.timestamp = now - Duration::seconds(15);
+
+        write_agent_events(hub_dir, "agent-1", &[e1.clone(), e2.clone()]);
+        write_agent_events(hub_dir, "agent-2", &[e3.clone(), e4.clone()]);
+
+        let worktree_outcome = reduce_worktree(hub_dir);
+
+        // Commit the SAME logs to v3 refs (events.log at each agent's tree root),
+        // with NO checkpoint ref so both sides start from the default checkpoint.
+        let repo_tmp = tempfile::tempdir().unwrap();
+        let repo = repo_tmp.path();
+        ref_repo_init(repo);
+        crate::hub_v3::commit_log_bytes(repo, "agent-1", &log_bytes(&[e1, e2]), "a1").unwrap();
+        crate::hub_v3::commit_log_bytes(repo, "agent-2", &log_bytes(&[e3, e4]), "a2").unwrap();
+
+        let ref_source = RefHubSource::new(repo).unwrap();
+        let ref_outcome = crate::compaction::reduce(&ref_source).unwrap();
+
+        // Full state equality via serde_json value comparison.
+        let wt = serde_json::to_value(&worktree_outcome.state).unwrap();
+        let rf = serde_json::to_value(&ref_outcome.state).unwrap();
+        assert_eq!(
+            wt, rf,
+            "WorktreeSource and RefHubSource must reduce to identical state"
+        );
+        assert_eq!(
+            worktree_outcome.events_processed, ref_outcome.events_processed,
+            "both sources must process the same number of events"
         );
     }
 }

--- a/crosslink/src/hub_v3.rs
+++ b/crosslink/src/hub_v3.rs
@@ -29,6 +29,38 @@ use crate::utils::is_windows_reserved_name;
 /// Namespace prefix for per-agent hub refs.
 pub const AGENT_REF_PREFIX: &str = "refs/crosslink/agents/";
 
+/// Ref holding the pure-cache compaction checkpoint (`state.json` at tree root).
+///
+/// Written by whichever process compacts and pushed with `--force-with-lease`
+/// (REQ-7). Concurrent compactions are harmless: the same event set reduces to
+/// the same deterministic state, so two writers produce byte-identical content
+/// and the lease loser simply refetches an identical result.
+pub const CHECKPOINT_REF: &str = "refs/crosslink/checkpoint";
+
+/// Ref holding hub metadata: the version marker (`hub.json`) and the
+/// `allowed_signers` trust store (REQ-9, REQ-12). Driver-written, CAS-updated.
+pub const META_REF: &str = "refs/crosslink/meta";
+
+/// Compare-and-swap expectation for the generalized single-file commit core.
+///
+/// Mirrors the `update-ref <ref> <new> <old>` contract: the update succeeds only
+/// if the ref's current value matches the expectation, otherwise it is rejected
+/// as a concurrent move.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+// Variants are selected by the different commit entry points (append vs.
+// genesis-or-update); the bin's duplicate module tree flags the unused-by-bin
+// constructors as dead code.
+#[allow(dead_code)]
+pub enum CasExpectation<'a> {
+    /// The ref must not currently exist (genesis write).
+    MustNotExist,
+    /// The ref must currently point at this exact SHA.
+    MustMatch(&'a str),
+    /// Read the current tip and CAS against it. `None` if the ref is absent
+    /// (treated as genesis), `Some(sha)` if it exists (treated as an update).
+    CurrentTip,
+}
+
 /// Build the full ref name for an agent.
 ///
 /// Validates the agent ID (3–64 characters, alphanumeric plus `-` and `_`;
@@ -86,6 +118,7 @@ pub struct RefAppendOutcome {
 }
 
 /// Outcome of a [`push_agent_ref`] call.
+#[derive(Debug)]
 pub enum PushOutcome {
     /// The push succeeded and the remote ref was updated.
     Pushed,
@@ -226,7 +259,7 @@ fn append_inner_impl<A: IntoAbortPoint>(
     }
 
     // ── Step e: mktree ───────────────────────────────────────────────
-    let tree_sha = git_mktree(repo_dir, &blob_sha)?;
+    let tree_sha = git_mktree_single(repo_dir, &blob_sha, "events.log")?;
 
     if abort_opt.should_abort_after_mktree() {
         return Ok(RefAppendOutcome {
@@ -296,18 +329,15 @@ pub fn commit_log_bytes(
     read_events_from_bytes(log_bytes)
         .context("refusing to commit unparseable events.log bytes to the agent ref")?;
 
-    let old_commit = git_rev_parse_optional(repo_dir, &ref_name)?;
-    let blob_sha = git_hash_object(repo_dir, log_bytes)?;
-    let tree_sha = git_mktree(repo_dir, &blob_sha)?;
-    let commit_sha = git_commit_tree(
+    commit_single_file_tree(
         repo_dir,
-        &tree_sha,
-        old_commit.as_deref(),
+        &ref_name,
+        "events.log",
+        log_bytes,
         message,
         agent_id,
-    )?;
-    git_update_ref_cas(repo_dir, &ref_name, &commit_sha, old_commit.as_deref())?;
-    Ok(commit_sha)
+        CasExpectation::CurrentTip,
+    )
 }
 
 // ── AbortPoint trait (sealed helper) ────────────────────────────────
@@ -359,16 +389,89 @@ impl IntoAbortPoint for Option<AbortPoint> {
 pub fn push_agent_ref(repo_dir: &Path, remote: &str, agent_id: &str) -> Result<PushOutcome> {
     validate_agent_id(agent_id)?;
     let ref_name = agent_ref_name(agent_id)?;
+    push_ref(repo_dir, remote, &ref_name)
+}
+
+/// Push an arbitrary `refs/crosslink/*` ref to a remote with a plain
+/// (non-force) push.
+///
+/// `git push <remote> <ref>:<ref>` — no `+`, no `--force-with-lease`. The plain
+/// push IS the fast-forward CAS; any non-fast-forward outcome is classified as
+/// [`PushOutcome::NonFastForward`] (REQ-1: never silently rebased). This is the
+/// generalization of [`push_agent_ref`], which is now a thin wrapper.
+///
+/// # Errors
+///
+/// Returns an error only if `git push` cannot be spawned; rejections and
+/// remote-not-found are reported as [`PushOutcome`] variants, not errors.
+// PR3 read/verify path and the migrate command push the checkpoint and meta
+// refs through this; flagged dead until those callers land.
+#[allow(dead_code)]
+pub fn push_ref(repo_dir: &Path, remote: &str, ref_name: &str) -> Result<PushOutcome> {
     let refspec = format!("{ref_name}:{ref_name}");
 
     let output = Command::new("git")
         .current_dir(repo_dir)
         .args(["push", remote, &refspec])
         .output()
-        .with_context(|| format!("failed to run git push for agent '{agent_id}'"))?;
+        .with_context(|| format!("failed to run git push for ref '{ref_name}'"))?;
 
+    Ok(classify_push_output(&output))
+}
+
+/// Push a ref with `--force-with-lease`, used for the checkpoint ref (REQ-7).
+///
+/// The checkpoint is a pure cache: two compactors over the same event set
+/// produce byte-identical content, so a checkpoint race is harmless. The lease
+/// guards against clobbering a checkpoint advanced by an unseen third party —
+/// the lease loser refetches and either fast-forwards or discards its identical
+/// result. `expected_remote` is the remote SHA the local side believes the ref
+/// holds:
+///
+/// - `Some(sha)` → `git push --force-with-lease=<ref>:<sha>` (strict lease).
+/// - `None` → `git push --force-with-lease=<ref>` (git uses the local
+///   remote-tracking ref as the lease baseline).
+///
+/// A failed lease (the remote advanced past `expected_remote`) is reported as
+/// [`PushOutcome::NonFastForward`]; the caller refetches and retries.
+///
+/// # Errors
+///
+/// Returns an error only if `git push` cannot be spawned.
+// PR3 compaction-checkpoint push is the production caller; flagged dead until
+// that path lands in part 2.
+#[allow(dead_code)]
+pub fn push_ref_with_lease(
+    repo_dir: &Path,
+    remote: &str,
+    ref_name: &str,
+    expected_remote: Option<&str>,
+) -> Result<PushOutcome> {
+    let lease = expected_remote.map_or_else(
+        || format!("--force-with-lease={ref_name}"),
+        |sha| format!("--force-with-lease={ref_name}:{sha}"),
+    );
+    let refspec = format!("{ref_name}:{ref_name}");
+
+    let output = Command::new("git")
+        .current_dir(repo_dir)
+        .args(["push", &lease, remote, &refspec])
+        .output()
+        .with_context(|| {
+            format!("failed to run git push --force-with-lease for ref '{ref_name}'")
+        })?;
+
+    Ok(classify_push_output(&output))
+}
+
+/// Classify a `git push` process output into a [`PushOutcome`].
+///
+/// Shared by [`push_ref`] and [`push_ref_with_lease`]. A failed
+/// `--force-with-lease` reports "stale info" / "rejected", which map to
+/// [`PushOutcome::NonFastForward`] — the caller refetches and retries.
+fn classify_push_output(output: &std::process::Output) -> PushOutcome {
     if output.status.success() {
-        return Ok(PushOutcome::Pushed);
+        return PushOutcome::Pushed;
     }
 
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -378,7 +481,7 @@ pub fn push_agent_ref(repo_dir: &Path, remote: &str, agent_id: &str) -> Result<P
         || stderr.contains("rejected")
         || stderr.contains("stale info")
     {
-        return Ok(PushOutcome::NonFastForward);
+        return PushOutcome::NonFastForward;
     }
 
     if stderr.contains("does not appear to be a git repository")
@@ -387,10 +490,170 @@ pub fn push_agent_ref(repo_dir: &Path, remote: &str, agent_id: &str) -> Result<P
         || stderr.contains("No such remote")
         || stderr.contains('\'') && stderr.contains("' does not")
     {
-        return Ok(PushOutcome::NoRemote);
+        return PushOutcome::NoRemote;
     }
 
-    Ok(PushOutcome::Failed(stderr.trim().to_string()))
+    PushOutcome::Failed(stderr.trim().to_string())
+}
+
+// ── Hub version detection ─────────────────────────────────────────────
+
+/// Branch name of the legacy v2 hub.
+const V2_HUB_BRANCH: &str = "refs/heads/crosslink/hub";
+
+/// Detected hub schema version.
+///
+/// See `.design/hub-v3-per-agent-refs.md` REQ-9. Detection is structural:
+/// presence of the v3 marker refs ([`META_REF`] + [`CHECKPOINT_REF`]) versus the
+/// legacy `crosslink/hub` branch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+// Consumed by the migrate command and the v3-aware warn path (part 2); the bin's
+// duplicate module tree flags the variants as dead code until then.
+#[allow(dead_code)]
+pub enum HubVersion {
+    /// A `crosslink/hub` branch exists but neither v3 marker ref does.
+    V2Only,
+    /// The v3 marker refs ([`META_REF`] + [`CHECKPOINT_REF`]) exist.
+    /// `v2_branch_present` records whether the old branch is still around
+    /// (true until `migrate hub-v3 --finalize` deletes it).
+    V3 { v2_branch_present: bool },
+    /// Neither a v2 branch nor the v3 marker refs exist (uninitialized hub).
+    Absent,
+}
+
+/// Detect the LOCAL hub version by inspecting refs in `repo_dir`.
+///
+/// Classification (REQ-9): if both [`META_REF`] and [`CHECKPOINT_REF`] resolve,
+/// the hub is `V3` (recording whether the v2 branch is still present); otherwise
+/// if the `crosslink/hub` branch resolves, it is `V2Only`; otherwise `Absent`.
+///
+/// # Errors
+///
+/// Returns an error only if `git rev-parse` cannot be spawned.
+// Part-2 migrate/refusal logic is the production caller; flagged dead until then.
+#[allow(dead_code)]
+pub fn detect_hub_version(repo_dir: &Path) -> Result<HubVersion> {
+    let meta = git_rev_parse_optional(repo_dir, META_REF)?.is_some();
+    let checkpoint = git_rev_parse_optional(repo_dir, CHECKPOINT_REF)?.is_some();
+    let v2 = git_rev_parse_optional(repo_dir, V2_HUB_BRANCH)?.is_some();
+
+    Ok(classify_hub_version(meta, checkpoint, v2))
+}
+
+/// Detect the REMOTE hub version via a single `git ls-remote` call.
+///
+/// Queries `git ls-remote <remote> refs/crosslink/* refs/heads/crosslink/hub`
+/// and classifies the returned ref listing identically to [`detect_hub_version`].
+/// Unlike the local probe, an unreachable or unauthenticated remote is a hard
+/// error — the version of an unreachable remote must never be guessed (REQ-9).
+///
+/// # Errors
+///
+/// Returns an error if `git ls-remote` cannot be spawned, or if the remote is
+/// unreachable / unauthenticated / unknown (classified from stderr, paralleling
+/// the [`PushOutcome`] stderr discrimination).
+// Part-2 migrate/refusal logic is the production caller; flagged dead until then.
+#[allow(dead_code)]
+pub fn detect_remote_hub_version(repo_dir: &Path, remote: &str) -> Result<HubVersion> {
+    let output = Command::new("git")
+        .current_dir(repo_dir)
+        .args(["ls-remote", remote, "refs/crosslink/*", V2_HUB_BRANCH])
+        .output()
+        .with_context(|| format!("failed to run git ls-remote for remote '{remote}'"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!(
+            "git ls-remote failed for remote '{remote}' (cannot determine remote hub version; \
+             remote unreachable, unauthenticated, or unknown): {}",
+            stderr.trim()
+        );
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut meta = false;
+    let mut checkpoint = false;
+    let mut v2 = false;
+    // Each line is "<sha>\t<refname>".
+    for line in stdout.lines() {
+        let Some((_, refname)) = line.split_once('\t') else {
+            continue;
+        };
+        let refname = refname.trim();
+        match refname {
+            META_REF => meta = true,
+            CHECKPOINT_REF => checkpoint = true,
+            V2_HUB_BRANCH => v2 = true,
+            _ => {}
+        }
+    }
+
+    Ok(classify_hub_version(meta, checkpoint, v2))
+}
+
+/// Pure classifier shared by the local and remote detectors.
+const fn classify_hub_version(
+    meta_present: bool,
+    checkpoint_present: bool,
+    v2_present: bool,
+) -> HubVersion {
+    if meta_present && checkpoint_present {
+        HubVersion::V3 {
+            v2_branch_present: v2_present,
+        }
+    } else if v2_present {
+        HubVersion::V2Only
+    } else {
+        HubVersion::Absent
+    }
+}
+
+// ── Hub meta marker (META_REF) ────────────────────────────────────────
+
+/// Hub version marker stored as `hub.json` on [`META_REF`].
+///
+/// Written by `crosslink migrate hub-v3` (part 2) alongside the `allowed_signers`
+/// blob. Records the schema version and provenance of the migration.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+// Constructed and read by the migrate command and the verify path (part 2);
+// flagged dead until those callers land.
+#[allow(dead_code)]
+pub struct HubMeta {
+    /// Hub schema version (3 for v3).
+    pub hub_version: u32,
+    /// The `crosslink/hub` commit the migration was derived from.
+    pub migrated_from_commit: String,
+    /// When the migration ran.
+    pub migrated_at: chrono::DateTime<chrono::Utc>,
+    /// When `migrate hub-v3 --finalize` deleted the legacy v2 branch, if ever.
+    /// `None` until finalize runs; `serde(default)` so pre-finalize markers and
+    /// markers written before this field existed parse cleanly.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub finalized_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// Read the [`HubMeta`] marker from the [`META_REF`] tip, if present.
+///
+/// Returns `Ok(None)` when the meta ref does not exist (no v3 marker yet) or
+/// when its tree has no `hub.json` (a meta ref carrying only `allowed_signers`).
+///
+/// # Errors
+///
+/// Returns an error if git plumbing fails or `hub.json` exists but does not
+/// parse as [`HubMeta`].
+// Part-2 verify / refusal logic is the production caller; flagged dead until then.
+#[allow(dead_code)]
+pub fn read_hub_meta(repo_dir: &Path) -> Result<Option<HubMeta>> {
+    let Some(tip) = git_rev_parse_optional(repo_dir, META_REF)? else {
+        return Ok(None);
+    };
+    let spec = format!("{tip}:hub.json");
+    let Some(bytes) = git_cat_file_blob_optional(repo_dir, &spec)? else {
+        return Ok(None);
+    };
+    let meta: HubMeta = serde_json::from_slice(&bytes)
+        .context("failed to parse hub.json on the meta ref as HubMeta")?;
+    Ok(Some(meta))
 }
 
 // ── Config helper ────────────────────────────────────────────────────
@@ -429,6 +692,34 @@ pub fn dual_write_enabled(crosslink_dir: &Path) -> bool {
     val.get("hub_v3.dual_write")
         .and_then(serde_json::Value::as_bool)
         .unwrap_or(false)
+}
+
+// ── v3-aware warn for v2 operation on a migrated hub ──────────────────
+
+/// One-shot guard so the migrated-hub warning fires at most once per process.
+static MIGRATED_V2_WARNED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Warn once if the hub at `repo_dir` has been migrated to v3 ([`detect_hub_version`]
+/// reports `V3`) while we are about to operate it in v2 mode.
+///
+/// Pre-finalize, mixed-version operation is user-managed (full refusal is the
+/// follow-up #754): v2 writes are NOT reflected in v3 until the cutover. This is
+/// cheap (a few `git rev-parse` probes) and never fatal — detection failures are
+/// swallowed so the warning can never block a hub operation.
+pub fn warn_if_migrated_v2_operation(repo_dir: &Path) {
+    use std::sync::atomic::Ordering;
+    if MIGRATED_V2_WARNED.load(Ordering::Relaxed) {
+        return;
+    }
+    if let Ok(HubVersion::V3 { .. }) = detect_hub_version(repo_dir) {
+        if !MIGRATED_V2_WARNED.swap(true, Ordering::Relaxed) {
+            tracing::warn!(
+                "hub has been migrated to v3; v2 writes are not reflected in v3 — \
+                 finish the cutover or avoid mixed operation"
+            );
+        }
+    }
 }
 
 // ── Shadow stats ──────────────────────────────────────────────────────
@@ -577,46 +868,6 @@ fn git_hash_object(repo_dir: &Path, data: &[u8]) -> Result<String> {
     Ok(sha)
 }
 
-/// Create a tree from a single `events.log` blob via `git mktree`.
-///
-/// The input line is `100644 blob <blob_sha>\tevents.log`.
-fn git_mktree(repo_dir: &Path, blob_sha: &str) -> Result<String> {
-    use std::io::Write as _;
-
-    let tree_line = format!("100644 blob {blob_sha}\tevents.log\n");
-
-    let mut child = Command::new("git")
-        .current_dir(repo_dir)
-        .args(["mktree"])
-        .stdin(std::process::Stdio::piped())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .spawn()
-        .context("failed to spawn git mktree")?;
-
-    child
-        .stdin
-        .take()
-        .ok_or_else(|| anyhow::anyhow!("git mktree stdin pipe unavailable"))?
-        .write_all(tree_line.as_bytes())
-        .context("failed to write to git mktree stdin")?;
-
-    let output = child
-        .wait_with_output()
-        .context("failed to wait for git mktree")?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("git mktree failed: {}", stderr.trim());
-    }
-
-    let sha = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if sha.is_empty() {
-        anyhow::bail!("git mktree returned empty SHA");
-    }
-    Ok(sha)
-}
-
 /// Create a commit object via `git commit-tree`.
 ///
 /// Sets deterministic author/committer identity from `agent_id`. Parent is
@@ -704,6 +955,238 @@ fn git_update_ref_cas(
         "ref moved concurrently: {ref_name} (git update-ref failed: {})",
         stderr.trim()
     )
+}
+
+// ── Generalized single-file / multi-file commit core ─────────────────
+
+/// Build a tree from a single file entry, commit it onto `ref_name`, and move
+/// the ref with a compare-and-swap.
+///
+/// This is the shared core extracted from the append path, [`commit_log_bytes`],
+/// and [`commit_blob_to_ref`]. It hashes `bytes`, creates a one-entry tree
+/// (`<file_name>`) at the TREE ROOT, commits it (parent = the resolved old tip),
+/// and CAS-updates the ref per `expected`.
+///
+/// The new state is always added as a CHILD of the current tip when one exists,
+/// so any subsequent push remains a fast-forward.
+///
+/// # Errors
+///
+/// - `MustNotExist` when the ref already exists, or `MustMatch`/`CurrentTip`
+///   when the ref moved between read and update: returns
+///   `"ref moved concurrently: <ref>"`.
+/// - Any git plumbing failure.
+fn commit_single_file_tree(
+    repo_dir: &Path,
+    ref_name: &str,
+    file_name: &str,
+    bytes: &[u8],
+    message: &str,
+    committer_id: &str,
+    expected: CasExpectation<'_>,
+) -> Result<String> {
+    let blob_sha = git_hash_object(repo_dir, bytes)?;
+    let tree_sha = git_mktree_single(repo_dir, &blob_sha, file_name)?;
+    commit_tree_and_update_ref(
+        repo_dir,
+        ref_name,
+        &tree_sha,
+        message,
+        committer_id,
+        expected,
+    )
+}
+
+/// Resolve the CAS old-value and the commit parent for an `expected`
+/// expectation, validating any `MustNotExist` / `MustMatch` precondition.
+///
+/// Returns `(parent_for_commit, old_value_for_cas)`. Both are `Option<String>`:
+/// `None` parent means a genesis (parentless) commit; `None`/`Some` old value
+/// maps directly onto the `git update-ref <ref> <new> <old>` contract.
+fn resolve_cas_old(
+    repo_dir: &Path,
+    ref_name: &str,
+    expected: CasExpectation<'_>,
+) -> Result<Option<String>> {
+    match expected {
+        CasExpectation::MustNotExist => {
+            if git_rev_parse_optional(repo_dir, ref_name)?.is_some() {
+                anyhow::bail!(
+                    "ref moved concurrently: {ref_name} (expected absent, but it exists)"
+                );
+            }
+            Ok(None)
+        }
+        CasExpectation::MustMatch(sha) => Ok(Some(sha.to_string())),
+        CasExpectation::CurrentTip => git_rev_parse_optional(repo_dir, ref_name),
+    }
+}
+
+/// Commit `tree_sha` onto `ref_name` with a parent/CAS resolved from `expected`,
+/// then CAS-update the ref. Shared by the single-file and multi-file paths.
+fn commit_tree_and_update_ref(
+    repo_dir: &Path,
+    ref_name: &str,
+    tree_sha: &str,
+    message: &str,
+    committer_id: &str,
+    expected: CasExpectation<'_>,
+) -> Result<String> {
+    let old_commit = resolve_cas_old(repo_dir, ref_name, expected)?;
+    let commit_sha = git_commit_tree(
+        repo_dir,
+        tree_sha,
+        old_commit.as_deref(),
+        message,
+        committer_id,
+    )?;
+    git_update_ref_cas(repo_dir, ref_name, &commit_sha, old_commit.as_deref())?;
+    Ok(commit_sha)
+}
+
+/// Commit a single blob to an arbitrary ref at the TREE ROOT under `file_name`.
+///
+/// Reads the current tip as the commit parent and CAS-updates on it
+/// ([`CasExpectation::CurrentTip`]): genesis when absent, fast-forward child
+/// when present. Used for the checkpoint ref (`state.json`) and any other
+/// single-file driver ref.
+///
+/// # Errors
+///
+/// Returns an error if the ref moved concurrently (CAS failure) or any git
+/// plumbing step fails.
+// PR3 read/verify path and the migrate command (part 2) are the production
+// callers; the bin's duplicate module tree flags it as dead code until then.
+#[allow(dead_code)]
+pub fn commit_blob_to_ref(
+    repo_dir: &Path,
+    ref_name: &str,
+    file_name: &str,
+    bytes: &[u8],
+    message: &str,
+) -> Result<String> {
+    commit_single_file_tree(
+        repo_dir,
+        ref_name,
+        file_name,
+        bytes,
+        message,
+        "crosslink",
+        CasExpectation::CurrentTip,
+    )
+}
+
+/// Commit MULTIPLE files into a single tree at the TREE ROOT and move `ref_name`.
+///
+/// `files` is a slice of `(file_name, bytes)` pairs. The entries are sorted by
+/// name before `git mktree` so the tree is well-formed regardless of the input
+/// order. Used for [`META_REF`], which carries `hub.json` plus `allowed_signers`.
+///
+/// Reads the current tip as the commit parent ([`CasExpectation::CurrentTip`]):
+/// genesis when absent, fast-forward child when present.
+///
+/// # mktree ordering
+///
+/// Git's tree object format requires entries sorted by name. Modern `git mktree`
+/// (observed: 2.54) re-sorts its stdin, but older versions and `--missing` mode
+/// can reject unsorted input, so this function sorts defensively before feeding
+/// mktree. Duplicate file names are rejected (a malformed tree request).
+///
+/// # Errors
+///
+/// Returns an error on duplicate file names, CAS failure, or any git plumbing
+/// failure.
+// PR3 migrate command (part 2) writes META_REF; flagged dead until then.
+#[allow(dead_code)]
+pub fn commit_files_to_ref(
+    repo_dir: &Path,
+    ref_name: &str,
+    files: &[(&str, &[u8])],
+    message: &str,
+) -> Result<String> {
+    anyhow::ensure!(
+        !files.is_empty(),
+        "commit_files_to_ref requires at least one file"
+    );
+
+    // Hash every blob, then sort tree lines by file name (git tree invariant).
+    let mut entries: Vec<(String, String)> = Vec::with_capacity(files.len());
+    for (name, bytes) in files {
+        anyhow::ensure!(
+            !name.contains('/') && !name.is_empty(),
+            "commit_files_to_ref file name must be a non-empty tree-root name, got '{name}'"
+        );
+        let blob_sha = git_hash_object(repo_dir, bytes)?;
+        entries.push(((*name).to_string(), blob_sha));
+    }
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    for pair in entries.windows(2) {
+        anyhow::ensure!(
+            pair[0].0 != pair[1].0,
+            "commit_files_to_ref got duplicate file name '{}'",
+            pair[0].0
+        );
+    }
+
+    let tree_sha = git_mktree_multi(repo_dir, &entries)?;
+    commit_tree_and_update_ref(
+        repo_dir,
+        ref_name,
+        &tree_sha,
+        message,
+        "crosslink",
+        CasExpectation::CurrentTip,
+    )
+}
+
+/// Create a tree from a single blob under an arbitrary `file_name` via
+/// `git mktree`. Generalizes [`git_mktree`] (which hardcodes `events.log`).
+fn git_mktree_single(repo_dir: &Path, blob_sha: &str, file_name: &str) -> Result<String> {
+    git_mktree_multi(repo_dir, &[(file_name.to_string(), blob_sha.to_string())])
+}
+
+/// Create a tree from sorted `(file_name, blob_sha)` entries via `git mktree`.
+fn git_mktree_multi(repo_dir: &Path, entries: &[(String, String)]) -> Result<String> {
+    use std::fmt::Write as _;
+    use std::io::Write as _;
+
+    let mut input = String::new();
+    for (name, blob_sha) in entries {
+        // `write!` to a String is infallible; the trait method returns Result so
+        // the unused-result is intentionally discarded.
+        let _ = writeln!(input, "100644 blob {blob_sha}\t{name}");
+    }
+
+    let mut child = Command::new("git")
+        .current_dir(repo_dir)
+        .args(["mktree"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .context("failed to spawn git mktree")?;
+
+    child
+        .stdin
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("git mktree stdin pipe unavailable"))?
+        .write_all(input.as_bytes())
+        .context("failed to write to git mktree stdin")?;
+
+    let output = child
+        .wait_with_output()
+        .context("failed to wait for git mktree")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("git mktree failed: {}", stderr.trim());
+    }
+
+    let sha = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if sha.is_empty() {
+        anyhow::bail!("git mktree returned empty SHA");
+    }
+    Ok(sha)
 }
 
 // ── Tests ────────────────────────────────────────────────────────────
@@ -1294,5 +1777,381 @@ mod tests {
         assert_eq!(read.pushed, 40);
         assert_eq!(read.push_failures, 2);
         assert_eq!(read.last_failure.as_deref(), Some("test failure"));
+    }
+
+    // ── Test 10: commit_blob_to_ref genesis + CAS conflict ───────────
+
+    #[test]
+    fn commit_blob_to_ref_genesis_and_cas_conflict() {
+        let dir = tempfile::tempdir().unwrap();
+        git_init(dir.path());
+
+        let ref_name = CHECKPOINT_REF;
+
+        // Genesis: ref does not exist yet.
+        let sha1 = commit_blob_to_ref(
+            dir.path(),
+            ref_name,
+            "state.json",
+            b"{\"v\":1}\n",
+            "genesis checkpoint",
+        )
+        .unwrap();
+        let tip = run_git_output(dir.path(), &["rev-parse", ref_name]);
+        assert_eq!(tip, sha1, "ref must point at the genesis commit");
+
+        // Genesis commit must be parentless and the blob readable at the root.
+        let log = run_git_output(dir.path(), &["log", "--oneline", ref_name]);
+        assert_eq!(log.lines().count(), 1, "genesis commit must have no parent");
+        let blob = run_git_output(
+            dir.path(),
+            &["cat-file", "blob", &format!("{sha1}:state.json")],
+        );
+        assert_eq!(blob, "{\"v\":1}");
+
+        // Second commit fast-forwards onto the tip (CurrentTip CAS).
+        let sha2 = commit_blob_to_ref(
+            dir.path(),
+            ref_name,
+            "state.json",
+            b"{\"v\":2}\n",
+            "second checkpoint",
+        )
+        .unwrap();
+        assert_ne!(sha1, sha2);
+        let count = run_git_output(dir.path(), &["rev-list", "--count", ref_name]);
+        assert_eq!(count, "2", "second commit must chain onto the first");
+
+        // CAS conflict: directly invoke the single-file core with a stale
+        // MustMatch expectation (ref has moved past sha1).
+        let stale = commit_single_file_tree(
+            dir.path(),
+            ref_name,
+            "state.json",
+            b"{\"v\":3}\n",
+            "stale checkpoint",
+            "crosslink",
+            CasExpectation::MustMatch(&sha1),
+        );
+        assert!(stale.is_err(), "stale MustMatch CAS must fail");
+        let msg = format!("{:?}", stale.unwrap_err());
+        assert!(
+            msg.contains("ref moved concurrently"),
+            "CAS conflict error must mention concurrent move, got: {msg}"
+        );
+
+        // MustNotExist on an existing ref must also fail.
+        let exists = commit_single_file_tree(
+            dir.path(),
+            ref_name,
+            "state.json",
+            b"{}\n",
+            "genesis on existing",
+            "crosslink",
+            CasExpectation::MustNotExist,
+        );
+        assert!(exists.is_err(), "MustNotExist on an existing ref must fail");
+    }
+
+    // ── Test 11: commit_files_to_ref multi-file tree + ordering ──────
+
+    #[test]
+    fn commit_files_to_ref_multi_file_ordering() {
+        let dir = tempfile::tempdir().unwrap();
+        git_init(dir.path());
+
+        // Deliberately pass entries in NON-sorted order (hub.json before
+        // allowed_signers) to exercise the defensive sort.
+        let files: &[(&str, &[u8])] = &[
+            ("hub.json", b"{\"hub_version\":3}\n"),
+            ("allowed_signers", b"signer line\n"),
+        ];
+        let sha = commit_files_to_ref(dir.path(), META_REF, files, "meta genesis").unwrap();
+
+        // Both files readable at the tree root.
+        let hub = run_git_output(
+            dir.path(),
+            &["cat-file", "blob", &format!("{sha}:hub.json")],
+        );
+        assert_eq!(hub, "{\"hub_version\":3}");
+        let signers = run_git_output(
+            dir.path(),
+            &["cat-file", "blob", &format!("{sha}:allowed_signers")],
+        );
+        assert_eq!(signers, "signer line");
+
+        // ls-tree output is sorted by name (git tree invariant): allowed_signers
+        // sorts before hub.json.
+        let listing = run_git_output(dir.path(), &["ls-tree", "--name-only", sha.as_str()]);
+        let names: Vec<&str> = listing.lines().collect();
+        assert_eq!(names, vec!["allowed_signers", "hub.json"]);
+
+        // Duplicate file names are rejected.
+        let dup: &[(&str, &[u8])] = &[("a.json", b"1"), ("a.json", b"2")];
+        assert!(
+            commit_files_to_ref(dir.path(), META_REF, dup, "dup").is_err(),
+            "duplicate file names must be rejected"
+        );
+    }
+
+    // ── Test 12: push_ref_with_lease success + lease rejection ───────
+
+    #[test]
+    fn push_ref_with_lease_success_and_rejection() {
+        let local_dir = tempfile::tempdir().unwrap();
+        let remote_dir = tempfile::tempdir().unwrap();
+        git_init(local_dir.path());
+        run_git(remote_dir.path(), &["init", "--bare"]);
+        run_git(
+            local_dir.path(),
+            &[
+                "remote",
+                "add",
+                "origin",
+                remote_dir.path().to_str().unwrap(),
+            ],
+        );
+
+        let ref_name = CHECKPOINT_REF;
+
+        // Genesis checkpoint, then push with lease (no expected baseline → None).
+        commit_blob_to_ref(
+            local_dir.path(),
+            ref_name,
+            "state.json",
+            b"{\"v\":1}\n",
+            "cp1",
+        )
+        .unwrap();
+        let p1 = push_ref_with_lease(local_dir.path(), "origin", ref_name, None).unwrap();
+        assert!(
+            matches!(p1, PushOutcome::Pushed),
+            "genesis lease push must succeed"
+        );
+        let remote_tip1 = run_git_output(remote_dir.path(), &["rev-parse", ref_name]);
+
+        // Advance locally and push again with the correct expected remote SHA.
+        commit_blob_to_ref(
+            local_dir.path(),
+            ref_name,
+            "state.json",
+            b"{\"v\":2}\n",
+            "cp2",
+        )
+        .unwrap();
+        let p2 =
+            push_ref_with_lease(local_dir.path(), "origin", ref_name, Some(&remote_tip1)).unwrap();
+        assert!(
+            matches!(p2, PushOutcome::Pushed),
+            "matching-lease push must succeed"
+        );
+        let remote_tip2 = run_git_output(remote_dir.path(), &["rev-parse", ref_name]);
+
+        // Now move the REMOTE ref out from under us to a divergent commit, then
+        // push with a STALE expected baseline (remote_tip2). The lease must
+        // reject.
+        // Build a divergent commit on the remote by pushing an unrelated history.
+        commit_blob_to_ref(
+            remote_dir.path(),
+            "refs/crosslink/scratch",
+            "state.json",
+            b"X\n",
+            "scratch",
+        )
+        .unwrap();
+        let divergent = run_git_output(remote_dir.path(), &["rev-parse", "refs/crosslink/scratch"]);
+        run_git(remote_dir.path(), &["update-ref", ref_name, &divergent]);
+
+        // Local still believes remote is at remote_tip2 → stale lease → rejected.
+        commit_blob_to_ref(
+            local_dir.path(),
+            ref_name,
+            "state.json",
+            b"{\"v\":3}\n",
+            "cp3",
+        )
+        .unwrap();
+        let p3 =
+            push_ref_with_lease(local_dir.path(), "origin", ref_name, Some(&remote_tip2)).unwrap();
+        assert!(
+            matches!(p3, PushOutcome::NonFastForward),
+            "stale lease must be rejected as NonFastForward, got a different outcome"
+        );
+        // Remote unchanged by the rejected push.
+        let remote_after = run_git_output(remote_dir.path(), &["rev-parse", ref_name]);
+        assert_eq!(
+            remote_after, divergent,
+            "rejected lease push must not move the remote"
+        );
+    }
+
+    // ── Test 13: detect_hub_version matrix ───────────────────────────
+
+    #[test]
+    fn detect_hub_version_matrix() {
+        let dir = tempfile::tempdir().unwrap();
+        git_init(dir.path());
+
+        // Absent: no refs at all.
+        assert_eq!(detect_hub_version(dir.path()).unwrap(), HubVersion::Absent);
+
+        // V2Only: create a crosslink/hub branch (needs a commit to point at).
+        let cp = commit_blob_to_ref(dir.path(), "refs/crosslink/tmp", "x", b"x\n", "tmp").unwrap();
+        run_git(dir.path(), &["update-ref", "refs/heads/crosslink/hub", &cp]);
+        assert_eq!(detect_hub_version(dir.path()).unwrap(), HubVersion::V2Only);
+
+        // V3 with v2 branch present: add meta + checkpoint refs.
+        commit_files_to_ref(dir.path(), META_REF, &[("hub.json", b"{}\n")], "meta").unwrap();
+        commit_blob_to_ref(dir.path(), CHECKPOINT_REF, "state.json", b"{}\n", "cp").unwrap();
+        assert_eq!(
+            detect_hub_version(dir.path()).unwrap(),
+            HubVersion::V3 {
+                v2_branch_present: true
+            }
+        );
+
+        // V3 without v2 branch: delete the v2 branch.
+        run_git(
+            dir.path(),
+            &["update-ref", "-d", "refs/heads/crosslink/hub"],
+        );
+        assert_eq!(
+            detect_hub_version(dir.path()).unwrap(),
+            HubVersion::V3 {
+                v2_branch_present: false
+            }
+        );
+    }
+
+    // ── Test 14: detect_remote_hub_version matrix + unreachable ──────
+
+    #[test]
+    fn detect_remote_hub_version_matrix_and_unreachable() {
+        let local_dir = tempfile::tempdir().unwrap();
+        let remote_dir = tempfile::tempdir().unwrap();
+        git_init(local_dir.path());
+        run_git(remote_dir.path(), &["init", "--bare"]);
+        run_git(
+            local_dir.path(),
+            &[
+                "remote",
+                "add",
+                "origin",
+                remote_dir.path().to_str().unwrap(),
+            ],
+        );
+
+        // Absent: bare remote with no crosslink refs.
+        assert_eq!(
+            detect_remote_hub_version(local_dir.path(), "origin").unwrap(),
+            HubVersion::Absent
+        );
+
+        // V2Only: create the v2 branch on the remote.
+        commit_blob_to_ref(remote_dir.path(), "refs/crosslink/tmp", "x", b"x\n", "tmp").unwrap();
+        let tmp = run_git_output(remote_dir.path(), &["rev-parse", "refs/crosslink/tmp"]);
+        run_git(
+            remote_dir.path(),
+            &["update-ref", "refs/heads/crosslink/hub", &tmp],
+        );
+        run_git(
+            remote_dir.path(),
+            &["update-ref", "-d", "refs/crosslink/tmp"],
+        );
+        assert_eq!(
+            detect_remote_hub_version(local_dir.path(), "origin").unwrap(),
+            HubVersion::V2Only
+        );
+
+        // V3 with v2 present: add meta + checkpoint on the remote.
+        commit_files_to_ref(
+            remote_dir.path(),
+            META_REF,
+            &[("hub.json", b"{}\n")],
+            "meta",
+        )
+        .unwrap();
+        commit_blob_to_ref(
+            remote_dir.path(),
+            CHECKPOINT_REF,
+            "state.json",
+            b"{}\n",
+            "cp",
+        )
+        .unwrap();
+        assert_eq!(
+            detect_remote_hub_version(local_dir.path(), "origin").unwrap(),
+            HubVersion::V3 {
+                v2_branch_present: true
+            }
+        );
+
+        // V3 without v2: drop the remote v2 branch.
+        run_git(
+            remote_dir.path(),
+            &["update-ref", "-d", "refs/heads/crosslink/hub"],
+        );
+        assert_eq!(
+            detect_remote_hub_version(local_dir.path(), "origin").unwrap(),
+            HubVersion::V3 {
+                v2_branch_present: false
+            }
+        );
+
+        // Unreachable remote → hard error (never guess).
+        let err = detect_remote_hub_version(local_dir.path(), "/no/such/remote/path").unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("ls-remote")
+                || msg.contains("remote unreachable")
+                || msg.contains("cannot determine"),
+            "unreachable remote must hard-error, got: {msg}"
+        );
+    }
+
+    // ── Test 15: HubMeta round-trip ──────────────────────────────────
+
+    #[test]
+    fn hub_meta_roundtrip_via_commit_files_and_read() {
+        let dir = tempfile::tempdir().unwrap();
+        git_init(dir.path());
+
+        // No meta ref → None.
+        assert!(read_hub_meta(dir.path()).unwrap().is_none());
+
+        let meta = HubMeta {
+            hub_version: 3,
+            migrated_from_commit: "deadbeefcafe1234".to_string(),
+            migrated_at: chrono::Utc::now(),
+            finalized_at: None,
+        };
+        let meta_bytes = serde_json::to_vec(&meta).unwrap();
+        commit_files_to_ref(
+            dir.path(),
+            META_REF,
+            &[("hub.json", &meta_bytes), ("allowed_signers", b"sig\n")],
+            "meta with marker",
+        )
+        .unwrap();
+
+        let read = read_hub_meta(dir.path())
+            .unwrap()
+            .expect("meta must be present");
+        assert_eq!(read.hub_version, 3);
+        assert_eq!(read.migrated_from_commit, "deadbeefcafe1234");
+        // chrono round-trips at the serialized precision.
+        assert_eq!(read, meta);
+
+        // A meta ref without hub.json (only allowed_signers) → None.
+        let dir2 = tempfile::tempdir().unwrap();
+        git_init(dir2.path());
+        commit_files_to_ref(
+            dir2.path(),
+            META_REF,
+            &[("allowed_signers", b"sig\n")],
+            "meta no marker",
+        )
+        .unwrap();
+        assert!(read_hub_meta(dir2.path()).unwrap().is_none());
     }
 }

--- a/crosslink/src/main.rs
+++ b/crosslink/src/main.rs
@@ -867,6 +867,23 @@ enum MigrateCommands {
     FromShared,
     /// Rename coordination branch from crosslink/locks to crosslink/hub
     RenameBranch,
+    /// Convert a v2 hub to the v3 per-agent-ref layout (one-shot, verified).
+    ///
+    /// Without `--finalize`: seeds per-agent refs + a genesis checkpoint from
+    /// the current hub state, runs the AC-6 full-state verification gate, and
+    /// pushes the v3 refs. The legacy crosslink/hub branch is left intact as a
+    /// read-only escape hatch.
+    ///
+    /// With `--finalize --yes-delete-v2`: re-verifies, then deletes the legacy
+    /// crosslink/hub branch locally and on the remote (the hard cutover).
+    HubV3 {
+        /// Delete the legacy crosslink/hub branch (destructive cutover).
+        #[arg(long)]
+        finalize: bool,
+        /// Required confirmation for `--finalize` (it deletes the v2 branch).
+        #[arg(long)]
+        yes_delete_v2: bool,
+    },
 }
 
 /// Subcommands for `crosslink dashboard` (GH #429).
@@ -2641,6 +2658,13 @@ fn main() -> Result<()> {
             MigrateCommands::RenameBranch => {
                 let crosslink_dir = find_crosslink_dir()?;
                 commands::migrate::rename_branch(&crosslink_dir)
+            }
+            MigrateCommands::HubV3 {
+                finalize,
+                yes_delete_v2,
+            } => {
+                let crosslink_dir = find_crosslink_dir()?;
+                commands::migrate_hub_v3::hub_v3(&crosslink_dir, finalize, yes_delete_v2)
             }
         },
 

--- a/crosslink/src/shared_writer/core.rs
+++ b/crosslink/src/shared_writer/core.rs
@@ -134,6 +134,11 @@ impl SharedWriter {
         // no file I/O for the flag check.
         let hub_v3_dual_write = crate::hub_v3::dual_write_enabled(crosslink_dir);
 
+        // Minimal v3-aware warn (full refusal is #754): if the hub has already
+        // been migrated to v3 but we are about to operate it in v2 mode, warn
+        // once. Cheap (a rev-parse), non-fatal — never blocks the operation.
+        crate::hub_v3::warn_if_migrated_v2_operation(&cache_dir);
+
         Ok(Some(Self {
             sync,
             agent,

--- a/crosslink/src/sync/cache.rs
+++ b/crosslink/src/sync/cache.rs
@@ -638,6 +638,11 @@ impl SyncManager {
         // with concurrent CLI writes if not serialized.
         let _lock_guard = self.acquire_lock()?;
 
+        // Minimal v3-aware warn (full refusal is #754): warn once if this hub
+        // has already been migrated to v3 but we are still fetching/operating it
+        // in v2 mode. Cheap rev-parse, non-fatal.
+        crate::hub_v3::warn_if_migrated_v2_operation(&self.cache_dir);
+
         // Recover from broken git states before attempting fetch (#454, #455, #456)
         self.hub_health_check();
 


### PR DESCRIPTION
## Summary

PR3 of the hub v3 migration (`.design/hub-v3-per-agent-refs.md` REQ-9; crosslink issue #753, third in the #751-#754 sequence).

### The v3 read path: `RefHubSource`

`HubSource` impl over the v3 ref namespace (`refs/crosslink/checkpoint` + `refs/crosslink/agents/*` + `refs/crosslink/meta`), pinned at construction — checkpoint tip, meta tip, and every agent ref tip resolved once, so concurrent pushes cannot produce a torn view. `reduce(RefHubSource)` = genesis checkpoint plus events above its watermark. The keystone test (`worktree_and_ref_hub_reduce_to_identical_state`) proves the worktree and ref sources reduce to byte-identical state over the same logs — #754 swaps the production read path onto this with no semantic change.

Plumbing generalized along the way: shared single-file commit core, `commit_blob_to_ref`, `commit_files_to_ref` (multi-file trees for the meta ref), `push_ref`, and `push_ref_with_lease` for the checkpoint (races are harmless deterministic content; the lease loser refetches — REQ-7).

### `crosslink migrate hub-v3`

- **Genesis built from the files** (the authoritative materialized state), not the event logs: issues with comments/time entries (deterministic sha256-derived UUIDs for V1 inline entries lacking identity), milestones, `display_id_map` from file claims with **duplicate-ID refusal** (corrupt v2 state must be repaired via `integrity`, never silently remapped), counters reconciled to on-disk maxima, locks from a forced compaction.
- **Watermark** = max `OrderingKey` across all v2 logs, with a fixed-epoch sentinel synthesized for no-event hubs — `reduce()` treats a `None` watermark as full-reset, which would wipe the genesis on first read.
- **Agent refs** seeded via child commits over live dual-write shadow tips (v2 logs are byte-supersets by the PR2 parity invariant).
- **AC-6 verification gate**: whole-state serde equality (genesis == independent file re-read == `reduce(RefHubSource)`) plus direct file-level invariants. Any failure rolls back every `refs/crosslink/*` ref to its recorded pre-migration tip — including restoring pre-existing shadow refs — and the v2 branch is never touched at any point.
- **Idempotent re-run** doubles as push retry for refs the remote lacks.
- **`--finalize --yes-delete-v2`**: re-verifies, stamps `finalized_at`, deletes the v2 branch local+remote. Documented honestly: this is the intentional hard stop for already-shipped binaries, which check `layout_version >= 2` and cannot be made to refuse a v3 hub; pre-finalize mixed operation is user-managed and warned about after every migration run.

### Version detection and warn wiring

`HubVersion {Absent, V2Only, V3}` local + `ls-remote` detection (unreachable remotes are errors, never guesses); `HubMeta` marker on the meta ref. `SharedWriter::new` and `SyncManager::fetch` warn once when operating v2 on a migrated hub. Full refusal flips in #754.

## Testing

- `cargo fmt --all -- --check` clean; both clippy gates clean (`--all-targets -D warnings` and CI-strict `-W clippy::unwrap_used -W clippy::expect_used`).
- 1978 lib (+12), 2975 bin (+8), 194 CLI integration — all green.
- Coverage: plumbing CAS/multi-file/lease behavior, detection matrices (local and remote), `HubMeta` round-trip, `RefHubSource` pinning/vanished-commit/genesis-plus-events, worktree-vs-ref reduction equivalence, migration happy path + idempotent re-run, genesis-equals-files, watermark gating with no pre-genesis double-application, rollback restoration of all tips, duplicate-ID refusal, no-events sentinel, finalize gating with old-binary hard-stop simulation.

Generated with [Claude Code](https://claude.com/claude-code)