### PR TITLE
fix(hub): silence stale migrated-hub warning for V3-mode clients

### DIFF
--- a/crosslink/src/commands/migrate_hub_v3.rs
+++ b/crosslink/src/commands/migrate_hub_v3.rs
@@ -1893,7 +1893,10 @@ mod tests {
             hub_v3::detect_hub_version(&cache_dir).unwrap(),
             HubVersion::V3 { .. }
         ));
-        // The warn function must run without panicking on a migrated hub.
-        hub_v3::warn_if_migrated_v2_operation(&cache_dir);
+        // The warn function must run without panicking on a migrated hub when
+        // the caller is (exotically) still in V2 mode, and must be a silent
+        // no-op for a V3-mode caller.
+        hub_v3::warn_if_migrated_v2_operation(&cache_dir, hub_v3::HubMode::V2);
+        hub_v3::warn_if_migrated_v2_operation(&cache_dir, hub_v3::HubMode::V3);
     }
 }

--- a/crosslink/src/hub_v3.rs
+++ b/crosslink/src/hub_v3.rs
@@ -1411,8 +1411,16 @@ static MIGRATED_V2_WARNED: std::sync::atomic::AtomicBool =
 /// follow-up #754): v2 writes are NOT reflected in v3 until the cutover. This is
 /// cheap (a few `git rev-parse` probes) and never fatal — detection failures are
 /// swallowed so the warning can never block a hub operation.
-pub fn warn_if_migrated_v2_operation(repo_dir: &Path) {
+pub fn warn_if_migrated_v2_operation(repo_dir: &Path, mode: HubMode) {
     use std::sync::atomic::Ordering;
+    // Since 754a clients route by detected hub version, so a V3 hub is
+    // operated through the ref paths and there is nothing to warn about.
+    // The warning only applies to the exotic state where V3 markers exist
+    // but this process is still on the v2 path (e.g. a mode resolved before
+    // a migration ran concurrently in another process).
+    if mode.is_v3() {
+        return;
+    }
     if MIGRATED_V2_WARNED.load(Ordering::Relaxed) {
         return;
     }

--- a/crosslink/src/shared_writer/core.rs
+++ b/crosslink/src/shared_writer/core.rs
@@ -154,7 +154,8 @@ impl SharedWriter {
         // Minimal v3-aware warn (full refusal is #754): if the hub has already
         // been migrated to v3 but we are about to operate it in v2 mode, warn
         // once. Cheap (a rev-parse), non-fatal — never blocks the operation.
-        crate::hub_v3::warn_if_migrated_v2_operation(&cache_dir);
+        // No-op when this client resolved V3 mode (754a routes by hub version).
+        crate::hub_v3::warn_if_migrated_v2_operation(&cache_dir, sync.hub_mode());
 
         Ok(Some(Self {
             sync,

--- a/crosslink/src/sync/cache.rs
+++ b/crosslink/src/sync/cache.rs
@@ -650,8 +650,9 @@ impl SyncManager {
 
         // Minimal v3-aware warn (full refusal is #754): warn once if this hub
         // has already been migrated to v3 but we are still fetching/operating it
-        // in v2 mode. Cheap rev-parse, non-fatal.
-        crate::hub_v3::warn_if_migrated_v2_operation(&self.cache_dir);
+        // in v2 mode. Cheap rev-parse, non-fatal. No-op when this client has
+        // already resolved V3 mode (754a routes by hub version).
+        crate::hub_v3::warn_if_migrated_v2_operation(&self.cache_dir, self.hub_mode());
 
         // Recover from broken git states before attempting fetch (#454, #455, #456)
         self.hub_health_check();


### PR DESCRIPTION
## Summary

`warn_if_migrated_v2_operation` predates the 754a mode routing: it fired whenever V3 markers were detected — including for clients that ARE operating v3. After the real migration of this repository (759 issues, 1345 comments, 16 locks in genesis, AC-6 verified, refs pushed), that meant a spurious WARN on every command and hook invocation.

The function now takes the caller's resolved `HubMode` and no-ops for V3-mode clients. The warning still covers its actual target: the exotic state where V3 markers exist but the process resolved V2 before a concurrent migration ran.

## Testing

1998 lib + 3009 bin green; fmt and both clippy gates clean. The migrate test exercises both the V2-mode (warn path) and V3-mode (silent no-op) calls.

Generated with [Claude Code](https://claude.com/claude-code)