### PR TITLE
feat(templates): argument-hint frontmatter on arg-taking command templates (GH#626)

### DIFF
--- a/crosslink/resources/claude/commands/crosslink-guide.md
+++ b/crosslink/resources/claude/commands/crosslink-guide.md
@@ -1,3 +1,8 @@
+---
+description: Answer questions about crosslink usage and commands
+argument-hint: [question about crosslink]
+---
+
 You are helping the user understand and use crosslink, an issue tracker designed for AI-assisted development. Read the project's CLAUDE.md for the full command reference, then answer the user's question using that context.
 
 ## What is Crosslink?

--- a/crosslink/resources/claude/commands/design.md
+++ b/crosslink/resources/claude/commands/design.md
@@ -1,6 +1,7 @@
 ---
 allowed-tools: Bash(crosslink *), Bash(git *), Bash(gh *), Bash(ls *), Bash(find *), Bash(mkdir *), Read, Grep, Glob, Write
 description: Interactive, iterative design document authoring grounded in codebase exploration
+argument-hint: ["feature description"] | --issue <id> | --gh-issue <number> | --continue <slug>
 ---
 
 ## Context

--- a/crosslink/resources/claude/commands/dev-release.md
+++ b/crosslink/resources/claude/commands/dev-release.md
@@ -1,6 +1,7 @@
 ---
 allowed-tools: Bash(git *), Bash(crosslink *), Bash(cargo *), Bash(npm *), Bash(gh *), Bash(ls *), Bash(cat *), Bash(grep *), Bash(wc *), Read, Grep, Glob
 description: Guided release automation — version bump, changelog, docs, tests, PR, tag, publish
+argument-hint: <version> [--from <branch>] [--to <branch>] [--skip-docs] [--skip-tests]
 ---
 
 ## Context

--- a/crosslink/resources/claude/commands/featree.md
+++ b/crosslink/resources/claude/commands/featree.md
@@ -1,6 +1,7 @@
 ---
 allowed-tools: Bash(git *), Bash(uuidgen), Bash(ls *), Bash(ln *), Bash(rm *), Bash(test *), Bash(mkdir *), Bash(grep *), Bash(echo *), Bash(crosslink *), Skill
 description: Create a feature branch and move it to a new git worktree
+argument-hint: <feature description>
 ---
 
 ## Context

--- a/crosslink/resources/claude/commands/feature.md
+++ b/crosslink/resources/claude/commands/feature.md
@@ -1,6 +1,7 @@
 ---
 allowed-tools: Bash(git *), Bash(crosslink *)
 description: Create a feature branch from a human-readable description
+argument-hint: <feature description> [--from <ref>]
 ---
 
 ## Context

--- a/crosslink/resources/claude/commands/kickoff.md
+++ b/crosslink/resources/claude/commands/kickoff.md
@@ -1,6 +1,7 @@
 ---
 allowed-tools: Bash(crosslink *), Bash(which *), Bash(tmux *)
 description: Create a worktree and launch a background claude agent in tmux to implement a feature
+argument-hint: <feature description> [--issue <id>] [--verify local|ci|thorough] [--container docker|podman]
 ---
 
 ## Context

--- a/crosslink/resources/claude/commands/qa.md
+++ b/crosslink/resources/claude/commands/qa.md
@@ -1,3 +1,8 @@
+---
+description: Automated architectural code review against SOLID, security, and complexity heuristics
+argument-hint: [path | "current diff"]
+---
+
 # SKILL: Automated Architectural Code Review (QA Agent)
 
 ## 1. Role Definition


### PR DESCRIPTION
## Summary

Implements #626: the shipped Claude Code command templates declared no `argument-hint`, so typing a crosslink slash command surfaced no inline guidance about accepted arguments.

Hints added to the seven arg-taking templates (`design`, `feature`, `featree`, `kickoff`, `dev-release`, `crosslink-guide`, `qa`), each **derived from the template's own documented Arguments/usage section** rather than transcribed from the issue's appendix, per the issue's own instruction. Two sanctioned deviations:

- `featree` drops `--from` — the template delegates to `/feature` with the description only and documents no `--from` passthrough (the appendix flagged this exact uncertainty).
- `kickoff` uses the trimmed readable form (`--model`/`--timeout` remain documented in the body).

Convention per AC-4: `<required>`, `[optional]`, `|` for alternatives. Argument-free templates intentionally untouched (AC-3). While here (flagged by the issue): `qa.md` and `crosslink-guide.md` had no frontmatter block at all and gained minimal ones (description derived from their own opening heading/sentence; no `allowed-tools` invented). No body changes anywhere — purely additive metadata.

## Testing

- 2770 bin + 194 CLI integration green (template/init content assertions unaffected); `cargo fmt --all -- --check` clean.
- Live verification: the repo's local (gitignored) `.claude/commands/` copies were synced, and the running Claude Code session picked up the new frontmatter immediately.

Refs #626

Generated with [Claude Code](https://claude.com/claude-code)