### PR TITLE
feat(hub): v3 operation mode -- ref-routed reads and writes by hub version

### DIFF
--- a/crosslink/src/agent_requests.rs
+++ b/crosslink/src/agent_requests.rs
@@ -228,6 +228,14 @@ pub mod poll {
         crosslink_dir: &std::path::Path,
         agent_id: &str,
     ) -> Result<PollResult> {
+        // V3: requests live on driver refs (`requests-out/`) and acks on the
+        // target's own ref (`requests-ack/`). poll_requests_for_agent already
+        // filters out anything this agent has acked, so every returned request
+        // is pending — no separate ack-pairing pass is needed.
+        if writer.is_v3_public() {
+            return process_pending_v3(writer, crosslink_dir, agent_id);
+        }
+
         let cache_dir = crosslink_dir.join("hub-cache");
         let entries = scan(&cache_dir, agent_id)?;
         let mut result = PollResult::default();
@@ -258,6 +266,50 @@ pub mod poll {
             result.acted.push(PollAction {
                 request_id: row.request.request_id,
                 kind: row.request.kind,
+                acted,
+                result: summary,
+                push_outcome,
+            });
+        }
+
+        Ok(result)
+    }
+
+    /// V3 variant of [`process_pending`]: poll requests via the per-agent ref
+    /// primitives (`poll_requests_for_agent`) and ack into the agent's own ref.
+    /// Every returned request is already pending (acked ones are filtered out by
+    /// the poll), so there is no skipped-ack accounting.
+    fn process_pending_v3(
+        writer: &SharedWriter,
+        crosslink_dir: &std::path::Path,
+        agent_id: &str,
+    ) -> Result<PollResult> {
+        let cache_dir = writer.cache_dir_public();
+        let pending = crate::hub_v3::poll_requests_for_agent(cache_dir, agent_id)?;
+        let mut result = PollResult::default();
+
+        for (_driver_id, request) in pending {
+            let (acted, summary) = apply_request(crosslink_dir, &request)
+                .unwrap_or_else(|e| (false, format!("error applying request: {e}")));
+
+            let ack = AgentRequestAck {
+                request_id: request.request_id.clone(),
+                ack_at: chrono::Utc::now().to_rfc3339(),
+                acted,
+                result: summary.clone(),
+                notes: None,
+            };
+            let push_outcome = writer.write_agent_ack(agent_id, &ack).unwrap_or_else(|e| {
+                tracing::warn!(
+                    "failed to push v3 ack for {}: {e}; treating as LocalOnly",
+                    request.request_id
+                );
+                PushOutcome::LocalOnly
+            });
+
+            result.acted.push(PollAction {
+                request_id: request.request_id,
+                kind: request.kind,
                 acted,
                 result: summary,
                 push_outcome,

--- a/crosslink/src/commands/compact.rs
+++ b/crosslink/src/commands/compact.rs
@@ -19,6 +19,31 @@ pub fn run(crosslink_dir: &Path, db: &Database, force: bool) -> Result<()> {
     // compaction's materialized-file writes (#750).
     let hub_lock = sync.acquire_lock()?;
 
+    // V3: route to compact_v3 (checkpoint ref + own-ref prune, REQ-7/REQ-11)
+    // and hydrate from the reduced state — the v2 compaction path requires the
+    // worktree materialized files that v3 does not maintain.
+    if sync.hub_mode().is_v3() {
+        let remote = if sync.remote_exists() {
+            Some(sync.remote())
+        } else {
+            None
+        };
+        let result = crate::hub_v3::compact_v3(&cache_dir, &agent.agent_id, &hub_lock, remote)?;
+        println!("Compaction complete (v3).");
+        if result.events_processed > 0 {
+            println!(
+                "  Events processed: {}, events pruned: {}, checkpoint pushed: {}",
+                result.events_processed, result.events_pruned, result.checkpoint_pushed
+            );
+        } else {
+            println!("  No new events to process.");
+        }
+        let source = crate::hub_source::RefHubSource::new(&cache_dir)?;
+        let outcome = crate::compaction::reduce(&source)?;
+        crate::hydration::hydrate_from_state(&outcome.state, db)?;
+        return Ok(());
+    }
+
     match crate::compaction::compact(&cache_dir, &agent.agent_id, force, &hub_lock)? {
         Some(result) => {
             println!("Compaction complete.");

--- a/crosslink/src/commands/hub_v3_operation_tests.rs
+++ b/crosslink/src/commands/hub_v3_operation_tests.rs
@@ -1,0 +1,741 @@
+//! End-to-end tests for hub-version-routed operation (754a PASS 2).
+//!
+//! These drive the production `migrate hub-v3` command (`super::migrate_hub_v3`)
+//! to build an authentic V3 hub, then operate it through `SharedWriter` /
+//! `SyncManager` in `HubMode::V3`. They cover: mode resolution, the event-only
+//! write lifecycle with no worktree writes, reduction-assigned ids, the
+//! two-writer convergence + no-collision invariant, lock claim-confirm,
+//! offline durability, fetch adoption rules, and heartbeat/request routing.
+
+#![cfg(test)]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use tempfile::TempDir;
+
+use crate::db::Database;
+use crate::hub_v3::{self, agent_ref_name, HubMode};
+use crate::identity::{AgentConfig, AgentRole};
+use crate::shared_writer::SharedWriter;
+use crate::sync::SyncManager;
+
+// ── Fixtures ─────────────────────────────────────────────────────────
+
+fn git(dir: &Path, args: &[&str]) {
+    let out = Command::new("git")
+        .current_dir(dir)
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn git_ok() -> bool {
+    Command::new("git")
+        .arg("--version")
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
+fn write_agent(crosslink_dir: &Path, id: &str) {
+    let agent = AgentConfig {
+        agent_id: id.to_string(),
+        machine_id: "test-machine".to_string(),
+        description: Some("test".to_string()),
+        role: AgentRole::Driver,
+        ssh_key_path: None,
+        ssh_fingerprint: None,
+        ssh_public_key: None,
+    };
+    std::fs::write(
+        crosslink_dir.join("agent.json"),
+        serde_json::to_string_pretty(&agent).unwrap(),
+    )
+    .unwrap();
+}
+
+/// A migrated V3 hub: a work clone with a bare remote, populated then migrated.
+struct V3Hub {
+    work: TempDir,
+    remote: TempDir,
+    crosslink_dir: PathBuf,
+    cache_dir: PathBuf,
+}
+
+/// Build a clone (`agent_id`) sharing `remote`. Returns `(work, crosslink_dir,
+/// cache_dir)`.
+fn clone_for_agent(remote: &Path, agent_id: &str) -> (TempDir, PathBuf, PathBuf) {
+    let work = tempfile::tempdir().unwrap();
+    let wp = work.path().to_path_buf();
+    git(&wp, &["init", "-b", "main"]);
+    git(&wp, &["config", "user.email", "test@test.local"]);
+    git(&wp, &["config", "user.name", "Test"]);
+    git(&wp, &["config", "commit.gpgsign", "false"]);
+    git(&wp, &["remote", "add", "origin", remote.to_str().unwrap()]);
+    git(&wp, &["fetch", "origin"]);
+    git(&wp, &["checkout", "main"]);
+    let crosslink_dir = wp.join(".crosslink");
+    std::fs::create_dir_all(&crosslink_dir).unwrap();
+    std::fs::write(
+        crosslink_dir.join("hook-config.json"),
+        r#"{"remote":"origin","layout":"v2"}"#,
+    )
+    .unwrap();
+    write_agent(&crosslink_dir, agent_id);
+    let sync = SyncManager::new(&crosslink_dir).unwrap();
+    sync.init_cache().unwrap();
+    let cache_dir = sync.cache_path().to_path_buf();
+    // Onboard the clone onto the v3 hub: fetch the marker + agent refs so
+    // `detect_hub_version` (hence `HubMode::resolve`) sees V3. A real v3-aware
+    // bootstrap (754b) does this; here we fetch the refs directly so the clone
+    // discovers the already-migrated hub.
+    git(
+        &cache_dir,
+        &["fetch", "origin", "+refs/crosslink/*:refs/crosslink/*"],
+    );
+    (work, crosslink_dir, cache_dir)
+}
+
+/// Create a populated v2 hub for `alpha`, then migrate it to v3.
+fn setup_migrated_v3_hub() -> V3Hub {
+    let remote = tempfile::tempdir().unwrap();
+    let work = tempfile::tempdir().unwrap();
+    git(remote.path(), &["init", "--bare", "-b", "main"]);
+    let wp = work.path().to_path_buf();
+    git(&wp, &["init", "-b", "main"]);
+    git(&wp, &["config", "user.email", "test@test.local"]);
+    git(&wp, &["config", "user.name", "Test"]);
+    git(&wp, &["config", "commit.gpgsign", "false"]);
+    git(
+        &wp,
+        &["remote", "add", "origin", remote.path().to_str().unwrap()],
+    );
+    std::fs::write(wp.join("README.md"), "# test\n").unwrap();
+    git(&wp, &["add", "."]);
+    git(&wp, &["commit", "-m", "init", "--no-gpg-sign"]);
+    git(&wp, &["push", "-u", "origin", "main"]);
+
+    let crosslink_dir = wp.join(".crosslink");
+    std::fs::create_dir_all(&crosslink_dir).unwrap();
+    std::fs::write(
+        crosslink_dir.join("hook-config.json"),
+        r#"{"remote":"origin","layout":"v2"}"#,
+    )
+    .unwrap();
+    write_agent(&crosslink_dir, "alpha");
+
+    let sync = SyncManager::new(&crosslink_dir).unwrap();
+    sync.init_cache().unwrap();
+    let cache_dir = sync.cache_path().to_path_buf();
+
+    let db = Database::open(&crosslink_dir.join("issues.db")).unwrap();
+    let writer = SharedWriter::new(&crosslink_dir).unwrap().unwrap();
+    let i1 = writer
+        .create_issue(&db, "First issue", Some("desc one"), "high", None, None)
+        .unwrap();
+    writer
+        .create_issue(&db, "Second issue", None, "medium", None, None)
+        .unwrap();
+    writer.add_label(&db, i1, "bug").unwrap();
+    writer.add_comment(&db, i1, "a note", "note").unwrap();
+    writer.create_milestone(&db, "v1.0", None).unwrap();
+
+    let lock = sync.acquire_lock().unwrap();
+    crate::compaction::compact(&cache_dir, "alpha", true, &lock).unwrap();
+    drop(lock);
+
+    // Migrate to v3 (the real command).
+    super::migrate_hub_v3::hub_v3(&crosslink_dir, false, false).unwrap();
+
+    V3Hub {
+        work,
+        remote,
+        crosslink_dir,
+        cache_dir,
+    }
+}
+
+/// Fingerprint of the v2 worktree issue files (relative path + size). Lets a
+/// test assert no V3 mutation wrote to the v2 worktree.
+fn issues_dir_fingerprint(cache_dir: &Path) -> Vec<(String, u64)> {
+    let issues = cache_dir.join("issues");
+    let mut out = Vec::new();
+    if let Ok(files) = walk_files(&issues) {
+        for p in files {
+            let rel = p
+                .strip_prefix(&issues)
+                .unwrap()
+                .to_string_lossy()
+                .into_owned();
+            let size = std::fs::metadata(&p).map_or(0, |m| m.len());
+            out.push((rel, size));
+        }
+    }
+    out.sort();
+    out
+}
+
+fn walk_files(dir: &Path) -> std::io::Result<Vec<PathBuf>> {
+    let mut out = Vec::new();
+    if !dir.exists() {
+        return Ok(out);
+    }
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            out.extend(walk_files(&path)?);
+        } else {
+            out.push(path);
+        }
+    }
+    Ok(out)
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+#[test]
+fn v3_mode_resolves_after_migration() {
+    if !git_ok() {
+        return;
+    }
+    let hub = setup_migrated_v3_hub();
+    let sync = SyncManager::new(&hub.crosslink_dir).unwrap();
+    assert_eq!(sync.hub_mode(), HubMode::V3);
+    let writer = SharedWriter::new(&hub.crosslink_dir).unwrap().unwrap();
+    assert!(writer.is_v3_public());
+}
+
+#[test]
+fn v3_lifecycle_no_worktree_writes() {
+    if !git_ok() {
+        return;
+    }
+    let hub = setup_migrated_v3_hub();
+    let before = issues_dir_fingerprint(&hub.cache_dir);
+
+    let db = Database::open(&hub.crosslink_dir.join("issues.db")).unwrap();
+    let writer = SharedWriter::new(&hub.crosslink_dir).unwrap().unwrap();
+
+    let new_id = writer
+        .create_issue(&db, "V3 created", Some("body"), "low", None, None)
+        .unwrap();
+    assert!(new_id > 0, "reduction should assign a positive display id");
+
+    let issue = db.get_issue(new_id).unwrap().expect("issue hydrated");
+    assert_eq!(issue.title, "V3 created");
+
+    // Update (priority), label, comment, and close all route through the v3
+    // event-only path.
+    writer
+        .update_issue(
+            &db,
+            new_id,
+            crate::shared_writer::IssueUpdate {
+                title: Some("V3 renamed"),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    writer.add_label(&db, new_id, "v3label").unwrap();
+    writer
+        .add_comment(&db, new_id, "v3 comment", "note")
+        .unwrap();
+    writer.close_issue(&db, new_id).unwrap();
+
+    let issue = db.get_issue(new_id).unwrap().unwrap();
+    assert_eq!(issue.title, "V3 renamed");
+    assert_eq!(issue.status, crate::models::IssueStatus::Closed);
+    assert!(db
+        .get_labels(new_id)
+        .unwrap()
+        .iter()
+        .any(|l| l == "v3label"));
+    assert!(!db.get_comments(new_id).unwrap().is_empty());
+
+    let after = issues_dir_fingerprint(&hub.cache_dir);
+    assert_eq!(
+        before, after,
+        "V3 mutations must not touch the v2 worktree issue files"
+    );
+
+    let seq = hub_v3::read_max_event_seq_from_ref(&hub.cache_dir, "alpha").unwrap();
+    assert!(seq > 0, "own ref should record events");
+}
+
+#[test]
+fn v3_display_ids_stable_across_re_reduce() {
+    if !git_ok() {
+        return;
+    }
+    let hub = setup_migrated_v3_hub();
+    let db = Database::open(&hub.crosslink_dir.join("issues.db")).unwrap();
+    let writer = SharedWriter::new(&hub.crosslink_dir).unwrap().unwrap();
+    let id = writer
+        .create_issue(&db, "Stable id", None, "medium", None, None)
+        .unwrap();
+
+    let uuid_str = db.get_issue_uuid_by_id(id).unwrap();
+    let uuid = uuid::Uuid::parse_str(&uuid_str).unwrap();
+
+    let source = crate::hub_source::RefHubSource::new(&hub.cache_dir).unwrap();
+    let state = crate::compaction::reduce(&source).unwrap().state;
+    assert_eq!(
+        state.display_id_map.get(&uuid).copied(),
+        Some(id),
+        "reduction-assigned display id must be stable across re-reduce"
+    );
+}
+
+#[test]
+fn v3_milestone_create_returns_reduction_id() {
+    if !git_ok() {
+        return;
+    }
+    let hub = setup_migrated_v3_hub();
+    let db = Database::open(&hub.crosslink_dir.join("issues.db")).unwrap();
+    let writer = SharedWriter::new(&hub.crosslink_dir).unwrap().unwrap();
+    let mid = writer.create_milestone(&db, "v2.0", Some("next")).unwrap();
+    assert!(
+        mid > 0,
+        "milestone id should be reduction-assigned positive"
+    );
+    let source = crate::hub_source::RefHubSource::new(&hub.cache_dir).unwrap();
+    let state = crate::compaction::reduce(&source).unwrap().state;
+    assert!(
+        state.milestones.values().any(|m| m.display_id == Some(mid)),
+        "milestone id must be present in reduced state"
+    );
+}
+
+#[test]
+fn v3_two_writers_converge_no_id_collision() {
+    if !git_ok() {
+        return;
+    }
+    let hub = setup_migrated_v3_hub();
+    let remote = hub.remote.path();
+
+    let db_a = Database::open(&hub.crosslink_dir.join("issues.db")).unwrap();
+    let writer_a = SharedWriter::new(&hub.crosslink_dir).unwrap().unwrap();
+    let a_id = writer_a
+        .create_issue(&db_a, "Alpha issue", None, "high", None, None)
+        .unwrap();
+
+    let (_wb, beta_dir, beta_cache) = clone_for_agent(remote, "beta");
+    let sync_b = SyncManager::new(&beta_dir).unwrap();
+    assert_eq!(sync_b.hub_mode(), HubMode::V3);
+    sync_b.fetch().unwrap();
+    let db_b = Database::open(&beta_dir.join("issues.db")).unwrap();
+    let writer_b = SharedWriter::new(&beta_dir).unwrap().unwrap();
+    let b_id = writer_b
+        .create_issue(&db_b, "Beta issue", None, "low", None, None)
+        .unwrap();
+    assert_ne!(a_id, b_id, "two writers must not collide on display ids");
+
+    let sync_a = SyncManager::new(&hub.crosslink_dir).unwrap();
+    sync_a.fetch().unwrap();
+
+    let state_a =
+        crate::compaction::reduce(&crate::hub_source::RefHubSource::new(&hub.cache_dir).unwrap())
+            .unwrap()
+            .state;
+    let state_b =
+        crate::compaction::reduce(&crate::hub_source::RefHubSource::new(&beta_cache).unwrap())
+            .unwrap()
+            .state;
+    assert_eq!(
+        state_a.issues.len(),
+        state_b.issues.len(),
+        "both writers converge to the same issue set"
+    );
+    assert_eq!(state_a.display_id_map, state_b.display_id_map);
+}
+
+#[test]
+fn v3_lock_claim_confirm_winner_and_loser() {
+    if !git_ok() {
+        return;
+    }
+    let hub = setup_migrated_v3_hub();
+    let remote = hub.remote.path();
+    let db_a = Database::open(&hub.crosslink_dir.join("issues.db")).unwrap();
+    let writer_a = SharedWriter::new(&hub.crosslink_dir).unwrap().unwrap();
+    let issue_id = writer_a
+        .create_issue(&db_a, "Contended", None, "high", None, None)
+        .unwrap();
+
+    let (_wb, beta_dir, _bc) = clone_for_agent(remote, "beta");
+    let sync_b = SyncManager::new(&beta_dir).unwrap();
+    sync_b.fetch().unwrap();
+    let writer_b = SharedWriter::new(&beta_dir).unwrap().unwrap();
+
+    let res_a = writer_a.claim_lock_v2(issue_id, None).unwrap();
+    assert_eq!(
+        res_a,
+        crate::shared_writer::LockClaimResult::Claimed,
+        "first claimant wins"
+    );
+
+    let res_b = writer_b.claim_lock_v2(issue_id, None).unwrap();
+    match res_b {
+        crate::shared_writer::LockClaimResult::Contended { winner_agent_id } => {
+            assert_eq!(winner_agent_id, "alpha");
+        }
+        other => panic!("expected Contended, got {other:?}"),
+    }
+}
+
+#[test]
+fn v3_offline_mutation_durable_then_delivered() {
+    if !git_ok() {
+        return;
+    }
+    let hub = setup_migrated_v3_hub();
+    let db = Database::open(&hub.crosslink_dir.join("issues.db")).unwrap();
+    let writer = SharedWriter::new(&hub.crosslink_dir).unwrap().unwrap();
+
+    // Break the remote.
+    git(
+        hub.work.path(),
+        &["remote", "set-url", "origin", "/nonexistent/remote-xyz.git"],
+    );
+
+    let id = writer
+        .create_issue(&db, "Offline issue", None, "medium", None, None)
+        .unwrap();
+    assert!(id > 0);
+    assert!(db.get_issue(id).unwrap().is_some());
+    let local_seq = hub_v3::read_max_event_seq_from_ref(&hub.cache_dir, "alpha").unwrap();
+    assert!(
+        local_seq > 0,
+        "event durable on local ref despite push failure"
+    );
+
+    // Restore + next op delivers the backlog.
+    git(
+        hub.work.path(),
+        &[
+            "remote",
+            "set-url",
+            "origin",
+            hub.remote.path().to_str().unwrap(),
+        ],
+    );
+    let id2 = writer
+        .create_issue(&db, "Back online", None, "low", None, None)
+        .unwrap();
+    assert!(id2 > 0);
+    let ls = Command::new("git")
+        .current_dir(hub.remote.path())
+        .args([
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            &agent_ref_name("alpha").unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        ls.status.success(),
+        "alpha ref should be on the remote after reconnecting"
+    );
+}
+
+#[test]
+fn v3_fetch_adopts_other_ref_never_moves_own() {
+    if !git_ok() {
+        return;
+    }
+    let hub = setup_migrated_v3_hub();
+    let remote = hub.remote.path();
+
+    let db_a = Database::open(&hub.crosslink_dir.join("issues.db")).unwrap();
+    let writer_a = SharedWriter::new(&hub.crosslink_dir).unwrap().unwrap();
+    writer_a
+        .create_issue(&db_a, "Alpha A", None, "high", None, None)
+        .unwrap();
+
+    let (_wb, beta_dir, beta_cache) = clone_for_agent(remote, "beta");
+    let sync_b = SyncManager::new(&beta_dir).unwrap();
+    sync_b.fetch().unwrap();
+    let db_b = Database::open(&beta_dir.join("issues.db")).unwrap();
+    let writer_b = SharedWriter::new(&beta_dir).unwrap().unwrap();
+    writer_b
+        .create_issue(&db_b, "Beta B", None, "low", None, None)
+        .unwrap();
+
+    let alpha_ref = agent_ref_name("alpha").unwrap();
+    let seq_before = hub_v3::read_max_event_seq_from_ref(&hub.cache_dir, "alpha").unwrap();
+
+    let sync_a = SyncManager::new(&hub.crosslink_dir).unwrap();
+    sync_a.fetch().unwrap();
+
+    // Fetch must NEVER adopt our own ref FROM the remote tracking tip — the
+    // local own ref is authoritative for the writer. (It may be locally
+    // rewritten by a REQ-11 prune, but is never set to the remote-tracking SHA.)
+    let own_after = hub_v3::git_rev_parse_optional(&hub.cache_dir, &alpha_ref).unwrap();
+    let own_remote_tracking =
+        hub_v3::git_rev_parse_optional(&hub.cache_dir, "refs/crosslink-remote/agents/alpha")
+            .unwrap();
+    if let Some(rt) = own_remote_tracking {
+        // The own ref carries alpha's authoritative head; if it equals the
+        // remote tracking tip that's only because no local-only events exist.
+        // What must NOT happen is a regression to a stale remote tip — assert
+        // the sequence high-water mark never dropped below what we wrote.
+        let _ = rt;
+    }
+    let seq_after = hub_v3::read_max_event_seq_from_ref(&hub.cache_dir, "alpha").unwrap();
+    assert!(
+        own_after.is_some() && seq_after >= seq_before,
+        "fetch must not regress our own ref's event high-water mark"
+    );
+
+    // alpha adopts beta's authoritative ref tip.
+    let beta_ref = agent_ref_name("beta").unwrap();
+    let beta_local = hub_v3::git_rev_parse_optional(&hub.cache_dir, &beta_ref).unwrap();
+    let beta_remote = hub_v3::git_rev_parse_optional(&beta_cache, &beta_ref).unwrap();
+    assert_eq!(
+        beta_local, beta_remote,
+        "alpha must adopt beta's authoritative ref tip"
+    );
+}
+
+#[test]
+fn v3_heartbeat_routed_to_ref() {
+    if !git_ok() {
+        return;
+    }
+    let hub = setup_migrated_v3_hub();
+    let sync = SyncManager::new(&hub.crosslink_dir).unwrap();
+    let agent = AgentConfig::load(&hub.crosslink_dir).unwrap().unwrap();
+    sync.push_heartbeat(&agent, Some(42)).unwrap();
+
+    let hbs = sync.read_heartbeats_auto().unwrap();
+    assert!(
+        hbs.iter()
+            .any(|h| h.agent_id == "alpha" && h.active_issue_id == Some(42)),
+        "v3 heartbeat must round-trip through the agent ref"
+    );
+}
+
+#[test]
+fn v3_request_and_ack_lifecycle() {
+    if !git_ok() {
+        return;
+    }
+    let hub = setup_migrated_v3_hub();
+    let remote = hub.remote.path();
+
+    let writer_a = SharedWriter::new(&hub.crosslink_dir).unwrap().unwrap();
+    let request = crate::agent_requests::AgentRequest {
+        request_id: crate::agent_requests::new_request_id(),
+        kind: crate::agent_requests::RequestKind::Pause,
+        subject: crate::agent_requests::RequestSubject::default(),
+        requested_by: "alpha-fp".to_string(),
+        requested_at: chrono::Utc::now().to_rfc3339(),
+        reason: Some("pause please".to_string()),
+    };
+    writer_a.write_agent_request("beta", &request).unwrap();
+
+    let (_wb, beta_dir, beta_cache) = clone_for_agent(remote, "beta");
+    let sync_b = SyncManager::new(&beta_dir).unwrap();
+    sync_b.fetch().unwrap();
+    let pending = hub_v3::poll_requests_for_agent(&beta_cache, "beta").unwrap();
+    assert_eq!(pending.len(), 1, "beta should see one pending request");
+    assert_eq!(pending[0].1.request_id, request.request_id);
+
+    let writer_b = SharedWriter::new(&beta_dir).unwrap().unwrap();
+    let ack = crate::agent_requests::AgentRequestAck {
+        request_id: request.request_id,
+        ack_at: chrono::Utc::now().to_rfc3339(),
+        acted: true,
+        result: "paused".to_string(),
+        notes: None,
+    };
+    writer_b.write_agent_ack("beta", &ack).unwrap();
+    let still_pending = hub_v3::poll_requests_for_agent(&beta_cache, "beta").unwrap();
+    assert!(
+        still_pending.is_empty(),
+        "acked request must no longer be pending"
+    );
+}
+
+#[test]
+fn v3_lock_check_reads_from_checkpoint() {
+    if !git_ok() {
+        return;
+    }
+    let hub = setup_migrated_v3_hub();
+    let db = Database::open(&hub.crosslink_dir.join("issues.db")).unwrap();
+    let writer = SharedWriter::new(&hub.crosslink_dir).unwrap().unwrap();
+    let id = writer
+        .create_issue(&db, "Lockable", None, "high", None, None)
+        .unwrap();
+    writer.claim_lock_v2(id, None).unwrap();
+
+    let sync = SyncManager::new(&hub.crosslink_dir).unwrap();
+    let locks = sync.read_locks_auto().unwrap();
+    assert!(
+        locks.is_locked_by(id, "alpha"),
+        "v3 lock_check must read the lock from the checkpoint state"
+    );
+}
+
+#[test]
+fn v3_dashboard_reader_reroutes_to_refs() {
+    if !git_ok() {
+        return;
+    }
+    let hub = setup_migrated_v3_hub();
+
+    // Claim a lock (event-only) and push a heartbeat so the snapshot has
+    // issues (from the checkpoint), a lock (state.locks), and a heartbeat
+    // (agent ref) all to surface through the ref-based reroute.
+    let db = Database::open(&hub.crosslink_dir.join("issues.db")).unwrap();
+    let writer = SharedWriter::new(&hub.crosslink_dir).unwrap().unwrap();
+    let id = writer
+        .create_issue(&db, "Lockable", None, "high", None, None)
+        .unwrap();
+    writer.claim_lock_v2(id, None).unwrap();
+    let sync = SyncManager::new(&hub.crosslink_dir).unwrap();
+    let agent = AgentConfig::load(&hub.crosslink_dir).unwrap().unwrap();
+    sync.push_heartbeat(&agent, Some(id)).unwrap();
+
+    // The dashboard reader resolves mode per project from the clone path. The
+    // hub-cache dir is where `crosslink/hub` and the v3 refs both resolve.
+    assert!(
+        HubMode::resolve(&hub.cache_dir).is_v3(),
+        "migrated cache must resolve to V3 mode"
+    );
+    let snap = crate::dashboard::reader::read_snapshot(&hub.cache_dir).unwrap();
+
+    assert_eq!(snap.layout_version, 3, "v3 hub reports layout version 3");
+    assert!(
+        snap.issues.iter().any(|i| i.title == "First issue"),
+        "v3 dashboard snapshot must surface checkpoint issues"
+    );
+    assert!(
+        snap.issues.iter().any(|i| i.title == "Lockable"),
+        "v3 dashboard snapshot must include the locked issue"
+    );
+    assert!(
+        snap.issues
+            .iter()
+            .any(|i| i.comments.iter().any(|c| c.content == "a note")),
+        "v3 dashboard snapshot must carry checkpoint comments"
+    );
+    assert!(
+        snap.locks.iter().any(|l| l.lock.agent_id == "alpha"),
+        "v3 dashboard snapshot must surface the lock from checkpoint state"
+    );
+    assert!(
+        snap.agents.iter().any(|h| h.agent_id == "alpha"),
+        "v3 dashboard snapshot must surface heartbeats read from agent refs"
+    );
+    assert!(
+        snap.agent_requests.is_empty(),
+        "v3 snapshot leaves agent_requests empty (surfaced via the poll path)"
+    );
+
+    // derive_counters must operate on the ref-sourced state without panicking.
+    let counters = snap.derive_counters(chrono::Utc::now(), 10, 60);
+    assert!(counters.open_issues >= 1);
+}
+
+#[test]
+fn v3_server_agents_handler_reads_from_refs() {
+    if !git_ok() {
+        return;
+    }
+    let hub = setup_migrated_v3_hub();
+
+    let db = Database::open(&hub.crosslink_dir.join("issues.db")).unwrap();
+    let writer = SharedWriter::new(&hub.crosslink_dir).unwrap().unwrap();
+    let id = writer
+        .create_issue(&db, "Server lockable", None, "high", None, None)
+        .unwrap();
+    writer.claim_lock_v2(id, None).unwrap();
+    let sync = SyncManager::new(&hub.crosslink_dir).unwrap();
+    let agent = AgentConfig::load(&hub.crosslink_dir).unwrap().unwrap();
+    sync.push_heartbeat(&agent, Some(id)).unwrap();
+
+    // Build server AppState over the migrated v3 hub and drive the agents/locks
+    // handlers directly. They route through SyncManager::read_*_auto, which is
+    // mode-aware, so a v3 hub must surface refs-sourced agents and locks.
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let handler_db = Database::open(&hub.crosslink_dir.join("issues.db")).unwrap();
+        let state = crate::server::state::AppState::new(handler_db, hub.crosslink_dir.clone());
+
+        let agents_json =
+            crate::server::handlers::agents::list_agents(axum::extract::State(state.clone()))
+                .await
+                .expect("list_agents must succeed on a v3 hub");
+        let agents = agents_json.0;
+        let items = agents["items"].as_array().expect("items array");
+        assert!(
+            items
+                .iter()
+                .any(|a| a["agent_id"].as_str() == Some("alpha")),
+            "v3 server agents handler must surface the ref heartbeat, got {agents}"
+        );
+
+        let locks_json =
+            crate::server::handlers::agents::list_locks(axum::extract::State(state.clone()))
+                .await
+                .expect("list_locks must succeed on a v3 hub");
+        let locks = locks_json.0;
+        let lock_items = locks["items"].as_array().expect("items array");
+        assert!(
+            lock_items
+                .iter()
+                .any(|l| l["agent_id"].as_str() == Some("alpha")),
+            "v3 server locks handler must surface the checkpoint lock, got {locks}"
+        );
+    });
+}
+
+#[test]
+fn v3_locks_cmd_and_stale_detection_over_refs() {
+    if !git_ok() {
+        return;
+    }
+    let hub = setup_migrated_v3_hub();
+
+    let db = Database::open(&hub.crosslink_dir.join("issues.db")).unwrap();
+    let writer = SharedWriter::new(&hub.crosslink_dir).unwrap().unwrap();
+    let id = writer
+        .create_issue(&db, "Cmd lockable", None, "high", None, None)
+        .unwrap();
+    writer.claim_lock_v2(id, None).unwrap();
+
+    // Fresh heartbeat on the agent ref: the lock must NOT be reported stale.
+    // The bug this guards against: `find_stale_locks` read V1-only
+    // `heartbeats/*.json` (empty on a v3 hub) and marked every lock stale.
+    let sync = SyncManager::new(&hub.crosslink_dir).unwrap();
+    let agent = AgentConfig::load(&hub.crosslink_dir).unwrap().unwrap();
+    sync.push_heartbeat(&agent, Some(id)).unwrap();
+
+    let stale = sync.find_stale_locks().unwrap();
+    assert!(
+        !stale.iter().any(|(sid, _)| *sid == id),
+        "a v3 lock with a fresh ref heartbeat must not be flagged stale, got {stale:?}"
+    );
+    let stale_aged = sync.find_stale_locks_with_age().unwrap();
+    assert!(
+        !stale_aged.iter().any(|(sid, _, _)| *sid == id),
+        "find_stale_locks_with_age must use ref heartbeats on a v3 hub"
+    );
+
+    // `locks check`/`list`/`next` route lock reads through read_locks_auto and
+    // must run without error on a v3 hub.
+    super::locks_cmd::check(&hub.crosslink_dir, id).unwrap();
+    super::locks_cmd::list(&hub.crosslink_dir, &db, true).unwrap();
+    super::next::run(&db, &hub.crosslink_dir).unwrap();
+}

--- a/crosslink/src/commands/locks_cmd.rs
+++ b/crosslink/src/commands/locks_cmd.rs
@@ -347,8 +347,15 @@ pub fn sync_cmd(crosslink_dir: &Path, db: &Database) -> Result<()> {
         Err(e) => tracing::warn!("layout cleanup failed: {e}"),
     }
 
-    // Hydrate local SQLite from JSON issue files on the coordination branch
-    let stats = hydrate_to_sqlite(sync.cache_path(), db)?;
+    // Hydrate local SQLite. V3 hydrates from the reduced CheckpointState (the
+    // v3 fetch above already adopted refs + compacted); V2 reads JSON files.
+    let stats = if sync.hub_mode().is_v3() {
+        let source = crate::hub_source::RefHubSource::new(sync.cache_path())?;
+        let outcome = crate::compaction::reduce(&source)?;
+        crate::hydration::hydrate_from_state(&outcome.state, db)?
+    } else {
+        hydrate_to_sqlite(sync.cache_path(), db)?
+    };
     // Record the hub ref so lazy auto-hydration knows we're current (#500)
     crate::hydration::record_hydrated_ref(crosslink_dir);
     if stats.issues > 0 {

--- a/crosslink/src/commands/mod.rs
+++ b/crosslink/src/commands/mod.rs
@@ -15,6 +15,8 @@ pub mod design_doc;
 pub mod export;
 pub mod external_issues;
 pub mod external_knowledge;
+#[cfg(test)]
+mod hub_v3_operation_tests;
 pub mod import;
 pub mod init;
 pub mod integrity_cmd;

--- a/crosslink/src/daemon.rs
+++ b/crosslink/src/daemon.rs
@@ -13,6 +13,16 @@ use crate::hydration::hydrate_to_sqlite;
 
 const FLUSH_INTERVAL_SECS: u64 = 30;
 
+/// Hydrate `SQLite` from the reduced v3 [`crate::checkpoint::CheckpointState`] for
+/// a daemon tick. Reduces the current v3 ref namespace and maps it into `SQLite`
+/// via `hydrate_from_state`, returning the same `HydrationStats` shape the v2
+/// `hydrate_to_sqlite` returns so the tick's reporting is uniform.
+fn hydrate_v3_tick(cache_dir: &Path, db: &Database) -> Result<crate::hydration::HydrationStats> {
+    let source = crate::hub_source::RefHubSource::new(cache_dir)?;
+    let outcome = crate::compaction::reduce(&source)?;
+    crate::hydration::hydrate_from_state(&outcome.state, db)
+}
+
 pub fn start(crosslink_dir: &Path) -> Result<()> {
     let pid_file = crosslink_dir.join("daemon.pid");
     let log_file = crosslink_dir.join("daemon.log");
@@ -260,7 +270,15 @@ pub fn run_daemon(crosslink_dir: &Path) -> Result<()> {
                             match sync.fetch() {
                                 Ok(()) => {
                                     if let Ok(db) = Database::open(&db_path) {
-                                        match hydrate_to_sqlite(sync.cache_path(), &db) {
+                                        // V3: hydrate from the reduced state (the
+                                        // v3 fetch already adopted refs +
+                                        // compacted); V2 reads JSON files.
+                                        let hydrate_result = if sync.hub_mode().is_v3() {
+                                            hydrate_v3_tick(sync.cache_path(), &db)
+                                        } else {
+                                            hydrate_to_sqlite(sync.cache_path(), &db)
+                                        };
+                                        match hydrate_result {
                                             Ok(stats) => {
                                                 crate::hydration::record_hydrated_ref(
                                                     crosslink_dir,

--- a/crosslink/src/dashboard/reader.rs
+++ b/crosslink/src/dashboard/reader.rs
@@ -21,7 +21,7 @@
 
 #![allow(dead_code)]
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use std::path::Path;
 use std::process::Command;
@@ -140,6 +140,15 @@ pub fn read_snapshot(clone_path: &Path) -> Result<HubSnapshot> {
     let hub_sha = git_rev_parse(clone_path, "crosslink/hub");
     let last_commit_at = git_last_commit_at(clone_path, "crosslink/hub");
 
+    // Mode-route PER PROJECT: the dashboard aggregates many tracked repos,
+    // each independently v2 or v3. A v3 hub keeps no worktree files (issues,
+    // locks, heartbeats all live on per-agent refs + the checkpoint ref), so
+    // the file-scanning path below would read nothing. Resolve the mode from
+    // this project's repo and take the ref-based path when it is v3.
+    if crate::hub_v3::HubMode::resolve(clone_path).is_v3() {
+        return read_snapshot_v3(clone_path, hub_sha, last_commit_at);
+    }
+
     // Prefer the hub-cache worktree (`.crosslink/.hub-cache/`) when it
     // exists — that's where `crosslink sync` keeps `crosslink/hub`
     // checked out. If it's missing we scan clone_path as a fallback
@@ -177,6 +186,138 @@ pub fn read_snapshot(clone_path: &Path) -> Result<HubSnapshot> {
         signature_state,
         last_commit_at,
     })
+}
+
+/// Read a snapshot from a v3 hub (per-agent refs + checkpoint ref).
+///
+/// A v3 hub stores no worktree files: issues/comments live in the reduced
+/// `CheckpointState` on `refs/crosslink/checkpoint`, locks in `state.locks`,
+/// and heartbeats on each agent ref's `heartbeat.json`. This reads the LAST
+/// MATERIALIZED checkpoint directly (no full `reduce`), which is the exact
+/// v2-equivalent freshness: the v2 file path equally reflects the last
+/// `compact`, lagging any un-compacted events until the next fetch/compact.
+///
+/// `meta/ci-status.json` has no v3 ref home and the v2 worktree path is gone,
+/// so `ci_status` is `None`; `signature_state` reuses the shared
+/// [`read_signature_state`] (mode-agnostic — it verifies the hub-tip commit
+/// signature via `SyncManager`). `agent_requests` stays empty: the v3
+/// request/ack streams live on refs and are surfaced through the agent poll
+/// path, not this snapshot reader.
+fn read_snapshot_v3(
+    clone_path: &Path,
+    hub_sha: Option<String>,
+    last_commit_at: Option<DateTime<Utc>>,
+) -> Result<HubSnapshot> {
+    let state = read_checkpoint_state(clone_path)?;
+
+    let issues: Vec<crate::issue_file::IssueFile> =
+        state.issues.values().map(compact_issue_to_file).collect();
+
+    let locks: Vec<LockRecord> = state
+        .locks
+        .into_iter()
+        .map(|(issue_id, entry)| LockRecord {
+            issue_id,
+            lock: crate::locks::Lock {
+                agent_id: entry.agent_id,
+                branch: entry.branch,
+                claimed_at: entry.claimed_at,
+                signed_by: String::new(),
+            },
+        })
+        .collect();
+
+    let mut agents: Vec<crate::locks::Heartbeat> =
+        crate::hub_v3::read_heartbeats_from_refs(clone_path)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|(_, hb)| hb)
+            .collect();
+    agents.sort_by(|a, b| a.agent_id.cmp(&b.agent_id));
+
+    Ok(HubSnapshot {
+        hub_sha,
+        // v3 retires the v1/v2 worktree layout marker; report 3 so downstream
+        // consumers can distinguish the ref-based hub from a v1/v2 file hub.
+        layout_version: 3,
+        issues,
+        agents,
+        locks,
+        agent_requests: Vec::new(),
+        ci_status: None,
+        signature_state: read_signature_state(clone_path),
+        last_commit_at,
+    })
+}
+
+/// Read the reduced [`crate::checkpoint::CheckpointState`] from the local v3
+/// checkpoint ref. Returns the default (empty) state when the ref or its
+/// `state.json` blob is absent (fresh v3 hub that hasn't compacted yet).
+fn read_checkpoint_state(repo_dir: &Path) -> Result<crate::checkpoint::CheckpointState> {
+    let Some(tip) = crate::hub_v3::git_rev_parse_optional(repo_dir, crate::hub_v3::CHECKPOINT_REF)?
+    else {
+        return Ok(crate::checkpoint::CheckpointState::default());
+    };
+    let spec = format!("{tip}:state.json");
+    let Some(bytes) = crate::hub_v3::git_cat_file_blob_optional(repo_dir, &spec)? else {
+        return Ok(crate::checkpoint::CheckpointState::default());
+    };
+    crate::checkpoint::CheckpointState::from_slice(&bytes)
+        .context("failed to parse v3 checkpoint state.json for dashboard snapshot")
+}
+
+/// Map a reduced [`crate::checkpoint::CompactIssue`] to the [`IssueFile`] shape
+/// the snapshot consumers (and `derive_counters`) already expect. The
+/// `BTreeSet`/`BTreeMap` collections become the `Vec` fields of `IssueFile`,
+/// preserving deterministic order.
+fn compact_issue_to_file(issue: &crate::checkpoint::CompactIssue) -> crate::issue_file::IssueFile {
+    let comments = issue
+        .comments
+        .values()
+        .map(|c| crate::issue_file::CommentEntry {
+            id: c.display_id.unwrap_or(0),
+            author: c.author.clone(),
+            content: c.content.clone(),
+            created_at: c.created_at,
+            kind: c.kind.clone(),
+            trigger_type: c.trigger_type.clone(),
+            intervention_context: c.intervention_context.clone(),
+            driver_key_fingerprint: c.driver_key_fingerprint.clone(),
+            signed_by: c.signed_by.clone(),
+            signature: c.signature.clone(),
+        })
+        .collect();
+    let time_entries = issue
+        .time_entries
+        .values()
+        .map(|t| crate::issue_file::TimeEntry {
+            id: t.display_id.unwrap_or(0),
+            started_at: t.started_at,
+            ended_at: t.ended_at,
+            duration_seconds: t.duration_seconds,
+        })
+        .collect();
+    crate::issue_file::IssueFile {
+        uuid: issue.uuid,
+        display_id: issue.display_id,
+        title: issue.title.clone(),
+        description: issue.description.clone(),
+        status: issue.status,
+        priority: issue.priority,
+        parent_uuid: issue.parent_uuid,
+        created_by: issue.created_by.clone(),
+        created_at: issue.created_at,
+        updated_at: issue.updated_at,
+        closed_at: issue.closed_at,
+        scheduled_at: issue.scheduled_at,
+        due_at: issue.due_at,
+        labels: issue.labels.iter().cloned().collect(),
+        comments,
+        blockers: issue.blockers.iter().copied().collect(),
+        related: issue.related.iter().copied().collect(),
+        milestone_uuid: issue.milestone_uuid,
+        time_entries,
+    }
 }
 
 /// Load `meta/ci-status.json` and confirm it matches `hub_sha`. Stale

--- a/crosslink/src/hub_v3.rs
+++ b/crosslink/src/hub_v3.rs
@@ -258,8 +258,17 @@ fn append_inner_impl<A: IntoAbortPoint>(
         });
     }
 
-    // ── Step e: mktree ───────────────────────────────────────────────
-    let tree_sha = git_mktree_single(repo_dir, &blob_sha, "events.log")?;
+    // ── Step e: mktree (sibling-preserving) ──────────────────────────
+    // Read the existing tree at the current tip and upsert events.log,
+    // keeping every unrelated sibling file/subtree (heartbeat.json,
+    // requests-ack/, requests-out/, …) byte-identical. A naive single-entry
+    // mktree here would DROP those siblings once refs carry them.
+    let tree_sha = write_tree_with(
+        repo_dir,
+        old_commit.as_deref(),
+        &[("events.log", BlobRef::Existing(&blob_sha))],
+        &[],
+    )?;
 
     if abort_opt.should_abort_after_mktree() {
         return Ok(RefAppendOutcome {
@@ -608,6 +617,66 @@ const fn classify_hub_version(
     }
 }
 
+// ── Operation mode (754a PASS 2) ──────────────────────────────────────
+
+/// Resolved operation mode for a hub, decided ONCE per `SyncManager` /
+/// `SharedWriter` construction from [`detect_hub_version`].
+///
+/// - [`HubMode::V3`] — the hub carries the v3 marker refs ([`META_REF`] +
+///   [`CHECKPOINT_REF`]). Mutations write events only to the agent's own ref;
+///   state is derived by reduction and hydrated from the resulting
+///   [`crate::checkpoint::CheckpointState`]. No worktree file writes, no
+///   counter reads, no rebase/conflict machinery.
+/// - [`HubMode::V2`] — [`HubVersion::V2Only`] or [`HubVersion::Absent`]. The
+///   today behavior is preserved bit-identically: worktree-file writes through
+///   the hub-cache, counter-claimed display ids, file-based hydration. `Absent`
+///   keeps the current init/bootstrap behavior (v3 bootstrap-from-scratch is
+///   tracked as 754b).
+///
+/// # Why the dual-write flag is ignored in V3
+///
+/// `hub_v3.dual_write` was the v2→v3 BRIDGE: while a hub was still v2, it
+/// mirrored every v2 log append onto the per-agent ref so the v3 layout could
+/// be soaked before cutover. Once the hub is v3 there is no v2 log to mirror
+/// FROM — the agent ref IS the only log — so the flag is a no-op in
+/// [`HubMode::V3`] and is never consulted on the v3 write path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HubMode {
+    /// Legacy worktree-file operation (v2 or uninitialized).
+    V2,
+    /// Per-agent-ref, event-only operation (v3).
+    V3,
+}
+
+impl HubMode {
+    /// Resolve the operation mode from the hub at `repo_dir` (the hub-cache
+    /// worktree or the main repo — refs resolve via the shared object store).
+    ///
+    /// `V3{..}` ⇒ [`HubMode::V3`]; `V2Only` / `Absent` ⇒ [`HubMode::V2`].
+    /// Any detection error degrades to [`HubMode::V2`] (the safe, unchanged
+    /// path) with a debug log — mode resolution must never block construction.
+    #[must_use]
+    pub fn resolve(repo_dir: &Path) -> Self {
+        match detect_hub_version(repo_dir) {
+            Ok(HubVersion::V3 { .. }) => HubMode::V3,
+            Ok(HubVersion::V2Only | HubVersion::Absent) => HubMode::V2,
+            Err(e) => {
+                tracing::debug!(
+                    "HubMode::resolve: detect_hub_version failed for {}: {e}; defaulting to V2",
+                    repo_dir.display()
+                );
+                HubMode::V2
+            }
+        }
+    }
+
+    /// Whether this is the v3 event-only mode.
+    #[must_use]
+    pub const fn is_v3(self) -> bool {
+        matches!(self, HubMode::V3)
+    }
+}
+
 // ── Hub meta marker (META_REF) ────────────────────────────────────────
 
 /// Hub version marker stored as `hub.json` on [`META_REF`].
@@ -654,6 +723,641 @@ pub fn read_hub_meta(repo_dir: &Path) -> Result<Option<HubMeta>> {
     let meta: HubMeta = serde_json::from_slice(&bytes)
         .context("failed to parse hub.json on the meta ref as HubMeta")?;
     Ok(Some(meta))
+}
+
+// ── Heartbeats on agent refs (REQ-7 auxiliary state) ──────────────────
+//
+// Writer-ownership: each agent's heartbeat lives at `heartbeat.json` at the
+// TREE ROOT of that agent's own ref (`refs/crosslink/agents/<id>`), the only
+// ref that agent writes (single-writer invariant). The serialized shape is the
+// SAME [`crate::locks::Heartbeat`] schema the v2 path uses, so a reader parses
+// either source without a v3-specific type. Because the write goes through the
+// sibling-preserving tree core, the agent's `events.log` (and any requests-ack/
+// subtree) survives a heartbeat write byte-for-byte.
+
+/// Write this agent's heartbeat to `heartbeat.json` at the root of its own ref.
+///
+/// One sibling-preserving commit: `events.log` and any `requests-ack/` subtree
+/// on the same ref are carried through unchanged. Reuses the v2
+/// [`crate::locks::Heartbeat`] serialization (`serde_json`) so v2 and v3 readers
+/// share one schema.
+///
+/// # Errors
+///
+/// Returns an error if serialization or any git plumbing step fails, or if the
+/// ref moved concurrently (CAS failure — caller re-reads and retries).
+// Wired into the v2 heartbeat caller by pass 2 (mode routing); flagged dead
+// until then because the bin's duplicate module tree sees no caller.
+#[allow(dead_code)]
+pub fn write_heartbeat_to_ref(
+    repo_dir: &Path,
+    agent_id: &str,
+    heartbeat: &crate::locks::Heartbeat,
+) -> Result<String> {
+    validate_agent_id(agent_id)?;
+    let ref_name = format!("{AGENT_REF_PREFIX}{agent_id}");
+    let bytes = serde_json::to_vec_pretty(heartbeat)
+        .context("failed to serialize heartbeat for the agent ref")?;
+    let message = format!("crosslink heartbeat: agent {agent_id}");
+    commit_upserts_to_ref(
+        repo_dir,
+        &ref_name,
+        &[("heartbeat.json", BlobRef::Bytes(&bytes))],
+        &[],
+        &message,
+        agent_id,
+        CasExpectation::CurrentTip,
+    )
+}
+
+/// Read every agent's heartbeat by scanning `refs/crosslink/agents/*` and
+/// reading `heartbeat.json` at each tip.
+///
+/// Agents whose ref carries no `heartbeat.json` (e.g. an events-only ref that
+/// has never beaten) are skipped, not errored. Returns `(agent_id, Heartbeat)`
+/// pairs; the embedded `Heartbeat::agent_id` always matches the ref's agent id
+/// for a well-formed hub, but the ref-derived id is authoritative for the tuple.
+///
+/// # Errors
+///
+/// Returns an error if `git for-each-ref` fails or a present `heartbeat.json`
+/// blob does not parse as [`crate::locks::Heartbeat`] (a corrupt heartbeat is
+/// surfaced, not silently dropped).
+// Wired into the dashboard/TUI reader by pass 3; flagged dead until then.
+#[allow(dead_code)]
+pub fn read_heartbeats_from_refs(
+    repo_dir: &Path,
+) -> Result<Vec<(String, crate::locks::Heartbeat)>> {
+    let mut out = Vec::new();
+    for ref_name in for_each_agent_ref(repo_dir)? {
+        let Some(agent_id) = ref_name.strip_prefix(AGENT_REF_PREFIX) else {
+            continue;
+        };
+        let Some(tip) = git_rev_parse_optional(repo_dir, &ref_name)? else {
+            continue;
+        };
+        let spec = format!("{tip}:heartbeat.json");
+        let Some(bytes) = git_cat_file_blob_optional(repo_dir, &spec)? else {
+            continue; // No heartbeat on this ref yet — skip.
+        };
+        let hb: crate::locks::Heartbeat = serde_json::from_slice(&bytes).with_context(|| {
+            format!("failed to parse heartbeat.json on ref '{ref_name}' as Heartbeat")
+        })?;
+        out.push((agent_id.to_string(), hb));
+    }
+    Ok(out)
+}
+
+// ── Agent requests / acks on agent refs (design doc §9, REQ-6) ────────
+//
+// Writer-ownership (single-writer-per-ref invariant):
+//
+//   - A DRIVER writes a request into ITS OWN ref under the subtree path
+//     `requests-out/<target_agent_id>--<ulid>.json`. The `<target>--<ulid>`
+//     encoding flattens what would otherwise be two nesting levels into one:
+//     the tree core supports exactly one subtree level, so the target id and
+//     ulid are joined with a `--` separator. Target ids are validated to
+//     `[-_a-zA-Z0-9]{3,64}`, which permits single hyphens but never a doubled
+//     `--`, so the filename is split on the LAST `--` to recover (target, ulid)
+//     unambiguously (a target id like `my-agent` parses correctly).
+//
+//   - The TARGET agent writes acks into ITS OWN ref under the subtree path
+//     `requests-ack/<ulid>.json`.
+//
+// Readers scan ALL agent refs' `requests-out/` subtrees. Both layouts use a
+// one-level subtree (supported by the tree core); requests and acks are
+// consistent in using subtrees rather than mixing flat-root and subtree forms.
+//
+// Signature model (mirrors v2 — see the v2 finding in the PR report): requests
+// and acks are plain JSON carrying a `requested_by` driver fingerprint; they are
+// NOT git-signed at the event level. v2's `poll::process_pending` trusts whatever
+// landed on the local cache because the hub-sync machinery rejects unsigned /
+// bad-signer COMMITS at fetch time (and `reduce` only WARNS on unsigned events,
+// never rejecting). The v3 ref primitives mirror this exactly: they perform no
+// per-request signature gate here — the same fetch-time / trust-boundary model
+// applies, with rogue-agent attribution handled by signed events + allowed_signers
+// + trust revoke per REQ-6.
+
+/// Subtree directory (under a driver's ref) holding outbound requests.
+const REQUESTS_OUT_DIR: &str = "requests-out";
+/// Subtree directory (under a target agent's ref) holding acks.
+const REQUESTS_ACK_DIR: &str = "requests-ack";
+
+/// Encode `(target_agent_id, request_id)` into the flattened one-level filename
+/// `requests-out/<target>--<ulid>.json`.
+fn request_out_path(target_agent_id: &str, request_id: &str) -> String {
+    format!("{REQUESTS_OUT_DIR}/{target_agent_id}--{request_id}.json")
+}
+
+/// Decode a `requests-out/` leaf filename back into `(target_agent_id, ulid)`.
+///
+/// Splits on the LAST `--` so a target id containing single hyphens parses
+/// correctly. Returns `None` for a name that does not end in `.json` or lacks a
+/// `--` separator.
+fn parse_request_out_name(file_name: &str) -> Option<(String, String)> {
+    let stem = file_name.strip_suffix(".json")?;
+    let (target, ulid) = stem.rsplit_once("--")?;
+    if target.is_empty() || ulid.is_empty() {
+        return None;
+    }
+    Some((target.to_string(), ulid.to_string()))
+}
+
+/// Write a request into the DRIVER's OWN ref under
+/// `requests-out/<target_agent_id>--<ulid>.json`.
+///
+/// Single sibling-preserving commit on the driver's ref (its `events.log`,
+/// `heartbeat.json`, and any other `requests-out/` entries survive). The driver
+/// is the sole writer of its ref, upholding the single-writer invariant — the v2
+/// scheme of writing into the TARGET's directory is rejected by this design.
+///
+/// # Errors
+///
+/// Returns an error if either agent id is invalid, serialization fails, or any
+/// git plumbing step fails (including a concurrent CAS move of the driver ref).
+// Wired into the driver CLI path by pass 2; flagged dead until then.
+#[allow(dead_code)]
+pub fn write_request_to_own_ref(
+    repo_dir: &Path,
+    driver_agent_id: &str,
+    target_agent_id: &str,
+    request: &crate::agent_requests::AgentRequest,
+) -> Result<String> {
+    validate_agent_id(driver_agent_id)?;
+    validate_agent_id(target_agent_id)?;
+    let ref_name = format!("{AGENT_REF_PREFIX}{driver_agent_id}");
+    let path = request_out_path(target_agent_id, &request.request_id);
+    let bytes = serde_json::to_vec_pretty(request).context("failed to serialize agent request")?;
+    let message = format!(
+        "crosslink request: {driver_agent_id} -> {target_agent_id} ({})",
+        request.request_id
+    );
+    commit_upserts_to_ref(
+        repo_dir,
+        &ref_name,
+        &[(&path, BlobRef::Bytes(&bytes))],
+        &[],
+        &message,
+        driver_agent_id,
+        CasExpectation::CurrentTip,
+    )
+}
+
+/// Write an ack into the TARGET agent's OWN ref under
+/// `requests-ack/<request_id>.json`.
+///
+/// Single sibling-preserving commit on the target's own ref. The target is the
+/// sole writer of its ref (single-writer invariant).
+///
+/// # Errors
+///
+/// Returns an error if the agent id is invalid, serialization fails, or any git
+/// plumbing step fails (including a concurrent CAS move of the agent ref).
+// Wired into the agent poll path by pass 2; flagged dead until then.
+#[allow(dead_code)]
+pub fn write_ack_to_own_ref(
+    repo_dir: &Path,
+    my_agent_id: &str,
+    request_id: &str,
+    ack: &crate::agent_requests::AgentRequestAck,
+) -> Result<String> {
+    validate_agent_id(my_agent_id)?;
+    let ref_name = format!("{AGENT_REF_PREFIX}{my_agent_id}");
+    let path = format!("{REQUESTS_ACK_DIR}/{request_id}.json");
+    let bytes = serde_json::to_vec_pretty(ack).context("failed to serialize agent request ack")?;
+    let message = format!("crosslink ack: {my_agent_id} ({request_id})");
+    commit_upserts_to_ref(
+        repo_dir,
+        &ref_name,
+        &[(&path, BlobRef::Bytes(&bytes))],
+        &[],
+        &message,
+        my_agent_id,
+        CasExpectation::CurrentTip,
+    )
+}
+
+/// Poll for requests targeting `my_agent_id` that have not yet been acked.
+///
+/// Scans EVERY agent ref's `requests-out/` subtree for entries whose flattened
+/// filename targets `my_agent_id`, then filters out any whose ulid already has a
+/// `requests-ack/<ulid>.json` on `my_agent_id`'s OWN ref. Returns
+/// `(driver_agent_id, AgentRequest)` pairs for the still-pending requests, sorted
+/// by ulid (lexicographic = chronological).
+///
+/// A driver's own ref is skipped only insofar as it would never target itself in
+/// practice; requests addressed to a DIFFERENT agent are not returned.
+///
+/// # Errors
+///
+/// Returns an error if git plumbing fails or a present request blob does not
+/// parse as [`crate::agent_requests::AgentRequest`].
+// Wired into the agent poll path by pass 2; flagged dead until then.
+#[allow(dead_code)]
+pub fn poll_requests_for_agent(
+    repo_dir: &Path,
+    my_agent_id: &str,
+) -> Result<Vec<(String, crate::agent_requests::AgentRequest)>> {
+    validate_agent_id(my_agent_id)?;
+
+    // Collect the set of ulids already acked on my own ref.
+    let my_ref = format!("{AGENT_REF_PREFIX}{my_agent_id}");
+    let acked: std::collections::HashSet<String> = match git_rev_parse_optional(repo_dir, &my_ref)?
+    {
+        None => std::collections::HashSet::new(),
+        Some(tip) => list_subtree_leaf_stems(repo_dir, &tip, REQUESTS_ACK_DIR)?
+            .into_iter()
+            .collect(),
+    };
+
+    let mut out = Vec::new();
+    for ref_name in for_each_agent_ref(repo_dir)? {
+        let Some(driver_id) = ref_name.strip_prefix(AGENT_REF_PREFIX) else {
+            continue;
+        };
+        let Some(tip) = git_rev_parse_optional(repo_dir, &ref_name)? else {
+            continue;
+        };
+        for leaf in list_subtree_leaf_names(repo_dir, &tip, REQUESTS_OUT_DIR)? {
+            let Some((target, ulid)) = parse_request_out_name(&leaf) else {
+                continue;
+            };
+            if target != my_agent_id {
+                continue; // Request for a different target.
+            }
+            if acked.contains(&ulid) {
+                continue; // Already acked by me.
+            }
+            let spec = format!("{tip}:{REQUESTS_OUT_DIR}/{leaf}");
+            let Some(bytes) = git_cat_file_blob_optional(repo_dir, &spec)? else {
+                continue;
+            };
+            let request: crate::agent_requests::AgentRequest = serde_json::from_slice(&bytes)
+                .with_context(|| format!("failed to parse request '{leaf}' on ref '{ref_name}'"))?;
+            out.push((driver_id.to_string(), request));
+        }
+    }
+
+    // Sort by ulid (lexicographic == chronological).
+    out.sort_by(|a, b| a.1.request_id.cmp(&b.1.request_id));
+    Ok(out)
+}
+
+/// Read the maximum `agent_seq` recorded in this agent's OWN REF `events.log`.
+///
+/// Returns `Ok(0)` when the ref does not exist or carries no `events.log`
+/// (genesis state). Used by the v3 write path to initialize the per-session
+/// sequence counter from the durable ref rather than a worktree file, so the
+/// sequence never regresses after a REQ-11 prune drops covered events (prune
+/// keeps the highest-seq events, so the max is preserved across prune as long
+/// as any event remains; a fully-pruned ref legitimately resets to 0 because
+/// every prior event is checkpoint-covered).
+///
+/// # Errors
+///
+/// Returns an error if git plumbing fails or the `events.log` blob does not
+/// parse (a corrupt ref is surfaced, not silently treated as empty).
+pub fn read_max_event_seq_from_ref(repo_dir: &Path, agent_id: &str) -> Result<u64> {
+    validate_agent_id(agent_id)?;
+    let ref_name = format!("{AGENT_REF_PREFIX}{agent_id}");
+    let Some(tip) = git_rev_parse_optional(repo_dir, &ref_name)? else {
+        return Ok(0);
+    };
+    let spec = format!("{tip}:events.log");
+    let Some(bytes) = git_cat_file_blob_optional(repo_dir, &spec)? else {
+        return Ok(0);
+    };
+    let events = read_events_from_bytes(&bytes)
+        .with_context(|| format!("failed to parse events.log on '{ref_name}' for seq init"))?;
+    Ok(events.iter().map(|e| e.agent_seq).max().unwrap_or(0))
+}
+
+/// Enumerate `refs/crosslink/agents/*` ref names.
+fn for_each_agent_ref(repo_dir: &Path) -> Result<Vec<String>> {
+    let pattern = format!("{AGENT_REF_PREFIX}*");
+    let output = Command::new("git")
+        .current_dir(repo_dir)
+        .args(["for-each-ref", "--format=%(refname)", &pattern])
+        .output()
+        .with_context(|| format!("failed to run git for-each-ref for '{pattern}'"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!(
+            "git for-each-ref failed for '{}': {}",
+            pattern,
+            stderr.trim()
+        );
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(stdout
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(str::to_string)
+        .collect())
+}
+
+/// List the leaf file names (e.g. `01J...--abc.json`) of a one-level subtree
+/// `<dir>` at `commit_sha`. Returns an empty vec if the subtree is absent.
+fn list_subtree_leaf_names(repo_dir: &Path, commit_sha: &str, dir: &str) -> Result<Vec<String>> {
+    let spec = format!("{commit_sha}:{dir}");
+    let output = Command::new("git")
+        .current_dir(repo_dir)
+        .args(["ls-tree", "--name-only", &spec])
+        .output()
+        .with_context(|| format!("failed to run git ls-tree for '{spec}'"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // Absent subtree → empty, not an error.
+        if stderr.contains("Not a valid object name")
+            || stderr.contains("does not exist")
+            || stderr.contains("not a tree")
+            || stderr.contains("Not a tree")
+        {
+            return Ok(Vec::new());
+        }
+        anyhow::bail!("git ls-tree failed for '{}': {}", spec, stderr.trim());
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(stdout
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(str::to_string)
+        .collect())
+}
+
+/// List the `.json` leaf STEMS (filename without the `.json` suffix) of a
+/// one-level subtree `<dir>` at `commit_sha`. Used to enumerate acked ulids.
+fn list_subtree_leaf_stems(repo_dir: &Path, commit_sha: &str, dir: &str) -> Result<Vec<String>> {
+    Ok(list_subtree_leaf_names(repo_dir, commit_sha, dir)?
+        .into_iter()
+        .filter_map(|n| n.strip_suffix(".json").map(str::to_string))
+        .collect())
+}
+
+// ── V3 compaction cycle (REQ-7 checkpoint + REQ-11 own-ref prune) ─────
+//
+// compact_v3 lives HERE (hub_v3.rs) rather than in compaction.rs because it
+// depends on the v3 ref-write primitives in THIS module (commit_blob_to_ref,
+// push_ref_with_lease, commit_log_bytes) plus RefHubSource. compaction.rs is the
+// I/O-agnostic reducer that already sits BELOW hub_v3 in the dependency graph
+// (hub_v3 → hub_source/RefHubSource → compaction::reduce); putting compact_v3 in
+// compaction.rs would invert that and create a cycle. hub_v3 → compaction::reduce
+// is the existing, acyclic direction.
+
+/// Outcome of a [`compact_v3`] cycle.
+#[derive(Debug, Clone)]
+// Consumed by the v3 compact CLI path (pass 2) and tests; the bin's duplicate
+// module tree flags the fields as dead until that caller lands.
+#[allow(dead_code)]
+pub struct CompactV3Result {
+    /// Number of events reduced in this pass (`reduce` outcome).
+    pub events_processed: usize,
+    /// SHA of the checkpoint commit written this pass, or `None` when the
+    /// checkpoint CAS was lost to a concurrent compactor (benign no-op).
+    pub checkpoint_commit: Option<String>,
+    /// Whether the checkpoint was successfully pushed (only when `remote` set).
+    pub checkpoint_pushed: bool,
+    /// Number of events pruned from this agent's OWN ref (REQ-11). Zero unless
+    /// the checkpoint was committed AND (if remote) pushed.
+    pub events_pruned: usize,
+}
+
+/// Run a full v3 compaction cycle for `agent_id`.
+///
+/// 1. `reduce(RefHubSource)` → materialized [`CheckpointState`].
+/// 2. Serialize the state and commit it to [`CHECKPOINT_REF`] as `state.json`
+///    via [`commit_blob_to_ref`] (CAS `CurrentTip`). A concurrent local
+///    compactor that moved the checkpoint first wins the CAS; THIS process loses
+///    it benignly (deterministic content — both produce the same state), logs at
+///    debug, and returns with `checkpoint_commit: None` and no prune.
+/// 3. If `remote` is `Some`, push the checkpoint with `--force-with-lease`. A
+///    lease loss is benign (REQ-7: identical content) → logged at debug, not an
+///    error, and prune is skipped.
+/// 4. REQ-11 prune: ONLY after the checkpoint covering watermark `W` is committed
+///    AND (if remote) pushed successfully, rewrite this agent's OWN ref's
+///    `events.log` to drop events with `OrderingKey <= W`. The rewrite goes
+///    through the sibling-preserving [`commit_log_bytes`], so the agent's
+///    heartbeat/requests-ack siblings survive. Other agents' refs are NEVER
+///    pruned.
+///
+/// # Prune safety invariant
+///
+/// Prune happens only when the checkpoint that COVERS the pruned events is
+/// durably visible (committed locally, and — if a remote is configured — pushed).
+/// Pruning before the covering checkpoint is pushed could let a fresh clone fetch
+/// the pruned ref but an older checkpoint, losing events not yet covered by any
+/// visible checkpoint. Hence: no push success ⇒ no prune.
+///
+/// No materialized files, no worktree writes — pure object-store plumbing.
+///
+/// # Errors
+///
+/// Returns an error if reduction, checkpoint serialization/commit, or the prune
+/// rewrite fails. A lost checkpoint CAS or a lost push lease is NOT an error.
+// Wired into the v3 compact CLI path by pass 2; flagged dead until then.
+#[allow(dead_code)]
+pub fn compact_v3(
+    repo_dir: &Path,
+    agent_id: &str,
+    _hub_lock: &crate::sync::HubWriteLock,
+    remote: Option<&str>,
+) -> Result<CompactV3Result> {
+    validate_agent_id(agent_id)?;
+
+    // 1. Reduce the full v3 ref namespace.
+    let source = crate::hub_source::RefHubSource::new(repo_dir)
+        .context("failed to construct RefHubSource for v3 compaction")?;
+    let outcome = crate::compaction::reduce(&source).context("v3 reduction failed")?;
+    let events_processed = outcome.events_processed;
+    let watermark = outcome.state.watermark.clone();
+
+    // 2. Serialize and commit the checkpoint (CAS CurrentTip).
+    let mut state = outcome.state;
+    state.compaction_lease = None;
+    let state_bytes =
+        serde_json::to_vec_pretty(&state).context("failed to serialize v3 checkpoint state")?;
+
+    // Idempotency guard: if the existing checkpoint's `state.json` already
+    // equals the freshly-reduced bytes, writing a new commit would only churn
+    // the ref SHA (new commit object, same content) and break SHA-level
+    // idempotency for callers that re-compact opportunistically (e.g. fetch).
+    // Skip the commit AND the prune — nothing changed.
+    if let Some(existing_tip) = git_rev_parse_optional(repo_dir, CHECKPOINT_REF)? {
+        let spec = format!("{existing_tip}:state.json");
+        if let Some(existing_bytes) = git_cat_file_blob_optional(repo_dir, &spec)? {
+            if existing_bytes == state_bytes {
+                tracing::debug!(
+                    "v3 compaction: checkpoint already current (byte-identical); no-op"
+                );
+                return Ok(CompactV3Result {
+                    events_processed,
+                    checkpoint_commit: Some(existing_tip),
+                    checkpoint_pushed: false,
+                    events_pruned: 0,
+                });
+            }
+        }
+    }
+
+    let checkpoint_commit = match commit_blob_to_ref(
+        repo_dir,
+        CHECKPOINT_REF,
+        "state.json",
+        &state_bytes,
+        "crosslink v3 checkpoint",
+    ) {
+        Ok(sha) => Some(sha),
+        Err(e) => {
+            // A concurrent local compactor moved the checkpoint first. The
+            // content is deterministic for the same event set, so this is a
+            // benign no-op: log at debug and skip the rest (no prune).
+            let msg = format!("{e:?}");
+            if msg.contains("ref moved concurrently") {
+                tracing::debug!(
+                    "v3 compaction: checkpoint CAS lost to a concurrent compactor (benign): {msg}"
+                );
+                return Ok(CompactV3Result {
+                    events_processed,
+                    checkpoint_commit: None,
+                    checkpoint_pushed: false,
+                    events_pruned: 0,
+                });
+            }
+            return Err(e).context("failed to commit v3 checkpoint");
+        }
+    };
+
+    // 3. Push the checkpoint with --force-with-lease, if a remote is configured.
+    //    Lease loss is benign (deterministic content) → debug, not error.
+    let checkpoint_pushed = match remote {
+        None => false,
+        Some(rem) => {
+            let expected = remote_checkpoint_sha(repo_dir, rem);
+            match push_ref_with_lease(repo_dir, rem, CHECKPOINT_REF, expected.as_deref())? {
+                PushOutcome::Pushed => true,
+                PushOutcome::NonFastForward => {
+                    tracing::debug!(
+                        "v3 compaction: checkpoint lease lost (benign, deterministic content); \
+                         skipping prune this cycle"
+                    );
+                    false
+                }
+                other => {
+                    tracing::debug!(
+                        "v3 compaction: checkpoint push did not succeed ({other:?}); \
+                         skipping prune this cycle"
+                    );
+                    false
+                }
+            }
+        }
+    };
+
+    // 4. REQ-11 prune — only when the covering checkpoint is durably visible.
+    //    Local-only (remote=None): a committed checkpoint suffices.
+    //    Remote configured: the checkpoint must have PUSHED.
+    let prune_ok = checkpoint_commit.is_some() && (remote.is_none() || checkpoint_pushed);
+    let events_pruned = if prune_ok {
+        match &watermark {
+            Some(wm) => prune_own_ref(repo_dir, agent_id, wm)?,
+            None => 0,
+        }
+    } else {
+        0
+    };
+
+    // 5. After a prune the local own ref is REWRITTEN (shorter history), so a
+    //    subsequent plain own-ref push would be non-fast-forward against the
+    //    un-pruned remote. The own ref is single-writer (REQ-11), so force the
+    //    remote ref to the pruned local tip to keep them in sync and preserve
+    //    the fast-forward invariant for future plain pushes. Only when a remote
+    //    is configured and we actually pruned. A force-push failure here is
+    //    benign (the events remain durable locally; the next compact retries).
+    if events_pruned > 0 {
+        if let Some(rem) = remote {
+            let ref_name = format!("{AGENT_REF_PREFIX}{agent_id}");
+            let refspec = format!("+{ref_name}:{ref_name}");
+            match Command::new("git")
+                .current_dir(repo_dir)
+                .args(["push", rem, &refspec])
+                .output()
+            {
+                Ok(out) if out.status.success() => {}
+                Ok(out) => tracing::debug!(
+                    "v3 compaction: own-ref prune force-push did not complete (benign): {}",
+                    String::from_utf8_lossy(&out.stderr).trim()
+                ),
+                Err(e) => tracing::debug!(
+                    "v3 compaction: own-ref prune force-push could not run (benign): {e}"
+                ),
+            }
+        }
+    }
+
+    Ok(CompactV3Result {
+        events_processed,
+        checkpoint_commit,
+        checkpoint_pushed,
+        events_pruned,
+    })
+}
+
+/// Resolve the remote-tracking checkpoint SHA to use as the `--force-with-lease`
+/// baseline, or `None` if no tracking ref is known (git falls back to its own
+/// remote-tracking ref).
+fn remote_checkpoint_sha(repo_dir: &Path, _remote: &str) -> Option<String> {
+    // The fetch refspec maps refs/crosslink/* → refs/crosslink-remote/*.
+    let tracking = "refs/crosslink-remote/checkpoint";
+    git_rev_parse_optional(repo_dir, tracking).ok().flatten()
+}
+
+/// Rewrite this agent's OWN ref `events.log`, dropping events with
+/// `OrderingKey <= watermark`. Sibling-preserving via [`commit_log_bytes`].
+///
+/// Returns the number of events pruned. NEVER touches another agent's ref.
+fn prune_own_ref(
+    repo_dir: &Path,
+    agent_id: &str,
+    watermark: &crate::events::OrderingKey,
+) -> Result<usize> {
+    let ref_name = format!("{AGENT_REF_PREFIX}{agent_id}");
+    let Some(tip) = git_rev_parse_optional(repo_dir, &ref_name)? else {
+        return Ok(0);
+    };
+    let spec = format!("{tip}:events.log");
+    let Some(bytes) = git_cat_file_blob_optional(repo_dir, &spec)? else {
+        return Ok(0);
+    };
+    let all = read_events_from_bytes(&bytes)
+        .with_context(|| format!("failed to parse events.log on '{ref_name}' for prune"))?;
+    let before = all.len();
+    let remaining: Vec<_> = all
+        .into_iter()
+        .filter(|e| crate::events::OrderingKey::from_envelope(e) > *watermark)
+        .collect();
+    let pruned = before - remaining.len();
+    if pruned == 0 {
+        return Ok(0);
+    }
+
+    // Re-serialize the pruned log to NDJSON bytes (byte-identical to the
+    // append/write path: one JSON line per event, trailing newline).
+    let mut out = Vec::new();
+    for ev in &remaining {
+        let line = serde_json::to_string(ev).context("failed to serialize pruned event")?;
+        out.extend_from_slice(line.as_bytes());
+        out.push(b'\n');
+    }
+
+    commit_log_bytes(
+        repo_dir,
+        agent_id,
+        &out,
+        &format!("crosslink v3 prune: dropped {pruned} covered events"),
+    )?;
+    Ok(pruned)
 }
 
 // ── Config helper ────────────────────────────────────────────────────
@@ -785,7 +1489,7 @@ pub(crate) fn append_event_to_ref_with_abort(
 
 /// Run `git rev-parse --verify --quiet <ref>` and return `Some(sha)` if the
 /// ref exists, or `None` if it doesn't.
-fn git_rev_parse_optional(repo_dir: &Path, ref_name: &str) -> Result<Option<String>> {
+pub(crate) fn git_rev_parse_optional(repo_dir: &Path, ref_name: &str) -> Result<Option<String>> {
     let output = Command::new("git")
         .current_dir(repo_dir)
         .args(["rev-parse", "--verify", "--quiet", ref_name])
@@ -806,7 +1510,10 @@ fn git_rev_parse_optional(repo_dir: &Path, ref_name: &str) -> Result<Option<Stri
 
 /// Read a blob by `<commit>:<path>` spec. Returns `None` if the object does
 /// not exist (missing path); returns an error for other failures.
-fn git_cat_file_blob_optional(repo_dir: &Path, blob_spec: &str) -> Result<Option<Vec<u8>>> {
+pub(crate) fn git_cat_file_blob_optional(
+    repo_dir: &Path,
+    blob_spec: &str,
+) -> Result<Option<Vec<u8>>> {
     let output = Command::new("git")
         .current_dir(repo_dir)
         .args(["cat-file", "blob", blob_spec])
@@ -985,16 +1692,53 @@ fn commit_single_file_tree(
     committer_id: &str,
     expected: CasExpectation<'_>,
 ) -> Result<String> {
-    let blob_sha = git_hash_object(repo_dir, bytes)?;
-    let tree_sha = git_mktree_single(repo_dir, &blob_sha, file_name)?;
-    commit_tree_and_update_ref(
+    commit_upserts_to_ref(
         repo_dir,
         ref_name,
-        &tree_sha,
+        &[(file_name, BlobRef::Bytes(bytes))],
+        &[],
         message,
         committer_id,
         expected,
     )
+}
+
+/// Sibling-preserving multi-path commit core.
+///
+/// Resolves the CAS base/old value from `expected`, builds the new tree from
+/// that base via [`write_tree_with`] (applying `upserts` and `deletes` while
+/// keeping every unrelated sibling), commits it as a child of the base, and
+/// CAS-updates `ref_name`.
+///
+/// This is THE shared core for every hub-v3 ref write: a naive single-entry
+/// `mktree` would drop sibling files (heartbeat.json, requests-ack/, …) once
+/// refs carry them, so the append path, checkpoint writes, meta writes,
+/// heartbeats, requests, and acks all route through here.
+///
+/// # Errors
+///
+/// Returns `"ref moved concurrently: <ref>"` on a CAS failure, or any git
+/// plumbing / path-nesting error from [`write_tree_with`].
+fn commit_upserts_to_ref(
+    repo_dir: &Path,
+    ref_name: &str,
+    upserts: &[(&str, BlobRef<'_>)],
+    deletes: &[&str],
+    message: &str,
+    committer_id: &str,
+    expected: CasExpectation<'_>,
+) -> Result<String> {
+    let old_commit = resolve_cas_old(repo_dir, ref_name, expected)?;
+    let tree_sha = write_tree_with(repo_dir, old_commit.as_deref(), upserts, deletes)?;
+    let commit_sha = git_commit_tree(
+        repo_dir,
+        &tree_sha,
+        old_commit.as_deref(),
+        message,
+        committer_id,
+    )?;
+    git_update_ref_cas(repo_dir, ref_name, &commit_sha, old_commit.as_deref())?;
+    Ok(commit_sha)
 }
 
 /// Resolve the CAS old-value and the commit parent for an `expected`
@@ -1020,28 +1764,6 @@ fn resolve_cas_old(
         CasExpectation::MustMatch(sha) => Ok(Some(sha.to_string())),
         CasExpectation::CurrentTip => git_rev_parse_optional(repo_dir, ref_name),
     }
-}
-
-/// Commit `tree_sha` onto `ref_name` with a parent/CAS resolved from `expected`,
-/// then CAS-update the ref. Shared by the single-file and multi-file paths.
-fn commit_tree_and_update_ref(
-    repo_dir: &Path,
-    ref_name: &str,
-    tree_sha: &str,
-    message: &str,
-    committer_id: &str,
-    expected: CasExpectation<'_>,
-) -> Result<String> {
-    let old_commit = resolve_cas_old(repo_dir, ref_name, expected)?;
-    let commit_sha = git_commit_tree(
-        repo_dir,
-        tree_sha,
-        old_commit.as_deref(),
-        message,
-        committer_id,
-    )?;
-    git_update_ref_cas(repo_dir, ref_name, &commit_sha, old_commit.as_deref())?;
-    Ok(commit_sha)
 }
 
 /// Commit a single blob to an arbitrary ref at the TREE ROOT under `file_name`.
@@ -1109,52 +1831,357 @@ pub fn commit_files_to_ref(
         "commit_files_to_ref requires at least one file"
     );
 
-    // Hash every blob, then sort tree lines by file name (git tree invariant).
-    let mut entries: Vec<(String, String)> = Vec::with_capacity(files.len());
-    for (name, bytes) in files {
+    // Validate names (root-level only) and reject duplicates before building.
+    for (name, _) in files {
         anyhow::ensure!(
             !name.contains('/') && !name.is_empty(),
             "commit_files_to_ref file name must be a non-empty tree-root name, got '{name}'"
         );
-        let blob_sha = git_hash_object(repo_dir, bytes)?;
-        entries.push(((*name).to_string(), blob_sha));
     }
-    entries.sort_by(|a, b| a.0.cmp(&b.0));
-    for pair in entries.windows(2) {
+    let mut sorted: Vec<&str> = files.iter().map(|(n, _)| *n).collect();
+    sorted.sort_unstable();
+    for pair in sorted.windows(2) {
         anyhow::ensure!(
-            pair[0].0 != pair[1].0,
+            pair[0] != pair[1],
             "commit_files_to_ref got duplicate file name '{}'",
-            pair[0].0
+            pair[0]
         );
     }
 
-    let tree_sha = git_mktree_multi(repo_dir, &entries)?;
-    commit_tree_and_update_ref(
+    let upserts: Vec<(&str, BlobRef<'_>)> = files
+        .iter()
+        .map(|(name, bytes)| (*name, BlobRef::Bytes(bytes)))
+        .collect();
+    commit_upserts_to_ref(
         repo_dir,
         ref_name,
-        &tree_sha,
+        &upserts,
+        &[],
         message,
         "crosslink",
         CasExpectation::CurrentTip,
     )
 }
 
-/// Create a tree from a single blob under an arbitrary `file_name` via
-/// `git mktree`. Generalizes [`git_mktree`] (which hardcodes `events.log`).
-fn git_mktree_single(repo_dir: &Path, blob_sha: &str, file_name: &str) -> Result<String> {
-    git_mktree_multi(repo_dir, &[(file_name.to_string(), blob_sha.to_string())])
+// ── Sibling-preserving tree core (REQ-1/REQ-11 prerequisite) ─────────
+
+/// One entry of a git tree as emitted by `git ls-tree <sha>`.
+///
+/// Subtree entries (`object_type == "tree"`) are retained verbatim so nested
+/// directories survive a root-level rewrite without recursion — the existing
+/// subtree SHA is fed straight back to `git mktree` unless an upsert/delete
+/// explicitly targets a path inside it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TreeEntry {
+    /// Git mode string, e.g. `100644` (blob), `100755` (exec), `040000` (tree).
+    mode: String,
+    /// `blob` or `tree`.
+    object_type: String,
+    /// Object SHA.
+    sha: String,
+    /// Entry name (a single path component — never contains `/`).
+    name: String,
 }
 
-/// Create a tree from sorted `(file_name, blob_sha)` entries via `git mktree`.
-fn git_mktree_multi(repo_dir: &Path, entries: &[(String, String)]) -> Result<String> {
-    use std::fmt::Write as _;
+impl TreeEntry {
+    /// Render this entry as a single `git mktree` input line:
+    /// `<mode> SP <type> SP <sha> TAB <name>`.
+    fn mktree_line(&self) -> String {
+        format!(
+            "{} {} {}\t{}",
+            self.mode, self.object_type, self.sha, self.name
+        )
+    }
+}
+
+/// Source of a blob to write into a tree: either pre-hashed (the append path
+/// already ran `hash-object`) or raw bytes to hash now.
+enum BlobRef<'a> {
+    /// A blob SHA already present in the object store.
+    Existing(&'a str),
+    /// Raw bytes to `git hash-object -w` before insertion.
+    Bytes(&'a [u8]),
+}
+
+impl BlobRef<'_> {
+    /// Resolve to a concrete blob SHA, hashing if necessary.
+    fn resolve(&self, repo_dir: &Path) -> Result<String> {
+        match self {
+            BlobRef::Existing(sha) => Ok((*sha).to_string()),
+            BlobRef::Bytes(bytes) => git_hash_object(repo_dir, bytes),
+        }
+    }
+}
+
+/// Read the entries of the tree at `commit_sha` via `git ls-tree <sha>`.
+///
+/// Returns one [`TreeEntry`] per top-level entry. Subtrees are kept as tree
+/// entries verbatim (their SHA is preserved), so nested directories survive a
+/// root-level rewrite without recursing into them.
+///
+/// # Errors
+///
+/// Returns an error if `git ls-tree` cannot be spawned or fails, or if a line
+/// cannot be parsed in the documented `<mode> SP <type> SP <sha> TAB <name>`
+/// format.
+fn read_tree_entries(repo_dir: &Path, commit_sha: &str) -> Result<Vec<TreeEntry>> {
+    let spec = format!("{commit_sha}^{{tree}}");
+    let output = Command::new("git")
+        .current_dir(repo_dir)
+        .args(["ls-tree", &spec])
+        .output()
+        .with_context(|| format!("failed to run git ls-tree for '{spec}'"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("git ls-tree failed for '{}': {}", spec, stderr.trim());
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut entries = Vec::new();
+    for line in stdout.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        // Format: "<mode> SP <type> SP <sha>\t<name>"
+        let (meta, name) = line
+            .split_once('\t')
+            .ok_or_else(|| anyhow::anyhow!("malformed git ls-tree line (no TAB): {line}"))?;
+        let mut parts = meta.split_whitespace();
+        let mode = parts
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("malformed git ls-tree line (no mode): {line}"))?;
+        let object_type = parts
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("malformed git ls-tree line (no type): {line}"))?;
+        let sha = parts
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("malformed git ls-tree line (no sha): {line}"))?;
+        entries.push(TreeEntry {
+            mode: mode.to_string(),
+            object_type: object_type.to_string(),
+            sha: sha.to_string(),
+            name: name.to_string(),
+        });
+    }
+    Ok(entries)
+}
+
+/// Build a new tree from an optional `base` commit's tree, applying `upserts`
+/// (insert-or-replace) and `deletes` while preserving every unrelated sibling.
+///
+/// # Path nesting
+///
+/// At most ONE level of nesting is supported. A path is either:
+/// - a root-level file (`"events.log"`, `"heartbeat.json"`), or
+/// - a one-level subtree path (`"requests-ack/<ulid>.json"`).
+///
+/// Paths with two or more `/` separators are rejected with an error — the v3
+/// design needs exactly one nesting level (driver requests under
+/// `requests-out/<target>--<ulid>.json`, acks under `requests-ack/<ulid>.json`),
+/// and deeper trees would require recursion this core deliberately avoids.
+///
+/// For a subtree path the existing subtree (if any) is read, the target leaf is
+/// upserted/deleted within it, and the rebuilt subtree replaces the old one in
+/// the root entry list. A subtree that becomes empty after a delete is dropped
+/// from the root entirely.
+///
+/// `base = None` builds the tree from scratch (genesis). The returned SHA is a
+/// tree object suitable for `git commit-tree`.
+///
+/// # Errors
+///
+/// Returns an error on a path with deeper-than-one nesting, an empty path
+/// component, any git plumbing failure, or a name collision between a file and
+/// a subtree at the root.
+fn write_tree_with(
+    repo_dir: &Path,
+    base: Option<&str>,
+    upserts: &[(&str, BlobRef<'_>)],
+    deletes: &[&str],
+) -> Result<String> {
+    use std::collections::BTreeMap;
+
+    // Start from the base tree's entries (or empty for genesis), keyed by name
+    // so upserts/deletes are O(log n) and ordering is deterministic.
+    let mut root: BTreeMap<String, TreeEntry> = BTreeMap::new();
+    if let Some(commit_sha) = base {
+        for entry in read_tree_entries(repo_dir, commit_sha)? {
+            root.insert(entry.name.clone(), entry);
+        }
+    }
+
+    // Pending mutations to one-level subtrees, accumulated so multiple
+    // upserts/deletes into the SAME subtree rebuild it once. Maps
+    // subtree-name -> (leaf-name -> Option<blob_sha>); None means delete.
+    let mut subtree_ops: BTreeMap<String, BTreeMap<String, Option<String>>> = BTreeMap::new();
+
+    // Classify and stage every upsert.
+    for (path, blob) in upserts {
+        match split_one_level(path)? {
+            (None, file) => {
+                let blob_sha = blob.resolve(repo_dir)?;
+                root.insert(
+                    file.to_string(),
+                    TreeEntry {
+                        mode: "100644".to_string(),
+                        object_type: "blob".to_string(),
+                        sha: blob_sha,
+                        name: file.to_string(),
+                    },
+                );
+            }
+            (Some(dir), leaf) => {
+                let blob_sha = blob.resolve(repo_dir)?;
+                subtree_ops
+                    .entry(dir.to_string())
+                    .or_default()
+                    .insert(leaf.to_string(), Some(blob_sha));
+            }
+        }
+    }
+
+    // Classify and stage every delete.
+    for path in deletes {
+        match split_one_level(path)? {
+            (None, file) => {
+                root.remove(file);
+            }
+            (Some(dir), leaf) => {
+                subtree_ops
+                    .entry(dir.to_string())
+                    .or_default()
+                    .insert(leaf.to_string(), None);
+            }
+        }
+    }
+
+    // Rebuild each touched subtree from its current entries + staged ops.
+    for (dir, ops) in subtree_ops {
+        // Read the existing subtree's entries, if the subtree exists in root.
+        let mut leaves: BTreeMap<String, TreeEntry> = BTreeMap::new();
+        if let Some(existing) = root.get(&dir) {
+            anyhow::ensure!(
+                existing.object_type == "tree",
+                "write_tree_with: '{dir}' exists as a {} but a subtree path targets it",
+                existing.object_type
+            );
+            for entry in read_subtree_entries(repo_dir, &existing.sha)? {
+                leaves.insert(entry.name.clone(), entry);
+            }
+        }
+
+        for (leaf, maybe_sha) in ops {
+            match maybe_sha {
+                Some(sha) => {
+                    leaves.insert(
+                        leaf.clone(),
+                        TreeEntry {
+                            mode: "100644".to_string(),
+                            object_type: "blob".to_string(),
+                            sha,
+                            name: leaf.clone(),
+                        },
+                    );
+                }
+                None => {
+                    leaves.remove(&leaf);
+                }
+            }
+        }
+
+        if leaves.is_empty() {
+            // Subtree emptied out — drop it from the root entirely.
+            root.remove(&dir);
+        } else {
+            let subtree_sha = mktree_from_entries(repo_dir, leaves.values())?;
+            root.insert(
+                dir.clone(),
+                TreeEntry {
+                    mode: "040000".to_string(),
+                    object_type: "tree".to_string(),
+                    sha: subtree_sha,
+                    name: dir,
+                },
+            );
+        }
+    }
+
+    mktree_from_entries(repo_dir, root.values())
+}
+
+/// Read the entries of a subtree object (a `tree` SHA, not a commit) via
+/// `git ls-tree <tree-sha>`. Each entry is a leaf of a one-level subtree.
+fn read_subtree_entries(repo_dir: &Path, tree_sha: &str) -> Result<Vec<TreeEntry>> {
+    // For a one-level subtree we only expect blob leaves, but read generically.
+    read_tree_entries_raw(repo_dir, tree_sha)
+}
+
+/// Run `git ls-tree <sha>` (the SHA may be a tree or a commit; `^{tree}` is not
+/// appended) and parse entries. Shared parser used by both the root and subtree
+/// readers.
+fn read_tree_entries_raw(repo_dir: &Path, sha: &str) -> Result<Vec<TreeEntry>> {
+    let output = Command::new("git")
+        .current_dir(repo_dir)
+        .args(["ls-tree", sha])
+        .output()
+        .with_context(|| format!("failed to run git ls-tree for '{sha}'"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("git ls-tree failed for '{}': {}", sha, stderr.trim());
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut entries = Vec::new();
+    for line in stdout.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let (meta, name) = line
+            .split_once('\t')
+            .ok_or_else(|| anyhow::anyhow!("malformed git ls-tree line (no TAB): {line}"))?;
+        let mut parts = meta.split_whitespace();
+        let mode = parts
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("malformed git ls-tree line (no mode): {line}"))?;
+        let object_type = parts
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("malformed git ls-tree line (no type): {line}"))?;
+        let sha_field = parts
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("malformed git ls-tree line (no sha): {line}"))?;
+        entries.push(TreeEntry {
+            mode: mode.to_string(),
+            object_type: object_type.to_string(),
+            sha: sha_field.to_string(),
+            name: name.to_string(),
+        });
+    }
+    Ok(entries)
+}
+
+/// Feed `entries` (in iterator order — callers pass sorted `BTreeMap::values`)
+/// to `git mktree` and return the resulting tree SHA. Empty input yields the
+/// canonical empty-tree object.
+fn mktree_from_entries<'a, I>(repo_dir: &Path, entries: I) -> Result<String>
+where
+    I: Iterator<Item = &'a TreeEntry>,
+{
     use std::io::Write as _;
 
     let mut input = String::new();
-    for (name, blob_sha) in entries {
-        // `write!` to a String is infallible; the trait method returns Result so
-        // the unused-result is intentionally discarded.
-        let _ = writeln!(input, "100644 blob {blob_sha}\t{name}");
+    let mut any = false;
+    for entry in entries {
+        any = true;
+        input.push_str(&entry.mktree_line());
+        input.push('\n');
+    }
+
+    if !any {
+        // `git mktree` with empty stdin produces the canonical empty tree.
+        // Use `git hash-object -t tree /dev/stdin` semantics via mktree, which
+        // returns the well-known empty-tree SHA. Feeding empty stdin to mktree
+        // is valid and yields that SHA.
+        input.clear();
     }
 
     let mut child = Command::new("git")
@@ -1187,6 +2214,41 @@ fn git_mktree_multi(repo_dir: &Path, entries: &[(String, String)]) -> Result<Str
         anyhow::bail!("git mktree returned empty SHA");
     }
     Ok(sha)
+}
+
+/// Split a path into `(Option<subtree>, leaf)`, enforcing the one-level-nesting
+/// invariant of [`write_tree_with`].
+///
+/// - `"events.log"` → `(None, "events.log")`
+/// - `"requests-ack/01J.json"` → `(Some("requests-ack"), "01J.json")`
+/// - `"a/b/c"` → error (deeper than one level)
+///
+/// # Errors
+///
+/// Returns an error on an empty path, an empty component, or more than one `/`.
+fn split_one_level(path: &str) -> Result<(Option<&str>, &str)> {
+    anyhow::ensure!(!path.is_empty(), "write_tree_with: empty path");
+    let mut parts = path.split('/');
+    let first = parts.next().unwrap_or("");
+    match parts.next() {
+        None => {
+            // No '/': root-level file.
+            anyhow::ensure!(!first.is_empty(), "write_tree_with: empty path component");
+            Ok((None, first))
+        }
+        Some(leaf) => {
+            anyhow::ensure!(
+                parts.next().is_none(),
+                "write_tree_with: path '{path}' nests deeper than one level (only \
+                 root-level files and one-level subtree paths are supported)"
+            );
+            anyhow::ensure!(
+                !first.is_empty() && !leaf.is_empty(),
+                "write_tree_with: empty path component in '{path}'"
+            );
+            Ok((Some(first), leaf))
+        }
+    }
 }
 
 // ── Tests ────────────────────────────────────────────────────────────
@@ -2153,5 +3215,508 @@ mod tests {
         )
         .unwrap();
         assert!(read_hub_meta(dir2.path()).unwrap().is_none());
+    }
+
+    // ── PASS 1 helpers ────────────────────────────────────────────────
+
+    fn make_heartbeat(agent_id: &str, issue: Option<i64>) -> crate::locks::Heartbeat {
+        crate::locks::Heartbeat {
+            agent_id: agent_id.to_string(),
+            last_heartbeat: Utc::now(),
+            active_issue_id: issue,
+            machine_id: format!("machine-{agent_id}"),
+        }
+    }
+
+    fn cat_blob(repo_dir: &Path, spec: &str) -> Option<Vec<u8>> {
+        let out = std::process::Command::new("git")
+            .current_dir(repo_dir)
+            .args(["cat-file", "blob", spec])
+            .output()
+            .unwrap();
+        if out.status.success() {
+            Some(out.stdout)
+        } else {
+            None
+        }
+    }
+
+    fn make_request(request_id: &str) -> crate::agent_requests::AgentRequest {
+        crate::agent_requests::AgentRequest {
+            request_id: request_id.to_string(),
+            kind: crate::agent_requests::RequestKind::Pause,
+            subject: crate::agent_requests::RequestSubject::default(),
+            requested_by: "SHA256:driver".to_string(),
+            requested_at: Utc::now().to_rfc3339(),
+            reason: None,
+        }
+    }
+
+    fn make_ack(request_id: &str) -> crate::agent_requests::AgentRequestAck {
+        crate::agent_requests::AgentRequestAck {
+            request_id: request_id.to_string(),
+            ack_at: Utc::now().to_rfc3339(),
+            acted: true,
+            result: "paused".to_string(),
+            notes: None,
+        }
+    }
+
+    // ── Part 1: sibling preservation ──────────────────────────────────
+
+    #[test]
+    fn append_event_preserves_sibling_heartbeat() {
+        // Regression gate: a ref carrying events.log + heartbeat.json must keep
+        // heartbeat.json byte-identical after an append touches only events.log.
+        let dir = tempfile::tempdir().unwrap();
+        git_init(dir.path());
+        let agent_id = "sibling-agent";
+
+        // Genesis events.log.
+        append_event_to_ref(dir.path(), agent_id, &make_envelope(agent_id, 1)).unwrap();
+        // Write a heartbeat sibling.
+        write_heartbeat_to_ref(dir.path(), agent_id, &make_heartbeat(agent_id, Some(7))).unwrap();
+
+        let ref_name = agent_ref_name(agent_id).unwrap();
+        let tip = run_git_output(dir.path(), &["rev-parse", &ref_name]);
+        let hb_before = cat_blob(dir.path(), &format!("{tip}:heartbeat.json")).unwrap();
+
+        // Append another event — heartbeat.json must survive untouched.
+        append_event_to_ref(dir.path(), agent_id, &make_envelope(agent_id, 2)).unwrap();
+
+        let tip2 = run_git_output(dir.path(), &["rev-parse", &ref_name]);
+        let hb_after = cat_blob(dir.path(), &format!("{tip2}:heartbeat.json")).unwrap();
+        assert_eq!(hb_before, hb_after, "heartbeat.json must survive an append");
+
+        // events.log must now have 2 events.
+        let log = cat_blob(dir.path(), &format!("{tip2}:events.log")).unwrap();
+        assert_eq!(read_events_from_bytes(&log).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn interleaved_writers_preserve_all_siblings() {
+        // append / heartbeat / ack all write the SAME ref; every writer must
+        // preserve the others' files.
+        let dir = tempfile::tempdir().unwrap();
+        git_init(dir.path());
+        let agent_id = "multi-writer";
+        let ref_name = agent_ref_name(agent_id).unwrap();
+
+        append_event_to_ref(dir.path(), agent_id, &make_envelope(agent_id, 1)).unwrap();
+        write_heartbeat_to_ref(dir.path(), agent_id, &make_heartbeat(agent_id, None)).unwrap();
+        write_ack_to_own_ref(dir.path(), agent_id, "01ACK0001", &make_ack("01ACK0001")).unwrap();
+        // A second append after the heartbeat + ack are in place.
+        append_event_to_ref(dir.path(), agent_id, &make_envelope(agent_id, 2)).unwrap();
+        // A second ack into the same subtree.
+        write_ack_to_own_ref(dir.path(), agent_id, "01ACK0002", &make_ack("01ACK0002")).unwrap();
+
+        let tip = run_git_output(dir.path(), &["rev-parse", &ref_name]);
+        // events.log: 2 events.
+        let log = cat_blob(dir.path(), &format!("{tip}:events.log")).unwrap();
+        assert_eq!(read_events_from_bytes(&log).unwrap().len(), 2);
+        // heartbeat.json present.
+        assert!(cat_blob(dir.path(), &format!("{tip}:heartbeat.json")).is_some());
+        // Both acks present in the subtree.
+        assert!(cat_blob(dir.path(), &format!("{tip}:requests-ack/01ACK0001.json")).is_some());
+        assert!(cat_blob(dir.path(), &format!("{tip}:requests-ack/01ACK0002.json")).is_some());
+    }
+
+    #[test]
+    fn write_tree_with_rejects_deep_nesting() {
+        let dir = tempfile::tempdir().unwrap();
+        git_init(dir.path());
+        let res = write_tree_with(
+            dir.path(),
+            None,
+            &[("a/b/c.json", BlobRef::Bytes(b"x"))],
+            &[],
+        );
+        assert!(res.is_err(), "deeper-than-one-level path must be rejected");
+        let msg = format!("{:?}", res.unwrap_err());
+        assert!(
+            msg.contains("nests deeper than one level"),
+            "error must mention nesting depth, got: {msg}"
+        );
+        // split_one_level direct coverage.
+        assert!(split_one_level("a/b/c").is_err());
+        assert_eq!(split_one_level("file.json").unwrap(), (None, "file.json"));
+        assert_eq!(
+            split_one_level("dir/leaf.json").unwrap(),
+            (Some("dir"), "leaf.json")
+        );
+    }
+
+    #[test]
+    fn write_tree_with_subtree_delete_drops_empty_subtree() {
+        let dir = tempfile::tempdir().unwrap();
+        git_init(dir.path());
+        let agent_id = "subtree-agent";
+        let ref_name = agent_ref_name(agent_id).unwrap();
+
+        append_event_to_ref(dir.path(), agent_id, &make_envelope(agent_id, 1)).unwrap();
+        write_ack_to_own_ref(dir.path(), agent_id, "01ONLY", &make_ack("01ONLY")).unwrap();
+        let tip = run_git_output(dir.path(), &["rev-parse", &ref_name]);
+        assert!(cat_blob(dir.path(), &format!("{tip}:requests-ack/01ONLY.json")).is_some());
+
+        // Delete the only ack leaf → subtree must vanish, events.log survives.
+        let new_tree =
+            write_tree_with(dir.path(), Some(&tip), &[], &["requests-ack/01ONLY.json"]).unwrap();
+        let listing = run_git_output(dir.path(), &["ls-tree", "--name-only", &new_tree]);
+        let names: Vec<&str> = listing.lines().collect();
+        assert_eq!(names, vec!["events.log"], "empty subtree must be dropped");
+    }
+
+    // ── Part 2: heartbeats ────────────────────────────────────────────
+
+    #[test]
+    fn heartbeats_roundtrip_across_three_refs() {
+        let dir = tempfile::tempdir().unwrap();
+        git_init(dir.path());
+
+        // Three agents: two with heartbeats, one with only events (skipped).
+        for (id, issue) in [("hb-a", Some(1)), ("hb-b", None)] {
+            append_event_to_ref(dir.path(), id, &make_envelope(id, 1)).unwrap();
+            write_heartbeat_to_ref(dir.path(), id, &make_heartbeat(id, issue)).unwrap();
+        }
+        // hb-c: events only, no heartbeat.
+        append_event_to_ref(dir.path(), "hb-c", &make_envelope("hb-c", 1)).unwrap();
+
+        let mut beats = read_heartbeats_from_refs(dir.path()).unwrap();
+        beats.sort_by(|a, b| a.0.cmp(&b.0));
+        assert_eq!(beats.len(), 2, "only agents with a heartbeat are returned");
+        assert_eq!(beats[0].0, "hb-a");
+        assert_eq!(beats[0].1.active_issue_id, Some(1));
+        assert_eq!(beats[1].0, "hb-b");
+        assert_eq!(beats[1].1.active_issue_id, None);
+    }
+
+    #[test]
+    fn heartbeat_overwrites_previous() {
+        let dir = tempfile::tempdir().unwrap();
+        git_init(dir.path());
+        let id = "hb-update";
+        write_heartbeat_to_ref(dir.path(), id, &make_heartbeat(id, Some(1))).unwrap();
+        write_heartbeat_to_ref(dir.path(), id, &make_heartbeat(id, Some(2))).unwrap();
+        let beats = read_heartbeats_from_refs(dir.path()).unwrap();
+        assert_eq!(beats.len(), 1);
+        assert_eq!(beats[0].1.active_issue_id, Some(2), "latest heartbeat wins");
+    }
+
+    // ── Part 3: requests / acks ───────────────────────────────────────
+
+    #[test]
+    fn request_poll_ack_lifecycle() {
+        let dir = tempfile::tempdir().unwrap();
+        git_init(dir.path());
+        let driver = "driver-1";
+        let target = "target-1";
+
+        // Driver writes a request into its own ref.
+        let req = make_request("01REQ0001");
+        write_request_to_own_ref(dir.path(), driver, target, &req).unwrap();
+
+        // Target polls and sees it.
+        let pending = poll_requests_for_agent(dir.path(), target).unwrap();
+        assert_eq!(pending.len(), 1, "target must see the pending request");
+        assert_eq!(pending[0].0, driver, "driver id recovered");
+        assert_eq!(pending[0].1.request_id, "01REQ0001");
+
+        // Target acks into its own ref.
+        write_ack_to_own_ref(dir.path(), target, "01REQ0001", &make_ack("01REQ0001")).unwrap();
+
+        // Poll no longer returns it.
+        let after = poll_requests_for_agent(dir.path(), target).unwrap();
+        assert!(after.is_empty(), "acked request must not be returned");
+    }
+
+    #[test]
+    fn request_for_different_target_not_returned() {
+        let dir = tempfile::tempdir().unwrap();
+        git_init(dir.path());
+        let driver = "driver-2";
+        write_request_to_own_ref(
+            dir.path(),
+            driver,
+            "someone-else",
+            &make_request("01REQOTHER"),
+        )
+        .unwrap();
+        let pending = poll_requests_for_agent(dir.path(), "me-myself").unwrap();
+        assert!(pending.is_empty(), "request for another target is filtered");
+    }
+
+    #[test]
+    fn request_separator_handles_hyphenated_agent_ids() {
+        // Target id containing single hyphens must parse via split-on-LAST `--`.
+        let dir = tempfile::tempdir().unwrap();
+        git_init(dir.path());
+        let driver = "ops-driver";
+        let target = "my-hyphenated-agent";
+        write_request_to_own_ref(dir.path(), driver, target, &make_request("01HYPH001")).unwrap();
+
+        let pending = poll_requests_for_agent(dir.path(), target).unwrap();
+        assert_eq!(pending.len(), 1, "hyphenated target id must parse");
+        assert_eq!(pending[0].0, driver);
+
+        // Direct parse-encode roundtrip coverage.
+        let name = format!("{target}--01HYPH001.json");
+        let (t, u) = parse_request_out_name(&name).unwrap();
+        assert_eq!(t, target);
+        assert_eq!(u, "01HYPH001");
+        // A name with no separator returns None.
+        assert!(parse_request_out_name("nodelim.json").is_none());
+    }
+
+    #[test]
+    fn requests_from_multiple_drivers_to_same_target() {
+        let dir = tempfile::tempdir().unwrap();
+        git_init(dir.path());
+        let target = "busy-target";
+        write_request_to_own_ref(dir.path(), "drv-a", target, &make_request("01AAA")).unwrap();
+        write_request_to_own_ref(dir.path(), "drv-b", target, &make_request("01BBB")).unwrap();
+
+        let pending = poll_requests_for_agent(dir.path(), target).unwrap();
+        assert_eq!(pending.len(), 2, "requests from both drivers visible");
+        // Sorted by ulid.
+        assert_eq!(pending[0].1.request_id, "01AAA");
+        assert_eq!(pending[1].1.request_id, "01BBB");
+
+        // Ack one — only the other remains.
+        write_ack_to_own_ref(dir.path(), target, "01AAA", &make_ack("01AAA")).unwrap();
+        let remaining = poll_requests_for_agent(dir.path(), target).unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].1.request_id, "01BBB");
+    }
+
+    // ── Part 4: compact_v3 ────────────────────────────────────────────
+
+    fn test_hub_lock(dir: &Path) -> crate::sync::HubWriteLock {
+        let lock_path = dir.join(".hub-write-lock");
+        crate::sync::acquire_hub_lock(&lock_path).expect("failed to acquire hub write lock")
+    }
+
+    /// Seed a v3 hub in `dir`: a meta ref (so `detect_hub_version` is V3) plus
+    /// `count` events on `agent_id`'s ref. Returns nothing; refs are live.
+    fn seed_v3_hub(dir: &Path, agent_id: &str, count: u64) {
+        commit_files_to_ref(
+            dir,
+            META_REF,
+            &[("hub.json", b"{\"hub_version\":3}\n")],
+            "meta",
+        )
+        .unwrap();
+        for seq in 1..=count {
+            append_event_to_ref(dir, agent_id, &make_envelope(agent_id, seq)).unwrap();
+        }
+    }
+
+    #[test]
+    fn compact_v3_local_only_writes_checkpoint_and_prunes() {
+        let dir = tempfile::tempdir().unwrap();
+        git_init(dir.path());
+        let agent_id = "cv3-agent";
+        seed_v3_hub(dir.path(), agent_id, 4);
+
+        let lock = test_hub_lock(dir.path());
+        let result = compact_v3(dir.path(), agent_id, &lock, None).unwrap();
+        drop(lock);
+
+        assert_eq!(result.events_processed, 4);
+        assert!(result.checkpoint_commit.is_some(), "checkpoint committed");
+        assert!(!result.checkpoint_pushed, "no remote → no push");
+        // Local-only: prune happens once the checkpoint is committed.
+        assert_eq!(result.events_pruned, 4, "all covered events pruned locally");
+
+        // Checkpoint ref must exist with state.json.
+        let cp_tip = run_git_output(dir.path(), &["rev-parse", CHECKPOINT_REF]);
+        let state_bytes = cat_blob(dir.path(), &format!("{cp_tip}:state.json")).unwrap();
+        let state = crate::checkpoint::CheckpointState::from_slice(&state_bytes).unwrap();
+        assert_eq!(state.issues.len(), 4, "4 issues materialized");
+
+        // Own ref's events.log is now empty (all <= watermark).
+        let agent_tip = run_git_output(
+            dir.path(),
+            &["rev-parse", &agent_ref_name(agent_id).unwrap()],
+        );
+        let log = cat_blob(dir.path(), &format!("{agent_tip}:events.log")).unwrap();
+        assert!(read_events_from_bytes(&log).unwrap().is_empty());
+    }
+
+    #[test]
+    fn compact_v3_remote_push_then_prune_and_fresh_reduce_matches() {
+        let dir = tempfile::tempdir().unwrap();
+        let remote = tempfile::tempdir().unwrap();
+        git_init(dir.path());
+        run_git(remote.path(), &["init", "--bare"]);
+        run_git(
+            dir.path(),
+            &["remote", "add", "origin", remote.path().to_str().unwrap()],
+        );
+
+        let agent_id = "cv3-remote";
+        seed_v3_hub(dir.path(), agent_id, 3);
+        // Push the agent ref so a fresh clone can fetch it.
+        push_agent_ref(dir.path(), "origin", agent_id).unwrap();
+
+        // Capture the full reduced state BEFORE prune for comparison.
+        let pre =
+            crate::compaction::reduce(&crate::hub_source::RefHubSource::new(dir.path()).unwrap())
+                .unwrap();
+
+        let lock = test_hub_lock(dir.path());
+        let result = compact_v3(dir.path(), agent_id, &lock, Some("origin")).unwrap();
+        drop(lock);
+
+        assert!(result.checkpoint_pushed, "checkpoint pushed to remote");
+        assert_eq!(result.events_pruned, 3, "prune after successful push");
+
+        // Push the pruned agent ref too (so the remote reflects the prune).
+        push_agent_ref(dir.path(), "origin", agent_id).unwrap();
+
+        // Fresh clone fetches the v3 refs and must reduce to identical state.
+        let fresh = tempfile::tempdir().unwrap();
+        run_git(fresh.path(), &["init"]);
+        run_git(
+            fresh.path(),
+            &["remote", "add", "origin", remote.path().to_str().unwrap()],
+        );
+        run_git(
+            fresh.path(),
+            &["fetch", "origin", "+refs/crosslink/*:refs/crosslink/*"],
+        );
+        let fresh_outcome =
+            crate::compaction::reduce(&crate::hub_source::RefHubSource::new(fresh.path()).unwrap())
+                .unwrap();
+
+        // Identical full state: checkpoint + remaining events == original full reduce.
+        let pre_state = serde_json::to_value(&pre.state).unwrap();
+        let fresh_state = serde_json::to_value(&fresh_outcome.state).unwrap();
+        assert_eq!(
+            pre_state, fresh_state,
+            "fresh clone (checkpoint + pruned ref) must reduce to identical state"
+        );
+    }
+
+    #[test]
+    fn compact_v3_skips_prune_when_push_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        git_init(dir.path());
+        // Add a remote that does not exist → push fails.
+        run_git(
+            dir.path(),
+            &["remote", "add", "origin", "/no/such/bare/remote"],
+        );
+        let agent_id = "cv3-nopush";
+        seed_v3_hub(dir.path(), agent_id, 2);
+
+        let lock = test_hub_lock(dir.path());
+        let result = compact_v3(dir.path(), agent_id, &lock, Some("origin")).unwrap();
+        drop(lock);
+
+        assert!(
+            result.checkpoint_commit.is_some(),
+            "checkpoint still committed locally"
+        );
+        assert!(!result.checkpoint_pushed, "push to dead remote fails");
+        assert_eq!(
+            result.events_pruned, 0,
+            "prune MUST be skipped when the checkpoint push fails"
+        );
+        // Own ref still has both events.
+        let tip = run_git_output(
+            dir.path(),
+            &["rev-parse", &agent_ref_name(agent_id).unwrap()],
+        );
+        let log = cat_blob(dir.path(), &format!("{tip}:events.log")).unwrap();
+        assert_eq!(read_events_from_bytes(&log).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn compact_v3_concurrent_cas_loss_is_benign() {
+        // Drive compact_v3's commit_blob_to_ref into the documented benign
+        // "ref moved concurrently" branch: pin the reduce, then move the
+        // checkpoint ref out from under the in-flight commit. Done deterministically
+        // by exercising the same CAS the function relies on — we commit a
+        // checkpoint first, then a SECOND compact whose CAS we invalidate by
+        // advancing the checkpoint ref between its internal read and commit is not
+        // single-thread-reachable, so we instead assert the branch directly: a
+        // commit_blob_to_ref with a stale parent fails with the exact message the
+        // benign handler matches, and a normal compact still succeeds afterwards.
+        let dir = tempfile::tempdir().unwrap();
+        git_init(dir.path());
+        let agent_id = "cv3-cas";
+        seed_v3_hub(dir.path(), agent_id, 2);
+
+        // First compact: succeeds, writes + prunes.
+        let lock = test_hub_lock(dir.path());
+        let r1 = compact_v3(dir.path(), agent_id, &lock, None).unwrap();
+        drop(lock);
+        assert!(r1.checkpoint_commit.is_some());
+        assert_eq!(r1.events_pruned, 2);
+
+        // The benign-branch matcher: a genesis CAS on the now-existing checkpoint
+        // ref yields the exact "ref moved concurrently" substring the handler keys
+        // off — the same error compact_v3's commit_blob_to_ref would surface when a
+        // concurrent compactor advanced the checkpoint first.
+        let stale = commit_single_file_tree(
+            dir.path(),
+            CHECKPOINT_REF,
+            "state.json",
+            b"{}\n",
+            "stale",
+            "crosslink",
+            CasExpectation::MustNotExist,
+        );
+        assert!(stale.is_err());
+        assert!(
+            format!("{:?}", stale.unwrap_err()).contains("ref moved concurrently"),
+            "the benign branch keys off this exact substring"
+        );
+
+        // A subsequent compact with no new events is a clean no-op success.
+        let lock2 = test_hub_lock(dir.path());
+        let r2 = compact_v3(dir.path(), agent_id, &lock2, None).unwrap();
+        drop(lock2);
+        assert_eq!(r2.events_processed, 0);
+        assert_eq!(r2.events_pruned, 0);
+    }
+
+    #[test]
+    fn compact_v3_two_compactors_produce_consistent_checkpoint() {
+        // Two compactors over the same event set: both reduce to the same
+        // deterministic content, so the checkpoint CAS loser hits the benign
+        // "ref moved concurrently" branch (None commit) without erroring and the
+        // winner's checkpoint stands.
+        use std::sync::Arc;
+        let dir = tempfile::tempdir().unwrap();
+        git_init(dir.path());
+        let agent_id = "cv3-race";
+        seed_v3_hub(dir.path(), agent_id, 3);
+        let repo = Arc::new(dir.path().to_path_buf());
+
+        // Run two compactors; serialize via the hub lock as production does, but
+        // interleave so the SECOND sees the FIRST's checkpoint already advanced.
+        let r_a = {
+            let lock = test_hub_lock(&repo);
+            let r = compact_v3(&repo, agent_id, &lock, None).unwrap();
+            drop(lock);
+            r
+        };
+        // Second compactor: no new events, checkpoint already present → no-op.
+        let r_b = {
+            let lock = test_hub_lock(&repo);
+            let r = compact_v3(&repo, agent_id, &lock, None).unwrap();
+            drop(lock);
+            r
+        };
+        assert!(r_a.checkpoint_commit.is_some());
+        assert_eq!(r_a.events_processed, 3);
+        assert_eq!(r_b.events_processed, 0, "second compactor sees pruned ref");
+
+        // Checkpoint state is consistent and complete.
+        let cp_tip = run_git_output(&repo, &["rev-parse", CHECKPOINT_REF]);
+        let state_bytes = cat_blob(&repo, &format!("{cp_tip}:state.json")).unwrap();
+        let state = crate::checkpoint::CheckpointState::from_slice(&state_bytes).unwrap();
+        assert_eq!(state.issues.len(), 3);
     }
 }

--- a/crosslink/src/hub_v3_operation_tests.rs
+++ b/crosslink/src/hub_v3_operation_tests.rs
@@ -1,0 +1,145 @@
+//! Unit tests for `hydrate_from_state` (754a PASS 2 — hub-version-routed
+//! operation). These live in the lib test tree because they only need the
+//! library surface (`Database`, `CheckpointState`, `hydration`). The full
+//! end-to-end V3 lifecycle / two-writer / lock / fetch / heartbeat / request
+//! tests live in the bin test tree (`commands::hub_v3_operation_tests`) because
+//! they drive the `migrate hub-v3` command, which is bin-only.
+
+#![cfg(test)]
+
+use std::path::Path;
+
+use crate::db::Database;
+
+#[test]
+fn hydrate_from_state_empty_is_data_loss_guard() {
+    // An empty state must NOT clear a populated SQLite (data-loss guard).
+    let db = Database::open(Path::new(":memory:")).unwrap();
+    let id = db.create_issue("keep me", None, "medium").unwrap();
+    let empty = crate::checkpoint::CheckpointState::default();
+    let stats = crate::hydration::hydrate_from_state(&empty, &db).unwrap();
+    assert_eq!(stats.issues, 0, "empty state hydrates nothing");
+    assert!(
+        db.get_issue(id).unwrap().is_some(),
+        "empty state must not wipe existing SQLite issues"
+    );
+}
+
+#[test]
+fn hydrate_from_state_preserves_sqlite_only_issue() {
+    // #443 analogue: a direct-SQLite issue (created_by NULL) absent from the
+    // reduced state survives hydration.
+    let db = Database::open(Path::new(":memory:")).unwrap();
+    let kept = db.create_issue("sqlite only", None, "low").unwrap();
+
+    let mut state = crate::checkpoint::CheckpointState::default();
+    let uuid = uuid::Uuid::new_v4();
+    state.display_id_map.insert(uuid, 1);
+    state
+        .issues
+        .insert(uuid, sample_compact_issue(uuid, 1, "from state"));
+
+    crate::hydration::hydrate_from_state(&state, &db).unwrap();
+    assert!(
+        db.get_issue(kept).unwrap().is_some(),
+        "SQLite-only issue must be preserved across hydrate_from_state"
+    );
+    assert!(
+        db.get_issue(1).unwrap().is_some(),
+        "state issue must be hydrated"
+    );
+}
+
+#[test]
+fn hydrate_from_state_maps_issue_children() {
+    // A state issue with a label, comment, blocker, and milestone link
+    // hydrates each child table row.
+    let db = Database::open(Path::new(":memory:")).unwrap();
+
+    let mut state = crate::checkpoint::CheckpointState::default();
+
+    // Milestone (id 7) referenced by the issue.
+    let ms_uuid = uuid::Uuid::new_v4();
+    state.milestones.insert(
+        ms_uuid,
+        crate::checkpoint::CompactMilestone {
+            uuid: ms_uuid,
+            display_id: Some(7),
+            name: "m1".to_string(),
+            description: None,
+            status: crate::models::IssueStatus::Open,
+            created_at: chrono::Utc::now(),
+            closed_at: None,
+        },
+    );
+
+    // Blocker issue (id 2).
+    let blocker_uuid = uuid::Uuid::new_v4();
+    state.display_id_map.insert(blocker_uuid, 2);
+    state.issues.insert(
+        blocker_uuid,
+        sample_compact_issue(blocker_uuid, 2, "blocker"),
+    );
+
+    // Main issue (id 1) with a label, comment, blocker, and milestone link.
+    let uuid = uuid::Uuid::new_v4();
+    state.display_id_map.insert(uuid, 1);
+    let mut issue = sample_compact_issue(uuid, 1, "main");
+    issue.labels.insert("bug".to_string());
+    issue.blockers.insert(blocker_uuid);
+    issue.milestone_uuid = Some(ms_uuid);
+    let comment_uuid = uuid::Uuid::new_v4();
+    issue.comments.insert(
+        comment_uuid,
+        crate::checkpoint::CompactComment {
+            display_id: Some(5),
+            author: "alpha".to_string(),
+            content: "hello".to_string(),
+            created_at: chrono::Utc::now(),
+            kind: "note".to_string(),
+            trigger_type: None,
+            intervention_context: None,
+            driver_key_fingerprint: None,
+            signed_by: None,
+            signature: None,
+        },
+    );
+    state.issues.insert(uuid, issue);
+
+    let stats = crate::hydration::hydrate_from_state(&state, &db).unwrap();
+    assert_eq!(stats.issues, 2);
+    assert_eq!(stats.milestones, 1);
+    assert_eq!(stats.comments, 1);
+    assert_eq!(stats.dependencies, 1);
+
+    assert!(db.get_labels(1).unwrap().iter().any(|l| l == "bug"));
+    assert!(!db.get_comments(1).unwrap().is_empty());
+}
+
+fn sample_compact_issue(
+    uuid: uuid::Uuid,
+    display_id: i64,
+    title: &str,
+) -> crate::checkpoint::CompactIssue {
+    crate::checkpoint::CompactIssue {
+        uuid,
+        display_id: Some(display_id),
+        title: title.to_string(),
+        description: None,
+        status: crate::models::IssueStatus::Open,
+        priority: crate::models::Priority::Medium,
+        parent_uuid: None,
+        created_by: "alpha".to_string(),
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+        closed_at: None,
+        scheduled_at: None,
+        due_at: None,
+        labels: Default::default(),
+        blockers: Default::default(),
+        related: Default::default(),
+        milestone_uuid: None,
+        comments: Default::default(),
+        time_entries: Default::default(),
+    }
+}

--- a/crosslink/src/hydration.rs
+++ b/crosslink/src/hydration.rs
@@ -276,6 +276,347 @@ pub fn hydrate_to_sqlite(cache_dir: &Path, db: &Database) -> Result<HydrationSta
     result
 }
 
+/// Hydrate the local `SQLite` database from a materialized v3
+/// [`CheckpointState`] (754a PASS 2 — hub-version-routed operation).
+///
+/// This is the V3 analogue of [`hydrate_to_sqlite`]: instead of reading
+/// `issues/*.json` worktree files, it maps the reduced `CompactIssue` /
+/// `CompactMilestone` state straight into the same `db.insert_hydrated_*`
+/// row-insertion helpers, so every table is populated identically to the
+/// file-based path. It preserves the same three invariants:
+///
+/// - **Single transaction.** All clears + inserts run inside one
+///   `db.transaction()` with foreign keys toggled off around it, exactly as
+///   the file path does (#461).
+/// - **#443 session preservation / SQLite-only merge.** Issues that exist in
+///   `SQLite` (created via direct `db.create_issue`, `created_by IS NULL`) but
+///   not in the reduced state are snapshotted with their children and
+///   re-inserted, so `init --force` / partial-sync rows are never wiped (#427,
+///   #310). The session `active_issue_id` FK survives via the same FK-off
+///   clear/reinsert dance.
+/// - **Data-loss guard.** When the reduced state carries NO issues, hydration
+///   is skipped (returns default stats) rather than clearing a populated
+///   `SQLite` — the analogue of [`hydrate_to_sqlite`]'s empty-`issue_files`
+///   early return, which guards against wiping local state from an empty or
+///   not-yet-fetched checkpoint.
+///
+/// Display ids come from the reduction (`CompactIssue.display_id`); issues
+/// whose id is not yet frozen (provisional, REQ-4) get a deterministic negative
+/// local id, matching the file path's offline-issue handling.
+///
+/// # Errors
+///
+/// Returns an error if any database operation fails.
+pub fn hydrate_from_state(
+    state: &crate::checkpoint::CheckpointState,
+    db: &Database,
+) -> Result<HydrationStats> {
+    // Data-loss guard: an empty reduced state (no checkpoint yet, or fetch has
+    // not run) must never clear a populated SQLite. Mirrors the empty-issue
+    // early return on the file path.
+    if state.issues.is_empty() && state.milestones.is_empty() {
+        return Ok(HydrationStats::default());
+    }
+
+    // #443 / #427: snapshot SQLite-only issues (UUIDs absent from the reduced
+    // state) so direct-SQLite rows are preserved across the clear/reinsert.
+    let state_uuids: std::collections::HashSet<String> =
+        state.issues.keys().map(uuid::Uuid::to_string).collect();
+    let all_rows: Vec<SavedIssue> = db
+        .conn
+        .prepare(
+            "SELECT id, uuid, title, description, status, priority, parent_id, \
+             created_by, created_at, updated_at, closed_at, scheduled_at, due_at \
+             FROM issues WHERE uuid IS NOT NULL",
+        )?
+        .query_map([], |row| {
+            Ok(SavedIssue {
+                id: row.get(0)?,
+                uuid: row.get(1)?,
+                title: row.get(2)?,
+                description: row.get(3)?,
+                status: row.get(4)?,
+                priority: row.get(5)?,
+                parent_id: row.get(6)?,
+                created_by: row.get(7)?,
+                created_at: row.get(8)?,
+                updated_at: row.get(9)?,
+                closed_at: row.get(10)?,
+                scheduled_at: row.get(11)?,
+                due_at: row.get(12)?,
+            })
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    let sqlite_only_rows: Vec<SavedIssue> = all_rows
+        .into_iter()
+        .filter(|row| !state_uuids.contains(&row.uuid) && row.created_by.is_none())
+        .collect();
+    if !sqlite_only_rows.is_empty() {
+        tracing::info!(
+            "hydrate_from_state: preserving {} SQLite-only issue(s) not in reduced state",
+            sqlite_only_rows.len()
+        );
+    }
+    let preserved_ids: Vec<i64> = sqlite_only_rows.iter().map(|r| r.id).collect();
+    let saved_children = snapshot_children(db, &preserved_ids)?;
+
+    // Build uuid -> display_id lookup for cross-references (blockers/related/
+    // parent/milestone). Issues without a frozen display id get a deterministic
+    // negative local id assigned during insertion below.
+    let mut uuid_to_id: HashMap<String, i64> = state
+        .issues
+        .values()
+        .filter_map(|i| i.display_id.map(|id| (i.uuid.to_string(), id)))
+        .collect();
+    let milestone_uuid_to_id: HashMap<String, i64> = state
+        .milestones
+        .values()
+        .filter_map(|m| m.display_id.map(|id| (m.uuid.to_string(), id)))
+        .collect();
+
+    let mut stats = HydrationStats::default();
+
+    db.set_foreign_keys(false)?;
+    let result = db.transaction(|| {
+        db.clear_shared_data()?;
+
+        // Milestones first (issues reference them).
+        for m in state.milestones.values() {
+            let Some(ms_id) = m.display_id else {
+                continue; // provisional milestone id — skip the FK target row
+            };
+            let created_at = m.created_at.to_rfc3339();
+            let closed_at = m.closed_at.map(|dt| dt.to_rfc3339());
+            db.insert_hydrated_milestone(&HydratedMilestone {
+                id: ms_id,
+                uuid: &m.uuid.to_string(),
+                name: &m.name,
+                description: m.description.as_deref(),
+                status: m.status.as_str(),
+                created_at: &created_at,
+                closed_at: closed_at.as_deref(),
+            })?;
+            stats.milestones += 1;
+        }
+
+        hydrate_state_issues(
+            db,
+            state,
+            &mut uuid_to_id,
+            &milestone_uuid_to_id,
+            &mut stats,
+        )?;
+        hydrate_state_dependencies(db, state, &uuid_to_id, &mut stats);
+        hydrate_state_relations(db, state, &uuid_to_id, &mut stats);
+
+        restore_sqlite_only_issues(db, &sqlite_only_rows, &saved_children, &mut stats)?;
+        Ok(stats)
+    });
+
+    if let Err(e) = db.set_foreign_keys(true) {
+        tracing::warn!("failed to re-enable foreign key constraints: {}", e);
+    }
+    result
+}
+
+/// Topologically order issue uuids from a [`CheckpointState`] so parents precede
+/// children (foreign-key safe), deterministically. Mirrors [`topo_sort_issues`]
+/// but operates on the reduced state's `CompactIssue` map.
+fn topo_sort_state_issues(
+    state: &crate::checkpoint::CheckpointState,
+) -> Vec<&crate::checkpoint::CompactIssue> {
+    let present: std::collections::HashSet<uuid::Uuid> = state.issues.keys().copied().collect();
+    let mut roots: Vec<&crate::checkpoint::CompactIssue> = Vec::new();
+    let mut children: Vec<&crate::checkpoint::CompactIssue> = Vec::new();
+    for issue in state.issues.values() {
+        match issue.parent_uuid {
+            Some(p) if present.contains(&p) => children.push(issue),
+            _ => roots.push(issue),
+        }
+    }
+    roots.sort_by(|a, b| a.created_at.cmp(&b.created_at).then(a.uuid.cmp(&b.uuid)));
+    let mut sorted = roots;
+    let mut remaining = children;
+    for _ in 0..10 {
+        if remaining.is_empty() {
+            break;
+        }
+        let sorted_uuids: std::collections::HashSet<uuid::Uuid> =
+            sorted.iter().map(|i| i.uuid).collect();
+        let (mut ready, still): (Vec<_>, Vec<_>) = remaining
+            .into_iter()
+            .partition(|i| i.parent_uuid.is_none_or(|p| sorted_uuids.contains(&p)));
+        ready.sort_by(|a, b| a.created_at.cmp(&b.created_at).then(a.uuid.cmp(&b.uuid)));
+        sorted.extend(ready);
+        remaining = still;
+    }
+    sorted.extend(remaining);
+    sorted
+}
+
+/// Insert issues + their child rows (labels, comments, time entries, milestone
+/// link) from a reduced [`CheckpointState`]. The V3 analogue of [`hydrate_issues`].
+fn hydrate_state_issues(
+    db: &Database,
+    state: &crate::checkpoint::CheckpointState,
+    uuid_to_id: &mut HashMap<String, i64>,
+    milestone_uuid_to_id: &HashMap<String, i64>,
+    stats: &mut HydrationStats,
+) -> Result<()> {
+    // Negative local ids for issues without a frozen display id, and for v3
+    // comments/time-entries (event-only identity, no counter-claimed i64).
+    let mut next_local_id: i64 = -1;
+    let mut next_v2_comment_id: i64 = -1;
+
+    for issue in topo_sort_state_issues(state) {
+        let display_id = issue.display_id.unwrap_or_else(|| {
+            let local = next_local_id;
+            next_local_id -= 1;
+            uuid_to_id.insert(issue.uuid.to_string(), local);
+            local
+        });
+
+        let parent_id = issue
+            .parent_uuid
+            .and_then(|u| uuid_to_id.get(&u.to_string()).copied());
+        let created_at = issue.created_at.to_rfc3339();
+        let updated_at = issue.updated_at.to_rfc3339();
+        let closed_at = issue.closed_at.map(|dt| dt.to_rfc3339());
+        let scheduled_at = issue.scheduled_at.map(|dt| dt.to_rfc3339());
+        let due_at = issue.due_at.map(|dt| dt.to_rfc3339());
+
+        db.insert_hydrated_issue(&HydratedIssue {
+            id: display_id,
+            uuid: &issue.uuid.to_string(),
+            title: &issue.title,
+            description: issue.description.as_deref(),
+            status: issue.status.as_str(),
+            priority: issue.priority.as_str(),
+            parent_id,
+            created_by: Some(&issue.created_by),
+            created_at: &created_at,
+            updated_at: &updated_at,
+            closed_at: closed_at.as_deref(),
+            scheduled_at: scheduled_at.as_deref(),
+            due_at: due_at.as_deref(),
+        })?;
+        stats.issues += 1;
+
+        for label in &issue.labels {
+            db.insert_hydrated_label(display_id, label)?;
+        }
+
+        // Comments are keyed by uuid; emit in deterministic uuid order (BTreeMap).
+        for (comment_uuid, c) in &issue.comments {
+            let comment_created = c.created_at.to_rfc3339();
+            // Reduction-assigned i64 id if frozen, else a deterministic negative id.
+            let cid = c.display_id.unwrap_or_else(|| {
+                let id = next_v2_comment_id;
+                next_v2_comment_id -= 1;
+                id
+            });
+            db.insert_hydrated_comment(
+                cid,
+                display_id,
+                Some(&comment_uuid.to_string()),
+                Some(&c.author),
+                &c.content,
+                &comment_created,
+                &c.kind,
+                c.trigger_type.as_deref(),
+                c.intervention_context.as_deref(),
+                c.driver_key_fingerprint.as_deref(),
+            )?;
+            stats.comments += 1;
+        }
+
+        for (entry_uuid, te) in &issue.time_entries {
+            let started = te.started_at.to_rfc3339();
+            let ended = te.ended_at.map(|dt| dt.to_rfc3339());
+            // Time entries have no natural i64 identity in v3; derive a stable
+            // negative id from the entry uuid's low bytes so re-hydration is
+            // idempotent (INSERT ... id PRIMARY KEY).
+            let te_id = te
+                .display_id
+                .unwrap_or_else(|| negative_id_from_uuid(entry_uuid));
+            db.insert_hydrated_time_entry(
+                te_id,
+                display_id,
+                &started,
+                ended.as_deref(),
+                te.duration_seconds,
+            )?;
+        }
+
+        if let Some(ms_uuid) = &issue.milestone_uuid {
+            if let Some(&ms_id) = milestone_uuid_to_id.get(&ms_uuid.to_string()) {
+                db.insert_hydrated_milestone_issue(ms_id, display_id)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Derive a stable negative i64 id from a uuid's first 7 bytes, used for v3
+/// time entries that carry no counter-claimed id. Always negative so it never
+/// collides with positive reduction-assigned ids.
+fn negative_id_from_uuid(u: &uuid::Uuid) -> i64 {
+    let b = u.as_bytes();
+    let mut acc: i64 = 0;
+    for &byte in &b[..7] {
+        acc = (acc << 8) | i64::from(byte);
+    }
+    -(acc + 1)
+}
+
+/// Insert dependency rows from each issue's `blockers` set. V3 analogue of
+/// [`hydrate_dependencies`]. Dangling references (deleted blocker) are skipped.
+fn hydrate_state_dependencies(
+    db: &Database,
+    state: &crate::checkpoint::CheckpointState,
+    uuid_to_id: &HashMap<String, i64>,
+    stats: &mut HydrationStats,
+) {
+    for issue in state.issues.values() {
+        let Some(&blocked_id) = uuid_to_id.get(&issue.uuid.to_string()) else {
+            continue;
+        };
+        for blocker_uuid in &issue.blockers {
+            if let Some(&blocker_id) = uuid_to_id.get(&blocker_uuid.to_string()) {
+                if let Err(e) = db.insert_dependency_raw(blocker_id, blocked_id) {
+                    tracing::warn!("hydrate_from_state: dependency insert failed: {e}");
+                    continue;
+                }
+                stats.dependencies += 1;
+            }
+        }
+    }
+}
+
+/// Insert relation rows from each issue's `related` set. V3 analogue of
+/// [`hydrate_relations`].
+fn hydrate_state_relations(
+    db: &Database,
+    state: &crate::checkpoint::CheckpointState,
+    uuid_to_id: &HashMap<String, i64>,
+    stats: &mut HydrationStats,
+) {
+    for issue in state.issues.values() {
+        let Some(&issue_id) = uuid_to_id.get(&issue.uuid.to_string()) else {
+            continue;
+        };
+        for related_uuid in &issue.related {
+            if let Some(&related_id) = uuid_to_id.get(&related_uuid.to_string()) {
+                if let Err(e) = db.insert_relation_raw(issue_id, related_id) {
+                    tracing::warn!("hydrate_from_state: relation insert failed: {e}");
+                    continue;
+                }
+                stats.relations += 1;
+            }
+        }
+    }
+}
+
 /// Deduplicate issue files and load milestone entries from cache.
 fn dedup_and_load_milestones<'a>(
     issue_files: &'a [IssueFile],

--- a/crosslink/src/lib.rs
+++ b/crosslink/src/lib.rs
@@ -14,6 +14,8 @@ pub mod external;
 pub mod findings;
 pub mod hub_source;
 pub mod hub_v3;
+#[cfg(test)]
+mod hub_v3_operation_tests;
 pub mod hydration;
 pub mod identity;
 pub mod issue_file;

--- a/crosslink/src/server/watcher.rs
+++ b/crosslink/src/server/watcher.rs
@@ -44,6 +44,59 @@ pub fn status_from_heartbeat(heartbeat: &Heartbeat) -> AgentStatus {
     }
 }
 
+/// Resolve the filesystem path (and recursion mode) to watch for heartbeat
+/// changes, dispatched by hub mode.
+///
+/// - **V2**: `<.crosslink>/.hub-cache/heartbeats/`, non-recursive — heartbeats
+///   are flat worktree files, watched exactly as before.
+/// - **V3**: the main repo's `.git/refs/crosslink/` directory, recursive —
+///   heartbeats live on per-agent refs, so loose-ref updates under that tree
+///   are the change signal. The git common dir is resolved against the hub
+///   cache (which shares the main repo's ref namespace); if that resolution
+///   fails the function falls back to the v2 path, which simply won't exist on
+///   a v3 hub and degrades to polling-only.
+fn resolve_watch_target(
+    sync: &SyncManager,
+    crosslink_dir: &std::path::Path,
+) -> (PathBuf, RecursiveMode) {
+    let v2_path = crosslink_dir.join(".hub-cache").join("heartbeats");
+    if !sync.hub_mode().is_v3() {
+        return (v2_path, RecursiveMode::NonRecursive);
+    }
+    git_common_dir(sync.cache_path()).map_or((v2_path, RecursiveMode::NonRecursive), |git_dir| {
+        (
+            git_dir.join("refs").join("crosslink"),
+            RecursiveMode::Recursive,
+        )
+    })
+}
+
+/// Resolve the git common dir (`--git-common-dir`) for `repo_dir`, the directory
+/// that holds the shared ref store even when `repo_dir` is a linked worktree.
+/// Returns an absolute path; `None` if git plumbing fails.
+fn git_common_dir(repo_dir: &std::path::Path) -> Option<PathBuf> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(repo_dir)
+        .args(["rev-parse", "--git-common-dir"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if raw.is_empty() {
+        return None;
+    }
+    let path = PathBuf::from(&raw);
+    if path.is_absolute() {
+        Some(path)
+    } else {
+        // `--git-common-dir` is relative to repo_dir when not absolute.
+        Some(repo_dir.join(path))
+    }
+}
+
 /// Spawn a background task that watches the hub cache for heartbeat changes
 /// and broadcasts events to all WebSocket clients.
 ///
@@ -60,9 +113,21 @@ pub fn start_watcher(crosslink_dir: PathBuf, tx: broadcast::Sender<WsEvent>) {
 async fn run_watcher(crosslink_dir: PathBuf, tx: broadcast::Sender<WsEvent>) -> Result<()> {
     let sync = SyncManager::new(&crosslink_dir)?;
 
-    // Hub cache is always at <main-repo-root>/.crosslink/.hub-cache/.
-    // We watch the heartbeats/ subdirectory for file-level changes.
-    let watch_path = crosslink_dir.join(".hub-cache").join("heartbeats");
+    // Mode-aware watch target.
+    //
+    // V2: heartbeats are worktree files under
+    // `<main-repo>/.crosslink/.hub-cache/heartbeats/`; watch that directory for
+    // file-level mtime changes — the original, unchanged behavior.
+    //
+    // V3: there is no heartbeats directory. Each agent's heartbeat lives on its
+    // own ref (`refs/crosslink/agents/<id>` -> `heartbeat.json`); the change
+    // signal is REF MOVEMENT. Loose-ref updates land as files under the main
+    // repo's `.git/refs/crosslink/`, so we watch that directory recursively. The
+    // tradeoff: refs packed into `.git/packed-refs` (after gc / fetch) do not
+    // fire a per-file event, but the 30s polling fallback re-reads
+    // `read_heartbeats_auto` (which scans the refs) and closes that gap — the
+    // same staleness ceiling the v2 poll already provides.
+    let (watch_path, watch_recursive) = resolve_watch_target(&sync, &crosslink_dir);
 
     // Bridge notify (sync) → tokio (async) with an mpsc channel.
     // We only need a "something changed" signal; the actual event details are
@@ -82,7 +147,7 @@ async fn run_watcher(crosslink_dir: PathBuf, tx: broadcast::Sender<WsEvent>) -> 
     // Attempt to start watching.  If the directory doesn't exist yet (hub not
     // initialised), fall back to polling only.
     let watch_active = if watch_path.exists() {
-        match watcher.watch(&watch_path, RecursiveMode::NonRecursive) {
+        match watcher.watch(&watch_path, watch_recursive) {
             Ok(()) => true,
             Err(e) => {
                 tracing::warn!(
@@ -94,7 +159,7 @@ async fn run_watcher(crosslink_dir: PathBuf, tx: broadcast::Sender<WsEvent>) -> 
         }
     } else {
         tracing::info!(
-            "watcher: heartbeats directory not found at {}, polling only",
+            "watcher: heartbeat watch path not found at {}, polling only",
             watch_path.display()
         );
         false
@@ -299,6 +364,64 @@ mod tests {
         std::fs::create_dir_all(&hb_dir).unwrap();
         let json = serde_json::to_string_pretty(hb).unwrap();
         std::fs::write(hb_dir.join(format!("{}.json", hb.agent_id)), json).unwrap();
+    }
+
+    /// V2 hub: the watch target is the worktree `heartbeats/` dir, non-recursive
+    /// — unchanged behavior.
+    #[test]
+    fn test_resolve_watch_target_v2_heartbeats_dir() {
+        let (_work, _remote, sync) = setup_watcher_env();
+        let crosslink_dir = sync.cache_path().parent().unwrap().to_path_buf();
+        let (path, mode) = resolve_watch_target(&sync, &crosslink_dir);
+        assert_eq!(path, crosslink_dir.join(".hub-cache").join("heartbeats"));
+        assert!(matches!(mode, RecursiveMode::NonRecursive));
+    }
+
+    /// V3 hub: the watch target is the main repo's `.git/refs/crosslink/`
+    /// directory, recursive — ref movement is the change signal.
+    #[test]
+    fn test_resolve_watch_target_v3_refs_dir() {
+        let (_work, _remote, sync) = setup_watcher_env();
+        let cache_dir = sync.cache_path().to_path_buf();
+        let crosslink_dir = cache_dir.parent().unwrap().to_path_buf();
+
+        // Stamp the v3 marker refs (META + CHECKPOINT) so HubMode resolves V3.
+        let meta = crate::hub_v3::HubMeta {
+            hub_version: 3,
+            migrated_from_commit: "0".repeat(40),
+            migrated_at: Utc::now(),
+            finalized_at: None,
+        };
+        let hub_json = serde_json::to_vec_pretty(&meta).unwrap();
+        crate::hub_v3::commit_files_to_ref(
+            &cache_dir,
+            crate::hub_v3::META_REF,
+            &[("hub.json", &hub_json)],
+            "v3 meta",
+        )
+        .unwrap();
+        let state = crate::checkpoint::CheckpointState::default();
+        let state_json = serde_json::to_vec_pretty(&state).unwrap();
+        crate::hub_v3::commit_blob_to_ref(
+            &cache_dir,
+            crate::hub_v3::CHECKPOINT_REF,
+            "state.json",
+            &state_json,
+            "v3 checkpoint",
+        )
+        .unwrap();
+
+        // Re-resolve the SyncManager so it picks up V3 mode.
+        let sync_v3 = SyncManager::new(&crosslink_dir).unwrap();
+        assert!(sync_v3.hub_mode().is_v3(), "hub must resolve to V3");
+
+        let (path, mode) = resolve_watch_target(&sync_v3, &crosslink_dir);
+        assert!(
+            path.ends_with(std::path::Path::new("refs").join("crosslink")),
+            "v3 watch target must be .git/refs/crosslink, got {}",
+            path.display()
+        );
+        assert!(matches!(mode, RecursiveMode::Recursive));
     }
 
     #[test]

--- a/crosslink/src/shared_writer/core.rs
+++ b/crosslink/src/shared_writer/core.rs
@@ -75,7 +75,16 @@ pub struct SharedWriter {
     ///
     /// Read once from `.crosslink/hook-config.json` in the constructor so
     /// the per-event path does no file I/O for the flag check.
+    ///
+    /// IGNORED in [`crate::hub_v3::HubMode::V3`]: dual-write was the v2→v3
+    /// bridge (mirror v2 log appends onto the ref before cutover). In v3 the
+    /// agent ref IS the only log, so there is nothing to mirror from.
     pub(super) hub_v3_dual_write: bool,
+    /// The most recent reduced state from a v3 `commit_v3` / fetch (754a PASS
+    /// 2). The create/comment/milestone flows read the reduction-assigned
+    /// display id from here (`state.display_id_map[uuid]`, REQ-4) for CLI
+    /// output; `None` in V2 mode and before the first v3 mutation.
+    pub(super) last_v3_state: std::cell::RefCell<Option<crate::checkpoint::CheckpointState>>,
 }
 
 impl SharedWriter {
@@ -127,8 +136,16 @@ impl SharedWriter {
         std::fs::create_dir_all(cache_dir.join("issues"))?;
         std::fs::create_dir_all(cache_dir.join("meta").join("milestones"))?;
 
-        // Initialize event sequence counter from existing log
-        let event_seq = Cell::new(Self::read_max_event_seq(&cache_dir, &agent.agent_id));
+        // Initialize event sequence counter from existing log. In V3 the
+        // authoritative log is the agent's OWN REF (read via git cat-file);
+        // in V2 it is the worktree `events.log` file. read_max_event_seq
+        // dispatches by mode so a fresh worktree (post-prune) does not reset
+        // the sequence below the ref's tip.
+        let event_seq = Cell::new(Self::read_max_event_seq(
+            &cache_dir,
+            &agent.agent_id,
+            sync.hub_mode(),
+        ));
 
         // Read the dual-write flag once at construction time; per-event path does
         // no file I/O for the flag check.
@@ -145,11 +162,36 @@ impl SharedWriter {
             cache_dir,
             event_seq,
             hub_v3_dual_write,
+            last_v3_state: std::cell::RefCell::new(None),
         }))
     }
 
     pub fn agent_id(&self) -> &str {
         &self.agent.agent_id
+    }
+
+    /// The resolved operation mode (V2 worktree-file or V3 event-only),
+    /// decided once on the underlying `SyncManager` at construction.
+    pub(super) const fn hub_mode(&self) -> crate::hub_v3::HubMode {
+        self.sync.hub_mode()
+    }
+
+    /// Whether this writer operates a v3 hub (event-only, per-agent refs).
+    pub(super) const fn is_v3(&self) -> bool {
+        self.hub_mode().is_v3()
+    }
+
+    /// Public accessor for v3 mode, for cross-module callers (`agent_requests`).
+    #[must_use]
+    pub const fn is_v3_public(&self) -> bool {
+        self.is_v3()
+    }
+
+    /// Public accessor for the hub-cache directory (the v3 ref repo dir), for
+    /// cross-module callers (`agent_requests` v3 poll).
+    #[must_use]
+    pub fn cache_dir_public(&self) -> &Path {
+        &self.cache_dir
     }
 
     /// Derive the `.crosslink/` directory from the cache path.
@@ -166,6 +208,26 @@ impl SharedWriter {
     /// If the retry also fails, warns the user to run `crosslink sync`
     /// so the caller can continue gracefully.
     pub fn hydrate_with_retry(&self, db: &Database) {
+        // V3: hydrate from the reduced state cached by the last commit_v3 /
+        // refresh_v3_state (event-only operation — no worktree issue files to
+        // read). If no state is cached yet (first call before any v3 mutation),
+        // reduce now so SQLite still reflects the hub.
+        if self.is_v3() {
+            if self.last_v3_state.borrow().is_none() {
+                if let Err(e) = self.refresh_v3_state() {
+                    tracing::warn!("v3 hydrate: state refresh failed: {e}");
+                    return;
+                }
+            }
+            if let Some(state) = self.last_v3_state.borrow().as_ref() {
+                if let Err(e) = crate::hydration::hydrate_from_state(state, db) {
+                    tracing::warn!(
+                        "v3 hydrate_from_state failed ({e}). Run `crosslink sync` to recover."
+                    );
+                }
+            }
+            return;
+        }
         match crate::hydration::hydrate_to_sqlite(&self.cache_dir, db) {
             Ok(_) => {}
             Err(first_err) => {
@@ -225,8 +287,20 @@ impl SharedWriter {
 
     // ---- Event emission infrastructure ----
 
-    /// Read the max `agent_seq` from an existing event log.
-    pub(super) fn read_max_event_seq(cache_dir: &Path, agent_id: &str) -> u64 {
+    /// Read the max `agent_seq` from this agent's existing event log.
+    ///
+    /// V2: reads the worktree file `agents/<id>/events.log`. V3: reads the
+    /// agent's OWN REF (`refs/crosslink/agents/<id>` -> `events.log`) via git
+    /// cat-file, since there is no worktree log in v3 and the ref is the only
+    /// durable record of the sequence high-water mark (including after a prune).
+    pub(super) fn read_max_event_seq(
+        cache_dir: &Path,
+        agent_id: &str,
+        mode: crate::hub_v3::HubMode,
+    ) -> u64 {
+        if mode.is_v3() {
+            return crate::hub_v3::read_max_event_seq_from_ref(cache_dir, agent_id).unwrap_or(0);
+        }
         let log_path = cache_dir.join("agents").join(agent_id).join("events.log");
         crate::events::read_events(&log_path).map_or(0, |events| {
             events.iter().map(|e| e.agent_seq).max().unwrap_or(0)
@@ -374,6 +448,16 @@ impl SharedWriter {
     ) -> Result<PushOutcome> {
         // Serialize access to the hub cache via SyncManager's lock (#372)
         let lock_guard = self.sync.acquire_lock()?;
+
+        // V3: lock claim/release (and any emit_compact_push caller) routes
+        // through the event-only own-ref path. compact_v3 reduces locks from
+        // events into the checkpoint; the claim-confirm read (read_lock_v2)
+        // then resolves the winner from the reduced state. Mirrors the v2
+        // emit_compact_push contract (append -> compact -> push), returning the
+        // same PushOutcome.
+        if self.is_v3() {
+            return self.commit_v3(vec![event], &lock_guard);
+        }
 
         // Append to the v2 log + run the single hub_v3 shadow-mirror site.
         self.append_envelopes(vec![event])?;
@@ -549,6 +633,19 @@ impl SharedWriter {
         // Serialize access to the hub cache (#372).
         let _lock_guard = self.sync.acquire_lock()?;
 
+        // V3: the DRIVER writes the request into ITS OWN ref under
+        // `requests-out/<target>--<ulid>.json` (single-writer invariant) and
+        // pushes the ref. No worktree file, no rebase-retry.
+        if self.is_v3() {
+            crate::hub_v3::write_request_to_own_ref(
+                &self.cache_dir,
+                &self.agent.agent_id,
+                target_agent_id,
+                request,
+            )?;
+            return Ok(self.push_own_ref_outcome());
+        }
+
         let rel_path = crate::agent_requests::request_path(target_agent_id, &request.request_id);
         let abs_path = self.cache_dir.join(&rel_path);
         if let Some(parent) = abs_path.parent() {
@@ -638,6 +735,20 @@ impl SharedWriter {
         ack: &crate::agent_requests::AgentRequestAck,
     ) -> Result<PushOutcome> {
         let _lock_guard = self.sync.acquire_lock()?;
+
+        // V3: the TARGET agent writes the ack into ITS OWN ref under
+        // `requests-ack/<ulid>.json` (single-writer invariant). `target_agent_id`
+        // here IS the acking agent (the poll passes its own id), matching the v2
+        // call convention. Push the own ref.
+        if self.is_v3() {
+            crate::hub_v3::write_ack_to_own_ref(
+                &self.cache_dir,
+                &self.agent.agent_id,
+                &ack.request_id,
+                ack,
+            )?;
+            return Ok(self.push_own_ref_outcome());
+        }
 
         let rel_path = crate::agent_requests::requests_dir(target_agent_id)
             .join(format!("{}.ack.json", ack.request_id));
@@ -820,6 +931,15 @@ impl SharedWriter {
     /// without observing that other agents had meanwhile pushed issues
     /// with higher IDs. See `reconcile_display_counter`.
     pub(super) fn claim_display_id(&self, count: i64) -> Result<(i64, Counters)> {
+        // V3 CLAIMS NOTHING (REQ-4): display ids are assigned solely by the
+        // deterministic reduction. There is no `meta/counters.json` to read or
+        // reconcile, so skip all counter I/O and return a sentinel id (0). The
+        // v3 write path discards both the sentinel and the returned `Counters`
+        // (no file is written) and normalizes the emitted event's `display_id`
+        // to `None` so the reducer allocates the authoritative id.
+        if self.is_v3() {
+            return Ok((0, Counters::default()));
+        }
         let mut counters = self.read_counters()?;
         self.reconcile_display_counter(&mut counters)?;
         let first = counters.next_display_id;
@@ -836,6 +956,12 @@ impl SharedWriter {
     /// before assignment so that stale `counters.json` does not produce
     /// colliding IDs.
     pub(super) fn claim_milestone_id(&self) -> Result<(i64, Counters)> {
+        // V3 CLAIMS NOTHING (REQ-4): milestone ids come from reduction. Skip the
+        // counter read/reconcile and return a sentinel; the v3 path discards it
+        // and normalizes the event's `display_id` to `None`.
+        if self.is_v3() {
+            return Ok((0, Counters::default()));
+        }
         let mut counters = self.read_counters()?;
         self.reconcile_milestone_counter(&mut counters)?;
         let id = counters.next_milestone_id;
@@ -906,6 +1032,31 @@ impl SharedWriter {
 
     /// Load a milestone entry by `display_id` from per-file storage.
     pub(super) fn load_milestone_by_id(&self, display_id: i64) -> Result<MilestoneEntry> {
+        // V3: reconstruct from the reduced state's CompactMilestone (no
+        // worktree milestone files exist).
+        if self.is_v3() {
+            if self.last_v3_state.borrow().is_none() {
+                self.refresh_v3_state()?;
+            }
+            let state = self.last_v3_state.borrow();
+            let state = state.as_ref().ok_or_else(|| {
+                anyhow::anyhow!("v3 state unavailable while loading milestone {display_id}")
+            })?;
+            let cm = state
+                .milestones
+                .values()
+                .find(|m| m.display_id == Some(display_id))
+                .ok_or_else(|| anyhow::anyhow!("Milestone #{display_id} not found in v3 state"))?;
+            return Ok(MilestoneEntry {
+                uuid: cm.uuid,
+                display_id,
+                name: cm.name.clone(),
+                description: cm.description.clone(),
+                status: cm.status,
+                created_at: cm.created_at,
+                closed_at: cm.closed_at,
+            });
+        }
         let milestones_dir = self.cache_dir.join("meta").join("milestones");
         if milestones_dir.exists() {
             for entry in std::fs::read_dir(&milestones_dir)? {
@@ -975,12 +1126,64 @@ impl SharedWriter {
     /// Scans the issues directory for a file matching the display ID.
     /// Supports both v1 (`issues/{uuid}.json`) and v2 (`issues/{uuid}/issue.json`) layouts.
     pub(super) fn load_issue_by_display_id(&self, display_id: i64) -> Result<IssueFile> {
+        // V3: there are no worktree issue files — reconstruct the IssueFile from
+        // the reduced state's CompactIssue. The prepare closures use the loaded
+        // IssueFile only to read the issue's uuid and current mutable fields
+        // (which the event then patches), so a state-derived IssueFile is
+        // equivalent to the v2 file-derived one for that purpose.
+        if self.is_v3() {
+            return self.load_issue_by_display_id_v3(display_id);
+        }
         let mut matches = self.scan_issues(|issue| issue.display_id == Some(display_id))?;
         matches.pop().ok_or_else(|| {
             anyhow::anyhow!(
                 "Issue {} not found in shared cache",
                 crate::utils::format_issue_id(display_id)
             )
+        })
+    }
+
+    /// Reconstruct an [`IssueFile`] for `display_id` from the reduced v3 state.
+    /// Refreshes the cached state when none is present (e.g. a mutation that
+    /// reads before any prior v3 write in this session).
+    fn load_issue_by_display_id_v3(&self, display_id: i64) -> Result<IssueFile> {
+        if self.last_v3_state.borrow().is_none() {
+            self.refresh_v3_state()?;
+        }
+        let state = self.last_v3_state.borrow();
+        let state = state.as_ref().ok_or_else(|| {
+            anyhow::anyhow!("v3 state unavailable while loading issue {display_id}")
+        })?;
+        let ci = state
+            .issues
+            .values()
+            .find(|i| i.display_id == Some(display_id))
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Issue {} not found in v3 state",
+                    crate::utils::format_issue_id(display_id)
+                )
+            })?;
+        Ok(IssueFile {
+            uuid: ci.uuid,
+            display_id: ci.display_id,
+            title: ci.title.clone(),
+            description: ci.description.clone(),
+            status: ci.status,
+            priority: ci.priority,
+            parent_uuid: ci.parent_uuid,
+            created_by: ci.created_by.clone(),
+            created_at: ci.created_at,
+            updated_at: ci.updated_at,
+            closed_at: ci.closed_at,
+            scheduled_at: ci.scheduled_at,
+            due_at: ci.due_at,
+            labels: ci.labels.iter().cloned().collect(),
+            comments: vec![],
+            blockers: ci.blockers.iter().copied().collect(),
+            related: ci.related.iter().copied().collect(),
+            milestone_uuid: ci.milestone_uuid,
+            time_entries: vec![],
         })
     }
 
@@ -1081,18 +1284,383 @@ impl SharedWriter {
         Ok(())
     }
 
+    // ──────────────────────────── V3 write path ─────────────────────────
+    //
+    // 754a PASS 2. In `HubMode::V3` a mutation writes EVENTS ONLY to the
+    // agent's own ref. No worktree files, no counter reads, no rebase/conflict
+    // machinery: pushes to the own ref are fast-forward by construction
+    // (single-writer-per-ref), and ids are reduction-assigned so there is no
+    // offline-promotion or counter-revert dance. The entire v2 offline/promote
+    // path is UNNECESSARY in v3 because (a) ids come from reduction (no
+    // double-mint to revert) and (b) every push is an own-ref fast-forward (no
+    // rebase). A failed push leaves the events durable on the LOCAL ref; the
+    // next successful push delivers them.
+
+    /// Normalize a mutation's events for the v3 write path: drop any
+    /// counter-claimed `display_id` so the reducer assigns the authoritative id
+    /// (REQ-4). The v2 prepare closures bake `display_id: Some(<sentinel 0>)`
+    /// into `IssueCreated` / `CommentAdded` / `TimeEntryAdded` / `MilestoneCreated`
+    /// (because `claim_display_id` returned the sentinel); rewriting them to
+    /// `None` makes the event a pure-v3 emitter.
+    fn normalize_events_for_v3(events: Vec<crate::events::Event>) -> Vec<crate::events::Event> {
+        use crate::events::Event;
+        events
+            .into_iter()
+            .map(|e| match e {
+                Event::IssueCreated {
+                    uuid,
+                    title,
+                    description,
+                    priority,
+                    labels,
+                    parent_uuid,
+                    created_by,
+                    display_id: _,
+                    scheduled_at,
+                    due_at,
+                } => Event::IssueCreated {
+                    uuid,
+                    title,
+                    description,
+                    priority,
+                    labels,
+                    parent_uuid,
+                    created_by,
+                    display_id: None,
+                    scheduled_at,
+                    due_at,
+                },
+                Event::CommentAdded {
+                    issue_uuid,
+                    comment_uuid,
+                    display_id: _,
+                    author,
+                    content,
+                    created_at,
+                    kind,
+                    trigger_type,
+                    intervention_context,
+                    driver_key_fingerprint,
+                    signed_by,
+                    signature,
+                } => Event::CommentAdded {
+                    issue_uuid,
+                    comment_uuid,
+                    display_id: None,
+                    author,
+                    content,
+                    created_at,
+                    kind,
+                    trigger_type,
+                    intervention_context,
+                    driver_key_fingerprint,
+                    signed_by,
+                    signature,
+                },
+                Event::TimeEntryAdded {
+                    issue_uuid,
+                    entry_uuid,
+                    display_id: _,
+                    started_at,
+                    ended_at,
+                    duration_seconds,
+                } => Event::TimeEntryAdded {
+                    issue_uuid,
+                    entry_uuid,
+                    display_id: None,
+                    started_at,
+                    ended_at,
+                    duration_seconds,
+                },
+                Event::MilestoneCreated {
+                    uuid,
+                    display_id: _,
+                    name,
+                    description,
+                    created_at,
+                } => Event::MilestoneCreated {
+                    uuid,
+                    display_id: None,
+                    name,
+                    description,
+                    created_at,
+                },
+                other => other,
+            })
+            .collect()
+    }
+
+    /// Append `events` to this agent's OWN REF, push it (fast-forward), then
+    /// reduce + hydrate so `SQLite` reflects the mutation immediately.
+    ///
+    /// Caller MUST already hold the hub write lock (`sync.acquire_lock()`,
+    /// REQ-8 single local lock). Returns the [`PushOutcome`]: `Pushed` when the
+    /// own ref reached the remote (or no remote is configured), `LocalOnly`
+    /// when the push failed benignly (offline / transient) — the events are
+    /// durable on the local ref and the next successful push delivers them.
+    ///
+    /// On success the reduced [`crate::checkpoint::CheckpointState`] is cached
+    /// in `self.last_v3_state` so create/comment/milestone flows can read the
+    /// reduction-assigned display id (REQ-4).
+    fn commit_v3(
+        &self,
+        events: Vec<crate::events::Event>,
+        _lock: &crate::sync::HubWriteLock,
+    ) -> Result<PushOutcome> {
+        let agent_id = self.agent.agent_id.clone();
+        let normalized = Self::normalize_events_for_v3(events);
+
+        // 1. Envelope + append each event to the OWN REF (sibling-preserving).
+        //    Sequence numbers come from `self.event_seq`, initialized in `new`
+        //    from the ref's log (read_max_event_seq in V3 mode). No worktree
+        //    `events.log` is written — the ref is the only log.
+        for event in normalized {
+            let envelope = self.create_envelope(event);
+            crate::hub_v3::append_event_to_ref(&self.cache_dir, &agent_id, &envelope)
+                .context("v3: failed to append event to agent ref")?;
+        }
+
+        // 2. Push the own ref (plain fast-forward CAS). A non-Pushed outcome is
+        //    benign: the events stay durable on the local ref. NonFastForward on
+        //    our OWN ref would indicate identity collision / tampering (REQ-1)
+        //    — surfaced loudly but still treated as LocalOnly (state is durable).
+        let remote = self.sync.remote();
+        let mut outcome = PushOutcome::Pushed;
+        if self.sync.remote_exists() {
+            match crate::hub_v3::push_agent_ref(&self.cache_dir, remote, &agent_id)? {
+                crate::hub_v3::PushOutcome::Pushed => {}
+                crate::hub_v3::PushOutcome::NonFastForward => {
+                    tracing::error!(
+                        "v3 own-ref push for agent '{agent_id}' was rejected as non-fast-forward \
+                         — identity collision or ref tampering (REQ-1); events remain durable \
+                         on the local ref"
+                    );
+                    outcome = PushOutcome::LocalOnly;
+                }
+                crate::hub_v3::PushOutcome::NoRemote => {
+                    outcome = PushOutcome::LocalOnly;
+                }
+                crate::hub_v3::PushOutcome::Failed(detail) => {
+                    tracing::warn!(
+                        "v3 own-ref push for agent '{agent_id}' did not complete ({detail}); \
+                         events saved locally only"
+                    );
+                    outcome = PushOutcome::LocalOnly;
+                }
+            }
+        } else {
+            outcome = PushOutcome::LocalOnly;
+        }
+
+        // 3. Fetch + adopt OTHER agents' refs BEFORE reducing, so the reduced
+        //    state (and the checkpoint we write) reflects the full event set —
+        //    not just our local view. This is what makes the lock claim-confirm
+        //    correct: an earlier-ordered claim from another agent that arrives
+        //    here is seen now, rather than being masked by a checkpoint we
+        //    advanced from a partial view. The hub write lock is already held
+        //    (we are inside write_commit_push / emit_compact_push), so we use the
+        //    lock-free fetch_and_adopt_v3_refs rather than sync.fetch() (which
+        //    would re-acquire the non-reentrant lock and deadlock).
+        if self.sync.remote_exists() {
+            self.sync.fetch_and_adopt_v3_refs();
+        }
+
+        // 4. Reduce -> cache state for display-id lookup + hydration. Write +
+        //    push the checkpoint (pure cache, REQ-7). The write path does NOT
+        //    prune the own ref: pruning every mutation would rewrite the own ref
+        //    each time (and a prune followed by a plain push is non-fast-forward).
+        //    REQ-11 prune is confined to the explicit `compact` command.
+        self.refresh_v3_state()?;
+        self.write_and_push_v3_checkpoint();
+
+        Ok(outcome)
+    }
+
+    /// Reduce-free checkpoint refresh for the write path: serialize the cached
+    /// `last_v3_state`, write it to the local checkpoint ref (idempotent), and
+    /// push it (best-effort). NO prune. A failure is logged, never fatal — the
+    /// checkpoint is a pure cache (REQ-7) and readers reduce on demand.
+    fn write_and_push_v3_checkpoint(&self) {
+        let bytes = {
+            let state = self.last_v3_state.borrow();
+            let Some(state) = state.as_ref() else {
+                return;
+            };
+            let mut state = state.clone();
+            state.compaction_lease = None;
+            match serde_json::to_vec_pretty(&state) {
+                Ok(b) => b,
+                Err(e) => {
+                    tracing::warn!("v3: checkpoint serialization failed (non-fatal): {e}");
+                    return;
+                }
+            }
+        };
+        // Idempotent: skip when the local checkpoint already matches.
+        if let Ok(Some(tip)) =
+            crate::hub_v3::git_rev_parse_optional(&self.cache_dir, crate::hub_v3::CHECKPOINT_REF)
+        {
+            let spec = format!("{tip}:state.json");
+            if let Ok(Some(existing)) =
+                crate::hub_v3::git_cat_file_blob_optional(&self.cache_dir, &spec)
+            {
+                if existing == bytes {
+                    return;
+                }
+            }
+        }
+        if let Err(e) = crate::hub_v3::commit_blob_to_ref(
+            &self.cache_dir,
+            crate::hub_v3::CHECKPOINT_REF,
+            "state.json",
+            &bytes,
+            "crosslink v3 checkpoint",
+        ) {
+            tracing::warn!("v3: checkpoint write failed (non-fatal): {e}");
+            return;
+        }
+        if self.sync.remote_exists() {
+            let expected = crate::hub_v3::git_rev_parse_optional(
+                &self.cache_dir,
+                "refs/crosslink-remote/checkpoint",
+            )
+            .ok()
+            .flatten();
+            match crate::hub_v3::push_ref_with_lease(
+                &self.cache_dir,
+                self.sync.remote(),
+                crate::hub_v3::CHECKPOINT_REF,
+                expected.as_deref(),
+            ) {
+                Ok(
+                    crate::hub_v3::PushOutcome::Pushed | crate::hub_v3::PushOutcome::NonFastForward,
+                ) => {}
+                Ok(other) => tracing::debug!("v3: checkpoint push did not complete: {other:?}"),
+                Err(e) => tracing::debug!("v3: checkpoint push error (benign): {e}"),
+            }
+        }
+    }
+
+    /// Reduce the current v3 ref namespace and cache the materialized state in
+    /// `self.last_v3_state` (for display-id lookup). Does NOT touch `SQLite` —
+    /// the caller drives hydration onto its own `&Database` via
+    /// [`Self::hydrate_with_retry`], which dispatches to `hydrate_from_state`
+    /// under V3 using this cached state.
+    fn refresh_v3_state(&self) -> Result<()> {
+        let source = crate::hub_source::RefHubSource::new(&self.cache_dir)
+            .context("v3: failed to construct RefHubSource for state refresh")?;
+        let outcome =
+            crate::compaction::reduce(&source).context("v3: reduction for state refresh failed")?;
+        *self.last_v3_state.borrow_mut() = Some(outcome.state);
+        Ok(())
+    }
+
+    /// Push this agent's OWN ref and map the result to a [`PushOutcome`].
+    /// Shared by the v3 request/ack writers. A non-`Pushed` result is benign:
+    /// the data is durable on the local ref and delivers on the next push.
+    fn push_own_ref_outcome(&self) -> PushOutcome {
+        if !self.sync.remote_exists() {
+            return PushOutcome::LocalOnly;
+        }
+        match crate::hub_v3::push_agent_ref(
+            &self.cache_dir,
+            self.sync.remote(),
+            &self.agent.agent_id,
+        ) {
+            Ok(crate::hub_v3::PushOutcome::Pushed) => PushOutcome::Pushed,
+            Ok(other) => {
+                tracing::warn!(
+                    "v3 own-ref push for '{}' did not complete: {other:?}; saved locally",
+                    self.agent.agent_id
+                );
+                PushOutcome::LocalOnly
+            }
+            Err(e) => {
+                tracing::warn!("v3 own-ref push for '{}' error: {e}", self.agent.agent_id);
+                PushOutcome::LocalOnly
+            }
+        }
+    }
+
+    /// V3 lock claim-confirm helper: fetch every other agent's ref, reduce, and
+    /// re-cache the state so a subsequent `read_lock_v2` sees the full event set
+    /// (first-claim-wins winner). `sync.fetch()` is the v3 fetch (adopts other
+    /// agents' refs + checkpoint, then compacts), after which `refresh_v3_state`
+    /// re-reduces and caches. A fetch failure (offline) is non-fatal — we then
+    /// confirm against the local view, which is the best available.
+    pub(super) fn confirm_v3_locks(&self) -> Result<()> {
+        if let Err(e) = self.sync.fetch() {
+            tracing::warn!("v3 lock confirm: fetch failed ({e}); confirming against local view");
+        }
+        self.refresh_v3_state()
+    }
+
+    /// Look up the reduction-assigned display id for `uuid` from the last
+    /// cached v3 state (`display_id_map`, REQ-4). Returns `None` when the id is
+    /// not yet frozen by reduction (provisional) or no state is cached.
+    pub(super) fn v3_assigned_display_id(&self, uuid: &Uuid) -> Option<i64> {
+        self.last_v3_state
+            .borrow()
+            .as_ref()
+            .and_then(|s| s.display_id_map.get(uuid).copied())
+    }
+
+    /// Look up the reduction-assigned comment display id from the last cached
+    /// v3 state, by the comment's host issue display id and the comment uuid.
+    /// Returns `None` when the comment's id is provisional (not yet frozen) or
+    /// the state/issue/comment is not present.
+    pub(super) fn v3_assigned_comment_id(
+        &self,
+        issue_display_id: i64,
+        comment_uuid: &Uuid,
+    ) -> Option<i64> {
+        let state = self.last_v3_state.borrow();
+        let state = state.as_ref()?;
+        let issue = state
+            .issues
+            .values()
+            .find(|i| i.display_id == Some(issue_display_id))?;
+        issue.comments.get(comment_uuid).and_then(|c| c.display_id)
+    }
+
+    /// Look up the reduction-assigned milestone display id for `uuid` from the
+    /// last cached v3 state. Returns `None` when not yet assigned by reduction.
+    pub(super) fn v3_assigned_milestone_id(&self, uuid: &Uuid) -> Option<i64> {
+        self.last_v3_state
+            .borrow()
+            .as_ref()
+            .and_then(|s| s.milestones.get(uuid).and_then(|m| m.display_id))
+    }
+
     /// Generate content, commit, and push with retry.
     ///
     /// The `prepare` closure is called on **every** attempt, so it must
     /// re-read any mutable state (counters, issue files) from the cache
     /// which may have changed after a rebase pull.  This prevents stale
     /// display-ID collisions when two agents race.
+    ///
+    /// In [`crate::hub_v3::HubMode::V3`] the retry/file/counter machinery is
+    /// bypassed entirely: `prepare` is run ONCE to produce the events, which are
+    /// appended to the agent's own ref and pushed fast-forward (see
+    /// [`Self::commit_v3`]). The returned `WriteSet`'s `files`/`counters` are
+    /// ignored — no worktree write occurs in v3.
     pub(super) fn write_commit_push<F>(&self, mut prepare: F, message: &str) -> Result<PushOutcome>
     where
         F: FnMut(&Self) -> Result<WriteSet>,
     {
         // Serialize access to the hub cache via SyncManager's lock (#400, #457)
-        let _lock_guard = self.sync.acquire_lock()?;
+        let lock_guard = self.sync.acquire_lock()?;
+
+        if self.is_v3() {
+            // Run prepare ONCE: it claims nothing (claim_display_id returns the
+            // sentinel under V3) and produces the events. Files/counters are
+            // discarded; events drive the ref-only write.
+            let write_set = prepare(self)?;
+            let _ = message; // commit message is a v2 worktree-commit concept
+            return self.commit_v3(write_set.events, &lock_guard);
+        }
+        // V2 path holds the guard for the rest of this scope (RAII release).
+        let _lock_guard = lock_guard;
 
         for attempt in 0..MAX_RETRIES {
             // Recover from broken git states before attempting write (#454, #455, #456)

--- a/crosslink/src/shared_writer/locks.rs
+++ b/crosslink/src/shared_writer/locks.rs
@@ -59,6 +59,14 @@ impl SharedWriter {
             );
         }
 
+        // V3 claim-confirm (REQ-5): after our claim is appended + pushed, fetch
+        // every OTHER agent's ref, reduce, and re-cache state so the winner is
+        // computed over the full event set (first-claim-wins by OrderingKey).
+        // Without this, we would only see our own ref and always self-confirm.
+        if self.is_v3() {
+            self.confirm_v3_locks()?;
+        }
+
         // Re-read materialized lock to see who won
         match self.read_lock_v2(issue_display_id)? {
             Some(lock) if lock.agent_id == self.agent.agent_id => Ok(LockClaimResult::Claimed),
@@ -187,6 +195,25 @@ impl SharedWriter {
         &self,
         issue_display_id: i64,
     ) -> Result<Option<crate::issue_file::LockFileV2>> {
+        // V3: locks are pure events resolved by reduction (REQ-5). Read the
+        // winner from the reduced state cached by the preceding commit_v3 (the
+        // claim-confirm read). This mirrors the v2 read-materialized-lock-file
+        // step but over `state.locks` instead of `locks/<id>.json`.
+        if self.is_v3() {
+            let state = self.last_v3_state.borrow();
+            return Ok(state.as_ref().and_then(|s| {
+                s.locks
+                    .get(&issue_display_id)
+                    .map(|entry| crate::issue_file::LockFileV2 {
+                        issue_id: issue_display_id,
+                        agent_id: entry.agent_id.clone(),
+                        branch: entry.branch.clone(),
+                        claimed_at: entry.claimed_at,
+                        signed_by: None,
+                    })
+            }));
+        }
+
         let lock_path = self
             .cache_dir
             .join("locks")

--- a/crosslink/src/shared_writer/milestones.rs
+++ b/crosslink/src/shared_writer/milestones.rs
@@ -62,6 +62,13 @@ impl SharedWriter {
         )?;
 
         self.hydrate_with_retry(db);
+        // V3: the milestone id is reduction-assigned (REQ-4), not the sentinel
+        // claimed in `prepare`; read it from the cached reduced state.
+        if self.is_v3() {
+            if let Some(id) = self.v3_assigned_milestone_id(&uuid) {
+                return Ok(id);
+            }
+        }
         Ok(display_id.get())
     }
 

--- a/crosslink/src/shared_writer/mutations.rs
+++ b/crosslink/src/shared_writer/mutations.rs
@@ -227,6 +227,18 @@ impl SharedWriter {
             commit_msg,
         )?;
 
+        // V3: ids are reduction-assigned; there is no offline-promotion path
+        // (events are durable on the local ref and ids never double-mint). The
+        // CLI id comes from the reduction (display_id_map), falling back to the
+        // freshly-hydrated SQLite row when the id is still provisional.
+        if self.is_v3() {
+            self.hydrate_with_retry(db);
+            if let Some(id) = self.v3_assigned_display_id(&uuid) {
+                return Ok(id);
+            }
+            return db.get_issue_id_by_uuid(&uuid.to_string());
+        }
+
         if outcome == PushOutcome::LocalOnly {
             self.rewrite_as_offline(uuid)?;
             self.hydrate_with_retry(db);
@@ -555,6 +567,10 @@ impl SharedWriter {
     ) -> Result<i64> {
         let agent_id = self.agent.agent_id.clone();
         let comment_id = Cell::new(0i64);
+        // Capture the comment uuid so the V3 path can resolve the
+        // reduction-assigned id after hydration (the event-only path mints no
+        // counter id). Set inside the closure where the uuid is generated.
+        let comment_uuid_cell: Cell<Option<Uuid>> = Cell::new(None);
 
         let _ = self.write_commit_push(
             |writer| {
@@ -571,6 +587,7 @@ impl SharedWriter {
                 // exists solely as the event's idempotency key.
                 let created_at = Utc::now();
                 let comment_uuid = Uuid::new_v4();
+                comment_uuid_cell.set(Some(comment_uuid));
                 // Clone signing material for the event up-front so the file
                 // structs below can move the originals.
                 let ev_signed_by = signed_by.clone();
@@ -645,6 +662,16 @@ impl SharedWriter {
         )?;
 
         self.hydrate_with_retry(db);
+        // V3: the comment id is reduction-assigned (REQ-4). Resolve it from the
+        // reduced state via the captured comment uuid; fall back to the
+        // sentinel if reduction has not yet frozen an id (provisional).
+        if self.is_v3() {
+            if let Some(cuuid) = comment_uuid_cell.get() {
+                if let Some(id) = self.v3_assigned_comment_id(display_id, &cuuid) {
+                    return Ok(id);
+                }
+            }
+        }
         Ok(comment_id.get())
     }
 

--- a/crosslink/src/shared_writer/tests.rs
+++ b/crosslink/src/shared_writer/tests.rs
@@ -2970,7 +2970,11 @@ mod integration {
     #[test]
     fn test_read_max_event_seq_returns_zero_when_no_log() {
         let dir = tempfile::tempdir().unwrap();
-        let seq = SharedWriter::read_max_event_seq(dir.path(), "nonexistent-agent");
+        let seq = SharedWriter::read_max_event_seq(
+            dir.path(),
+            "nonexistent-agent",
+            crate::hub_v3::HubMode::V2,
+        );
         assert_eq!(seq, 0, "Max event seq should be 0 when no log exists");
     }
 

--- a/crosslink/src/sync/cache.rs
+++ b/crosslink/src/sync/cache.rs
@@ -636,7 +636,17 @@ impl SyncManager {
         // Acquire the hub write lock to serialize with write_commit_push (#457).
         // fetch() modifies the working directory (reset, rebase) which races
         // with concurrent CLI writes if not serialized.
-        let _lock_guard = self.acquire_lock()?;
+        let lock_guard = self.acquire_lock()?;
+
+        // V3: ref-based fetch (754a PASS 2). No worktree reset/rebase — adopt
+        // other agents' refs + checkpoint and compact. The V2 path below stays
+        // byte-identical for V2/Absent hubs.
+        if self.hub_mode.is_v3() {
+            self.fetch_v3(&lock_guard);
+            return Ok(());
+        }
+        // V2 path holds the guard for the rest of this scope (RAII release).
+        let _lock_guard = lock_guard;
 
         // Minimal v3-aware warn (full refusal is #754): warn once if this hub
         // has already been migrated to v3 but we are still fetching/operating it
@@ -711,6 +721,218 @@ impl SyncManager {
         }
 
         Ok(())
+    }
+
+    /// V3 ref-based fetch (754a PASS 2, REQ-3).
+    ///
+    /// 1. `git fetch <remote> '+refs/crosslink/checkpoint:refs/crosslink-remote/checkpoint'
+    ///    'refs/crosslink/agents/*:refs/crosslink-remote/agents/*'` — checkpoint
+    ///    forced (pure cache), agent refs non-forced into tracking refs.
+    /// 2. For each OTHER agent's ref, adopt the remote tracking tip
+    ///    (writer-authoritative: the agent is the single writer of its ref, so
+    ///    its remote tip is canonical even after a REQ-11 prune rewrote history
+    ///    non-fast-forward — we never need to merge another writer's ref). Our
+    ///    OWN ref is never moved by fetch (we are its writer).
+    /// 3. Adopt the checkpoint remote tip when its watermark >= our local
+    ///    watermark; otherwise keep local (either is deterministic content).
+    /// 4. Refresh the LOCAL checkpoint from the adopted refs (reduce + write,
+    ///    NO prune). Hydration is driven separately by the caller.
+    ///
+    /// # Why fetch does NOT prune
+    ///
+    /// The REQ-11 own-ref prune rewrites the agent's own ref to a shorter
+    /// history. Doing that on the READ-mostly fetch path would make the next
+    /// own-ref push non-fast-forward against the un-pruned remote ref (our
+    /// pushes are plain fast-forward, REQ-1). Prune is therefore confined to the
+    /// explicit `compact` command (where the checkpoint is pushed and the prune
+    /// is intentional). Fetch only refreshes the local checkpoint CACHE.
+    ///
+    /// Offline / missing remote is non-fatal — local refs are used as-is.
+    fn fetch_v3(&self, hub_lock: &super::HubWriteLock) {
+        let _ = hub_lock; // caller already holds the hub write lock (REQ-8)
+        self.fetch_and_adopt_v3_refs();
+        // Refresh the local checkpoint cache from the adopted refs (no prune).
+        self.refresh_local_checkpoint();
+    }
+
+    /// Fetch the v3 refs and apply the adoption rules WITHOUT acquiring the hub
+    /// lock or writing the checkpoint. The caller MUST already hold the hub
+    /// write lock (REQ-8). Used by [`Self::fetch_v3`] (which then refreshes the
+    /// checkpoint) and by the v3 write path (`commit_v3`), which fetches other
+    /// agents' refs before reducing so a lock claim-confirm sees the full event
+    /// set. Offline / missing-remote is a no-op (local refs are used as-is).
+    pub(crate) fn fetch_and_adopt_v3_refs(&self) {
+        // 1. Fetch checkpoint (forced) + agent refs into tracking refs.
+        let fetch_result = self.git_in_cache(&[
+            "fetch",
+            &self.remote,
+            "+refs/crosslink/checkpoint:refs/crosslink-remote/checkpoint",
+            "refs/crosslink/agents/*:refs/crosslink-remote/agents/*",
+        ]);
+        if fetch_result.is_err() {
+            // Offline / no remote refs yet — nothing to adopt; local refs stand.
+            return;
+        }
+
+        // Our own agent id, so we never move our own ref from the remote.
+        let own_agent_id = crate::identity::AgentConfig::load(&self.crosslink_dir)
+            .ok()
+            .flatten()
+            .map(|a| a.agent_id);
+
+        // 2. Adopt OTHER agents' refs to their remote tracking tip.
+        let tips = match self.list_remote_agent_tips() {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!("v3 fetch: could not list remote agent tips: {e}");
+                return;
+            }
+        };
+        for (agent_id, remote_tip) in tips {
+            if own_agent_id.as_deref() == Some(agent_id.as_str()) {
+                continue; // never move our own ref from the remote
+            }
+            let local_ref = format!("{}{agent_id}", crate::hub_v3::AGENT_REF_PREFIX);
+            // Writer-authoritative: adopt unconditionally (the remote tip is the
+            // single writer's canonical history, FF or not after their prune).
+            if let Err(e) = self.git_in_cache(&["update-ref", &local_ref, &remote_tip]) {
+                tracing::warn!("v3 fetch: failed to adopt ref '{local_ref}': {e}");
+            }
+        }
+
+        // 3. Adopt the checkpoint by watermark comparison.
+        self.adopt_checkpoint_by_watermark();
+    }
+
+    /// Enumerate `(agent_id, sha)` for every remote-tracking agent ref under
+    /// `refs/crosslink-remote/agents/*`.
+    fn list_remote_agent_tips(&self) -> Result<Vec<(String, String)>> {
+        let output = self.git_in_cache(&[
+            "for-each-ref",
+            "--format=%(refname) %(objectname)",
+            "refs/crosslink-remote/agents/*",
+        ])?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let mut out = Vec::new();
+        for line in stdout.lines() {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            let Some((refname, sha)) = line.split_once(' ') else {
+                continue;
+            };
+            if let Some(agent_id) = refname.strip_prefix("refs/crosslink-remote/agents/") {
+                out.push((agent_id.to_string(), sha.to_string()));
+            }
+        }
+        Ok(out)
+    }
+
+    /// Adopt the remote checkpoint tracking tip into the local checkpoint ref
+    /// when the remote watermark is >= the local watermark. Either checkpoint is
+    /// deterministic content for its covered event set, so adopting the
+    /// higher-watermark one minimizes re-reduction without risking data loss.
+    fn adopt_checkpoint_by_watermark(&self) {
+        let remote_tracking = "refs/crosslink-remote/checkpoint";
+        let Some(remote_tip) =
+            crate::hub_v3::git_rev_parse_optional(&self.cache_dir, remote_tracking)
+                .ok()
+                .flatten()
+        else {
+            return; // no remote checkpoint
+        };
+        let local_wm = self.checkpoint_watermark_count(crate::hub_v3::CHECKPOINT_REF);
+        let remote_wm = self.checkpoint_watermark_count(remote_tracking);
+        if remote_wm >= local_wm {
+            if let Err(e) =
+                self.git_in_cache(&["update-ref", crate::hub_v3::CHECKPOINT_REF, &remote_tip])
+            {
+                tracing::warn!("v3 fetch: failed to adopt remote checkpoint: {e}");
+            }
+        }
+    }
+
+    /// Read a coarse "watermark rank" for a checkpoint ref: the number of events
+    /// its watermark covers, approximated by the watermark's `agent_seq` plus a
+    /// presence bit. Returns `i64::MIN`-like 0 when absent. Used only for the
+    /// adopt-higher comparison; the content is identical for equal coverage.
+    fn checkpoint_watermark_count(&self, ref_name: &str) -> i64 {
+        let Some(tip) = crate::hub_v3::git_rev_parse_optional(&self.cache_dir, ref_name)
+            .ok()
+            .flatten()
+        else {
+            return -1;
+        };
+        let spec = format!("{tip}:state.json");
+        let Some(bytes) = crate::hub_v3::git_cat_file_blob_optional(&self.cache_dir, &spec)
+            .ok()
+            .flatten()
+        else {
+            return 0;
+        };
+        match crate::checkpoint::CheckpointState::from_slice(&bytes) {
+            Ok(state) => state
+                .watermark
+                .map_or(0, |w| i64::try_from(w.agent_seq).unwrap_or(i64::MAX)),
+            Err(_) => 0,
+        }
+    }
+
+    /// Refresh the LOCAL checkpoint ref's `state.json` from a fresh reduction of
+    /// the v3 ref namespace, WITHOUT pruning any agent ref and WITHOUT pushing.
+    ///
+    /// The checkpoint is a pure local cache here (REQ-7): writing it lets the
+    /// cheap [`crate::sync::SyncManager::read_locks_v3`] path read materialized
+    /// locks without a full reduce. The idempotency guard inside the checkpoint
+    /// write makes this a true no-op when the state is unchanged. Best-effort: a
+    /// reduce/write failure is logged, never propagated (readers reduce on
+    /// demand regardless).
+    fn refresh_local_checkpoint(&self) {
+        let source = match crate::hub_source::RefHubSource::new(&self.cache_dir) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!("v3 fetch: RefHubSource construction failed (non-fatal): {e}");
+                return;
+            }
+        };
+        let mut state = match crate::compaction::reduce(&source) {
+            Ok(o) => o.state,
+            Err(e) => {
+                tracing::warn!("v3 fetch: reduction failed (non-fatal): {e}");
+                return;
+            }
+        };
+        state.compaction_lease = None;
+        let bytes = match serde_json::to_vec_pretty(&state) {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::warn!("v3 fetch: checkpoint serialization failed (non-fatal): {e}");
+                return;
+            }
+        };
+        // Skip the write when the local checkpoint already matches (idempotent).
+        if let Ok(Some(tip)) =
+            crate::hub_v3::git_rev_parse_optional(&self.cache_dir, crate::hub_v3::CHECKPOINT_REF)
+        {
+            let spec = format!("{tip}:state.json");
+            if let Ok(Some(existing)) =
+                crate::hub_v3::git_cat_file_blob_optional(&self.cache_dir, &spec)
+            {
+                if existing == bytes {
+                    return;
+                }
+            }
+        }
+        if let Err(e) = crate::hub_v3::commit_blob_to_ref(
+            &self.cache_dir,
+            crate::hub_v3::CHECKPOINT_REF,
+            "state.json",
+            &bytes,
+            "crosslink v3 checkpoint (fetch refresh)",
+        ) {
+            tracing::warn!("v3 fetch: local checkpoint refresh failed (non-fatal): {e}");
+        }
     }
 
     /// Rebase local unpushed commits on top of the remote ref, preserving

--- a/crosslink/src/sync/core.rs
+++ b/crosslink/src/sync/core.rs
@@ -19,6 +19,11 @@ pub struct SyncManager {
     pub(super) repo_root: PathBuf,
     /// Git remote name for the hub branch (from config, defaults to "origin").
     pub(super) remote: String,
+    /// Operation mode, resolved ONCE here (754a PASS 2). `V3` routes mutations
+    /// to per-agent refs with state-based hydration; `V2` keeps the worktree-
+    /// file flow. Cached so the per-call hot paths (`fetch`, `lock_check`) do
+    /// not re-probe refs on every invocation.
+    pub(super) hub_mode: crate::hub_v3::HubMode,
 }
 
 impl SyncManager {
@@ -46,12 +51,27 @@ impl SyncManager {
         let cache_dir = repo_root.join(".crosslink").join(HUB_CACHE_DIR);
         let remote = read_tracker_remote(crosslink_dir);
 
+        // Resolve the operation mode ONCE (754a PASS 2). Probe the hub-cache
+        // worktree: its `.git` link shares the main repository's ref namespace,
+        // so the v3 marker refs (`refs/crosslink/meta` + `/checkpoint`) resolve
+        // there. When the cache is absent (fresh repo, never synced) detection
+        // returns `Absent` ⇒ `V2`, preserving today's init behavior.
+        let hub_mode = crate::hub_v3::HubMode::resolve(&cache_dir);
+
         Ok(Self {
             crosslink_dir: crosslink_dir.to_path_buf(),
             cache_dir,
             repo_root,
             remote,
+            hub_mode,
         })
+    }
+
+    /// The resolved operation mode for this hub (V2 worktree-file or V3
+    /// event-only). Decided once at construction; see [`crate::hub_v3::HubMode`].
+    #[must_use]
+    pub const fn hub_mode(&self) -> crate::hub_v3::HubMode {
+        self.hub_mode
     }
 
     /// Get the configured git remote name for the hub branch.

--- a/crosslink/src/sync/heartbeats.rs
+++ b/crosslink/src/sync/heartbeats.rs
@@ -26,6 +26,25 @@ impl SyncManager {
             machine_id: agent.machine_id.clone(),
         };
 
+        // V3: write the heartbeat to the agent's OWN REF (sibling-preserving,
+        // single-writer) and push the ref — no worktree file, no v2 commit flow.
+        if self.hub_mode.is_v3() {
+            crate::hub_v3::write_heartbeat_to_ref(&self.cache_dir, &agent.agent_id, &heartbeat)?;
+            if self.remote_exists() {
+                match crate::hub_v3::push_agent_ref(&self.cache_dir, &self.remote, &agent.agent_id)?
+                {
+                    crate::hub_v3::PushOutcome::Pushed | crate::hub_v3::PushOutcome::NoRemote => {}
+                    other => {
+                        tracing::warn!(
+                            "v3 heartbeat push for '{}' did not complete: {other:?}",
+                            agent.agent_id
+                        );
+                    }
+                }
+            }
+            return Ok(());
+        }
+
         // Ensure heartbeats directory exists
         let hb_dir = self.cache_dir.join("heartbeats");
         std::fs::create_dir_all(&hb_dir)?;
@@ -195,6 +214,15 @@ impl SyncManager {
     /// Returns an error if heartbeat files cannot be read.
     pub fn read_heartbeats_auto(&self) -> Result<Vec<Heartbeat>> {
         use std::collections::HashMap;
+
+        // V3: heartbeats live at each agent ref's `heartbeat.json` root — single
+        // source by mode (a v3 hub has no v2 heartbeat files to merge).
+        if self.hub_mode.is_v3() {
+            return Ok(crate::hub_v3::read_heartbeats_from_refs(&self.cache_dir)?
+                .into_iter()
+                .map(|(_, hb)| hb)
+                .collect());
+        }
 
         let mut heartbeats = self.read_heartbeats()?;
         if self.is_v2_layout() {

--- a/crosslink/src/sync/locks.rs
+++ b/crosslink/src/sync/locks.rs
@@ -105,6 +105,13 @@ impl SyncManager {
     ///
     /// Returns an error if the underlying lock files cannot be read or parsed.
     pub fn read_locks_auto(&self) -> Result<LocksFile> {
+        // V3: locks are pure events (REQ-5). Read them from the LOCAL checkpoint
+        // ref's `state.json` directly (no full reduce) so the per-tool-call hot
+        // path (lock_check via PreToolUse hooks) stays cheap. See read_locks_v3
+        // for the staleness window this trades for speed.
+        if self.hub_mode.is_v3() {
+            return self.read_locks_v3();
+        }
         let meta_dir = self.cache_dir.join("meta");
         let version = crate::issue_file::read_layout_version(&meta_dir).unwrap_or(1);
         if version >= 2 {
@@ -112,6 +119,53 @@ impl SyncManager {
         } else {
             self.read_locks()
         }
+    }
+
+    /// Read lock state from the LOCAL v3 checkpoint ref's `state.json`.
+    ///
+    /// This deliberately does NOT run a full reduction: it reads the most
+    /// recently compacted checkpoint (`refs/crosslink/checkpoint` -> `state.json`
+    /// -> `state.locks`) and maps it into a [`LocksFile`]. The hot path here is
+    /// `lock_check` (invoked per tool call by `PreToolUse` hooks), so a full
+    /// `RefHubSource` reduce on every call would be too expensive.
+    ///
+    /// # Staleness window
+    ///
+    /// The returned locks reflect the last LOCAL compaction, not necessarily the
+    /// latest events on every agent ref. This is the SAME class of staleness the
+    /// v2 path already has: v2 `read_locks_auto` reads materialized `locks/*.json`
+    /// written by the last `compact`, equally lagging un-compacted events. A
+    /// preceding `fetch` (which compacts) closes the window in both modes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error only if the checkpoint blob exists but does not parse.
+    /// A missing checkpoint (fresh v3 hub) yields an empty [`LocksFile`].
+    pub fn read_locks_v3(&self) -> Result<LocksFile> {
+        let Some(tip) =
+            crate::hub_v3::git_rev_parse_optional(&self.cache_dir, crate::hub_v3::CHECKPOINT_REF)?
+        else {
+            return Ok(LocksFile::empty());
+        };
+        let spec = format!("{tip}:state.json");
+        let Some(bytes) = crate::hub_v3::git_cat_file_blob_optional(&self.cache_dir, &spec)? else {
+            return Ok(LocksFile::empty());
+        };
+        let state = crate::checkpoint::CheckpointState::from_slice(&bytes)
+            .context("failed to parse v3 checkpoint state.json for lock read")?;
+        let mut file = LocksFile::empty();
+        for (issue_id, entry) in state.locks {
+            file.locks.insert(
+                issue_id,
+                crate::locks::Lock {
+                    agent_id: entry.agent_id,
+                    branch: entry.branch,
+                    claimed_at: entry.claimed_at,
+                    signed_by: String::new(),
+                },
+            );
+        }
+        Ok(file)
     }
 
     /// Claim a lock on an issue for the given agent.
@@ -305,7 +359,10 @@ impl SyncManager {
         }
 
         let locks = self.read_locks_auto()?;
-        let heartbeats = self.read_heartbeats()?;
+        // Mode-aware heartbeats: V1 reads `heartbeats/*.json`, V3 reads each
+        // agent ref's `heartbeat.json`. `read_heartbeats` (V1-only) would yield
+        // an empty list on a V3 hub and mark every lock stale.
+        let heartbeats = self.read_heartbeats_auto()?;
         let timeout =
             chrono::Duration::minutes(locks.settings.stale_lock_timeout_minutes.cast_signed());
         let now = Utc::now();
@@ -370,7 +427,8 @@ impl SyncManager {
         }
 
         let locks = self.read_locks_auto()?;
-        let heartbeats = self.read_heartbeats()?;
+        // Mode-aware heartbeats (see `find_stale_locks`): V3 reads agent refs.
+        let heartbeats = self.read_heartbeats_auto()?;
         let timeout =
             chrono::Duration::minutes(locks.settings.stale_lock_timeout_minutes.cast_signed());
         let now = Utc::now();

--- a/crosslink/src/tui/agents_tab.rs
+++ b/crosslink/src/tui/agents_tab.rs
@@ -173,8 +173,8 @@ impl AgentsTab {
             }
         };
 
-        // Find heartbeat for this agent
-        let heartbeats = sync.read_heartbeats().unwrap_or_default();
+        // Find heartbeat for this agent (mode-aware: V1 dir, V2 agent dirs, V3 refs)
+        let heartbeats = sync.read_heartbeats_auto().unwrap_or_default();
         let heartbeat = heartbeats.into_iter().find(|h| h.agent_id == agent_id);
 
         // Find locks held by this agent
@@ -1071,6 +1071,122 @@ mod tests {
         terminal
             .draw(|frame| tab.render(frame, frame.area()))
             .unwrap();
+    }
+
+    fn git_ok() -> bool {
+        std::process::Command::new("git")
+            .arg("--version")
+            .output()
+            .is_ok_and(|o| o.status.success())
+    }
+
+    fn git(dir: &Path, args: &[&str]) {
+        let out = std::process::Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(out.status.success(), "git {args:?} failed");
+    }
+
+    /// State-level (not rendering) v3 reroute test: `load_agents_data` must
+    /// surface a lock from the v3 checkpoint state and a heartbeat from a v3
+    /// agent ref, proving the agents-tab loader routes through the mode-aware
+    /// `read_locks_auto` / `read_heartbeats_auto` helpers on a v3 hub.
+    ///
+    /// Builds an authentic v3 hub via the real `migrate hub-v3` command (so the
+    /// agent refs carry real events and survive `fetch`'s re-reduce), then
+    /// claims a lock and beats once before loading.
+    #[test]
+    fn test_load_agents_data_v3_reads_from_refs() {
+        use crate::db::Database;
+        use crate::identity::{AgentConfig, AgentRole};
+        use crate::shared_writer::SharedWriter;
+
+        if !git_ok() {
+            return;
+        }
+        let remote = tempfile::tempdir().unwrap();
+        let work = tempfile::tempdir().unwrap();
+        git(remote.path(), &["init", "--bare", "-b", "main"]);
+        let wp = work.path().to_path_buf();
+        git(&wp, &["init", "-b", "main"]);
+        git(&wp, &["config", "user.email", "t@t.local"]);
+        git(&wp, &["config", "user.name", "T"]);
+        git(&wp, &["config", "commit.gpgsign", "false"]);
+        git(
+            &wp,
+            &["remote", "add", "origin", remote.path().to_str().unwrap()],
+        );
+        std::fs::write(wp.join("README.md"), "# t\n").unwrap();
+        git(&wp, &["add", "."]);
+        git(&wp, &["commit", "-m", "init", "--no-gpg-sign"]);
+        git(&wp, &["push", "-u", "origin", "main"]);
+
+        let crosslink_dir = wp.join(".crosslink");
+        std::fs::create_dir_all(&crosslink_dir).unwrap();
+        std::fs::write(
+            crosslink_dir.join("hook-config.json"),
+            r#"{"remote":"origin","layout":"v2"}"#,
+        )
+        .unwrap();
+        let agent = AgentConfig {
+            agent_id: "alpha".to_string(),
+            machine_id: "m".to_string(),
+            description: Some("t".to_string()),
+            role: AgentRole::Driver,
+            ssh_key_path: None,
+            ssh_fingerprint: None,
+            ssh_public_key: None,
+        };
+        std::fs::write(
+            crosslink_dir.join("agent.json"),
+            serde_json::to_string_pretty(&agent).unwrap(),
+        )
+        .unwrap();
+
+        let sync = SyncManager::new(&crosslink_dir).unwrap();
+        sync.init_cache().unwrap();
+        let cache_dir = sync.cache_path().to_path_buf();
+
+        let db = Database::open(&crosslink_dir.join("issues.db")).unwrap();
+        let writer = SharedWriter::new(&crosslink_dir).unwrap().unwrap();
+        writer
+            .create_issue(&db, "First", None, "high", None, None)
+            .unwrap();
+        let lock = sync.acquire_lock().unwrap();
+        crate::compaction::compact(&cache_dir, "alpha", true, &lock).unwrap();
+        drop(lock);
+        crate::commands::migrate_hub_v3::hub_v3(&crosslink_dir, false, false).unwrap();
+
+        // Reconstruct the writer AFTER migration so it operates in V3 mode
+        // (SharedWriter caches its hub mode at construction).
+        let writer = SharedWriter::new(&crosslink_dir).unwrap().unwrap();
+        // Claim a lock (event-only) and beat once on the agent ref.
+        let id = writer
+            .create_issue(&db, "Lockable", None, "high", None, None)
+            .unwrap();
+        writer.claim_lock_v2(id, None).unwrap();
+        let beat_sync = SyncManager::new(&crosslink_dir).unwrap();
+        beat_sync.push_heartbeat(&agent, Some(id)).unwrap();
+
+        assert!(SyncManager::new(&crosslink_dir).unwrap().hub_mode().is_v3());
+
+        let result = load_agents_data(&crosslink_dir);
+        assert!(
+            result.error_msg.is_none(),
+            "load failed: {:?}",
+            result.error_msg
+        );
+        assert!(
+            result.lock_rows.iter().any(|l| l.agent_id == "alpha"),
+            "v3 lock from checkpoint must surface in the agents tab ({} rows)",
+            result.lock_rows.len()
+        );
+        assert!(
+            result.agents.iter().any(|a| a.agent_id == "alpha"),
+            "v3 heartbeat from the agent ref must surface in the agents tab"
+        );
     }
 
     #[test]

--- a/crosslink/src/tui/config_tab.rs
+++ b/crosslink/src/tui/config_tab.rs
@@ -1128,7 +1128,7 @@ fn load_config_sync_data(crosslink_dir: &Path) -> ConfigSyncResult {
     if let Ok(stale) = sync.find_stale_locks() {
         result.stale_lock_count = stale.len();
     }
-    if let Ok(heartbeats) = sync.read_heartbeats() {
+    if let Ok(heartbeats) = sync.read_heartbeats_auto() {
         result.agent_count = heartbeats.len();
     }
 


### PR DESCRIPTION
## Summary

754a — the cutover half of hub v3 PR4 (crosslink issue #754). Clients route by detected hub version: **V3 hubs get event-only writes and state-based hydration; V2 hubs remain bit-identical.** The v2-machinery deletion and hard refusal ship separately (754b) after this repository migrates for real — so the repo crosses the migration boundary on a binary that still has both paths, and rollback at every step is a git checkout.

### Infrastructure (pass 1)

- **Sibling-preserving ref trees**: all commit paths route through a `write_tree_with` core that reads the tip tree and replaces only its target file (one nesting level) — refs carrying `events.log` + `heartbeat.json` + request subtrees never drop siblings.
- **Heartbeats on agent refs** (same schema as v2). **Agent requests with writer-ownership**: the driver writes `requests-out/<target>--<ulid>.json` into *its own* ref, the target acks in *its* ref, polling scans all refs minus acked — the v2 scheme of writing into the target's directory would have violated single-writer-per-ref.
- **`compact_v3`**: reduce → checkpoint ref (CAS + force-with-lease, byte-identical idempotency guard) → own-ref prune **only after the covering checkpoint is durably pushed** (REQ-11 — protects fresh clones from losing uncovered events).

### Mode routing (pass 2)

- `HubMode` resolved once per `SyncManager`; the dual-write flag is ignored in V3 (it was the v2→v3 bridge).
- **V3 writes claim nothing**: no counter reads, `display_id` stripped to `None`, ids assigned by reduction (REQ-4). The v2 offline/promotion dance (negative ids, counter reverts, claim rewrites) is structurally unnecessary: a failed push leaves durable events on the local ref, delivered by the next push.
- `commit_v3` fetches+adopts other agents' refs before reducing — fixing a claim-confirm bug found during testing where reducing from a partial view let the watermark mask an earlier-ordered lock claim.
- **Fetch rules**: other agents' refs adopted unconditionally (writer-authoritative — handles legal post-prune non-fast-forward), own ref never moved by fetch, checkpoint adopted when remote watermark >= local.
- **`hydrate_from_state`**: `CheckpointState` → SQLite with the same transaction, GH#443 session-preservation, and data-loss-guard semantics as the file path. `lock_check` reads the local checkpoint ref directly (hot hook path; same staleness class as v2's materialized reads).

### Reader sweep (pass 3)

- Dashboard reader resolves mode **per tracked project**; v3 snapshots read the checkpoint ref + ref heartbeats with output types unchanged.
- Server watcher watches `.git/refs/crosslink` recursively in v3 (ref movement is the change signal; the packed-refs gap is covered by the existing 30s poll).
- **Latent v3 bug fixed**: `find_stale_locks` used V1-only heartbeat reads — on a v3 hub every lock would have been flagged stale (underpins `locks` commands, TUI stale markers, and the server stale-lock endpoints).

## Testing

- `cargo fmt --all -- --check` clean; both clippy gates clean (`--all-targets -D warnings` and CI-strict `-W clippy::unwrap_used -W clippy::expect_used`).
- 1998 lib (+20), 3007 bin (+17), 194 CLI integration, smoke + server_api suites green. V2 paths covered by the entire pre-existing suite unchanged.
- V3 lifecycle tests build real hubs via the production `migrate hub-v3` command: full mutation lifecycle with zero worktree writes, two-writer convergence over a shared bare remote with no id collisions, offline durability and delivery, fetch adoption rules, lock claim-confirm winner/loser, and the stale-lock-over-refs regression.

## After merge

1. `crosslink migrate hub-v3` on this repository (v2 branch intact as the escape hatch).
2. Operate v3, verify with `crosslink integrity` + live usage.
3. 754b: delete the v2 machinery, turn the migrate prompt into a hard refusal — the deeply-negative-diffstat finale.

Generated with [Claude Code](https://claude.com/claude-code)