### PR TITLE
fix(hooks,cli): never seed or bind stray .crosslink dirs from cwd drift (GH#625)

### DIFF
--- a/crosslink/resources/claude/hooks/crosslink_config.py
+++ b/crosslink/resources/claude/hooks/crosslink_config.py
@@ -68,19 +68,32 @@ def _resolve_main_repo_root(start_dir):
         return None
 
 
+def _is_initialized_crosslink_dir(candidate):
+    """Whether a .crosslink candidate is an initialized crosslink project dir.
+
+    `crosslink init` always writes hook-config.json. Stray `.crosslink/`
+    directories seeded in subdirectories by cwd drift (GH#625) lack it —
+    they contain only hydration caches. Binding to a stray sends hook
+    caches/heartbeats to the wrong place, so candidates without the marker
+    are skipped.
+    """
+    return os.path.isfile(os.path.join(candidate, 'hook-config.json'))
+
+
 def find_crosslink_dir():
-    """Find the .crosslink directory.
+    """Find the INITIALIZED .crosslink directory (GH#625-safe).
 
     Prefers the project root derived from the hook script's own path
     (reliable even when cwd is a subdirectory), falling back to walking
     up from cwd, then checking if we're in a git worktree and looking
-    in the main repo root.
+    in the main repo root. Candidates without hook-config.json are
+    strays and are never bound.
     """
     # Primary: resolve from script location
     root = project_root_from_script()
     if root:
         candidate = os.path.join(root, '.crosslink')
-        if os.path.isdir(candidate):
+        if os.path.isdir(candidate) and _is_initialized_crosslink_dir(candidate):
             return candidate
 
     # Fallback: walk up from cwd
@@ -88,7 +101,7 @@ def find_crosslink_dir():
     start = current
     for _ in range(10):
         candidate = os.path.join(current, '.crosslink')
-        if os.path.isdir(candidate):
+        if os.path.isdir(candidate) and _is_initialized_crosslink_dir(candidate):
             return candidate
         parent = os.path.dirname(current)
         if parent == current:
@@ -99,7 +112,7 @@ def find_crosslink_dir():
     main_root = _resolve_main_repo_root(start)
     if main_root:
         candidate = os.path.join(main_root, '.crosslink')
-        if os.path.isdir(candidate):
+        if os.path.isdir(candidate) and _is_initialized_crosslink_dir(candidate):
             return candidate
 
     return None

--- a/crosslink/resources/claude/hooks/heartbeat.py
+++ b/crosslink/resources/claude/hooks/heartbeat.py
@@ -18,13 +18,18 @@ HEARTBEAT_INTERVAL_SECONDS = 120  # 2 minutes
 
 
 def main():
-    # Find .crosslink directory
+    # Find the INITIALIZED .crosslink directory (GH#625-safe): candidates
+    # without hook-config.json are strays seeded by cwd drift and are skipped,
+    # never bound — binding one would throttle/cache heartbeats in the wrong
+    # place.
     cwd = os.getcwd()
     crosslink_dir = None
     current = cwd
     for _ in range(10):
         candidate = os.path.join(current, ".crosslink")
-        if os.path.isdir(candidate):
+        if os.path.isdir(candidate) and os.path.isfile(
+            os.path.join(candidate, "hook-config.json")
+        ):
             crosslink_dir = candidate
             break
         parent = os.path.dirname(current)

--- a/crosslink/resources/claude/hooks/post-edit-check.py
+++ b/crosslink/resources/claude/hooks/post-edit-check.py
@@ -425,11 +425,17 @@ def main():
     test_reminder = None
 
     if not is_agent:
-        # Debounced linting: only run linter if no edits in last 10 seconds
+        # Debounced linting: only run linter if no edits in last 10 seconds.
+        # GH#625: the debounce marker must live in the INITIALIZED crosslink
+        # dir (found via find_crosslink_dir, which requires hook-config.json),
+        # NEVER derived from project_root — in monorepos, project_root is the
+        # nearest package root (e.g. web/ with its package.json), and writing
+        # the marker there seeded stray `web/.crosslink/` directories that the
+        # CLI then bound to, silently splitting the database. With no
+        # initialized crosslink dir, skip debounce rather than create one.
         lint_marker = None
-        if project_root:
-            crosslink_cache = os.path.join(project_root, '.crosslink', '.cache')
-            lint_marker = os.path.join(crosslink_cache, 'last-edit-time')
+        if crosslink_dir:
+            lint_marker = os.path.join(crosslink_dir, '.cache', 'last-edit-time')
 
         should_lint = True
         if lint_marker:

--- a/crosslink/resources/claude/hooks/pre-web-check.py
+++ b/crosslink/resources/claude/hooks/pre-web-check.py
@@ -22,22 +22,32 @@ def _project_root_from_script():
         return None
 
 
+def _is_initialized_crosslink_dir(candidate):
+    """GH#625: only an initialized dir (hook-config.json present) counts.
+
+    Stray .crosslink/ dirs seeded in subdirectories by cwd drift lack the
+    marker and must never be bound.
+    """
+    return os.path.isfile(os.path.join(candidate, 'hook-config.json'))
+
+
 def find_crosslink_dir():
-    """Find the .crosslink directory.
+    """Find the INITIALIZED .crosslink directory (GH#625-safe).
 
     Prefers the project root derived from the hook script's own path,
-    falling back to walking up from cwd.
+    falling back to walking up from cwd. Candidates without
+    hook-config.json are strays and are skipped.
     """
     root = _project_root_from_script()
     if root:
         candidate = os.path.join(root, '.crosslink')
-        if os.path.isdir(candidate):
+        if os.path.isdir(candidate) and _is_initialized_crosslink_dir(candidate):
             return candidate
 
     current = os.getcwd()
     for _ in range(10):
         candidate = os.path.join(current, '.crosslink')
-        if os.path.isdir(candidate):
+        if os.path.isdir(candidate) and _is_initialized_crosslink_dir(candidate):
             return candidate
         parent = os.path.dirname(current)
         if parent == current:

--- a/crosslink/resources/claude/hooks/session-start.py
+++ b/crosslink/resources/claude/hooks/session-start.py
@@ -29,17 +29,24 @@ def run_crosslink(args):
         return None
 
 
+def _is_initialized(candidate):
+    """GH#625: only a dir with hook-config.json counts; strays are skipped."""
+    return os.path.isfile(os.path.join(candidate, "hook-config.json"))
+
+
 def check_crosslink_initialized():
-    """Check if .crosslink directory exists.
+    """Check if an INITIALIZED .crosslink directory exists (GH#625-safe).
 
     Prefers the project root derived from the hook script's own path
     (reliable even when cwd is a subdirectory), falling back to walking
-    up from cwd.
+    up from cwd. Stray .crosslink dirs without hook-config.json never
+    count as initialized.
     """
     # Primary: resolve from script location (.claude/hooks/ -> project root)
     try:
         root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-        if os.path.isdir(os.path.join(root, ".crosslink")):
+        candidate = os.path.join(root, ".crosslink")
+        if os.path.isdir(candidate) and _is_initialized(candidate):
             return True
     except (NameError, OSError):
         pass
@@ -48,7 +55,7 @@ def check_crosslink_initialized():
     current = os.getcwd()
     while True:
         candidate = os.path.join(current, ".crosslink")
-        if os.path.isdir(candidate):
+        if os.path.isdir(candidate) and _is_initialized(candidate):
             return True
         parent = os.path.dirname(current)
         if parent == current:

--- a/crosslink/src/main.rs
+++ b/crosslink/src/main.rs
@@ -2141,14 +2141,43 @@ fn init_tracing(log_level: &str, log_format: &str) {
 }
 
 fn find_crosslink_dir() -> Result<PathBuf> {
-    let mut current = env::current_dir()?;
+    find_crosslink_dir_from(&env::current_dir()?)
+}
 
-    // First, walk up from cwd looking for .crosslink (works in main repo)
-    let start = current.clone();
+/// Whether a `.crosslink` candidate is an initialized crosslink project dir.
+///
+/// `crosslink init` always writes `hook-config.json`, and agent worktrees
+/// carry it (committed on their branch or written by the worktree init).
+/// Stray `.crosslink/` directories seeded by cwd drift (GH#625) lack it —
+/// they contain only hydration caches (`issues.db`, `.cache/`). Binding to
+/// a stray silently splits the database, so candidates without the marker
+/// are skipped with a warning instead of bound.
+fn is_initialized_crosslink_dir(candidate: &std::path::Path) -> bool {
+    candidate.join("hook-config.json").is_file()
+}
+
+fn find_crosslink_dir_from(start: &std::path::Path) -> Result<PathBuf> {
+    let mut current = start.to_path_buf();
+    let mut skipped_strays: Vec<PathBuf> = Vec::new();
+
+    // First, walk up from the start dir looking for an INITIALIZED
+    // .crosslink (works in main repo). Stray dirs are skipped, not bound.
     loop {
         let candidate = current.join(".crosslink");
         if candidate.is_dir() {
-            return Ok(candidate);
+            if is_initialized_crosslink_dir(&candidate) {
+                for stray in &skipped_strays {
+                    tracing::warn!(
+                        "ignoring stray .crosslink at {} (no hook-config.json — likely \
+                         created by cwd drift, GH#625); using {} — consider deleting \
+                         the stray",
+                        stray.display(),
+                        candidate.display()
+                    );
+                }
+                return Ok(candidate);
+            }
+            skipped_strays.push(candidate);
         }
 
         if !current.pop() {
@@ -2157,14 +2186,36 @@ fn find_crosslink_dir() -> Result<PathBuf> {
     }
 
     // Not found — check if we're in a git worktree and look in the main repo root
-    if let Some(main_root) = utils::resolve_main_repo_root(&start) {
+    if let Some(main_root) = utils::resolve_main_repo_root(start) {
         let candidate = main_root.join(".crosslink");
-        if candidate.is_dir() {
+        if candidate.is_dir() && is_initialized_crosslink_dir(&candidate) {
             return Ok(candidate);
         }
     }
 
-    bail!("Not a crosslink repository (or any parent). Run 'crosslink init' first.");
+    if skipped_strays.is_empty() {
+        bail!("Not a crosslink repository (or any parent). Run 'crosslink init' first.");
+    }
+    bail!(
+        "Not a crosslink repository (or any parent). Found stray uninitialized \
+         .crosslink director{} (no hook-config.json) at: {} — likely created by \
+         cwd drift (GH#625). Delete {} or run 'crosslink init' at the project root.",
+        if skipped_strays.len() == 1 {
+            "y"
+        } else {
+            "ies"
+        },
+        skipped_strays
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", "),
+        if skipped_strays.len() == 1 {
+            "it"
+        } else {
+            "them"
+        },
+    );
 }
 
 fn get_db() -> Result<Database> {
@@ -3402,5 +3453,81 @@ fn main() -> Result<()> {
                 crosslink_dir,
             ))
         }
+    }
+}
+
+#[cfg(test)]
+mod find_crosslink_dir_tests {
+    use super::find_crosslink_dir_from;
+
+    fn mk_initialized(dir: &std::path::Path) {
+        let cl = dir.join(".crosslink");
+        std::fs::create_dir_all(&cl).unwrap();
+        std::fs::write(cl.join("hook-config.json"), "{}").unwrap();
+    }
+
+    fn mk_stray(dir: &std::path::Path) {
+        // GH#625 stray shape: hydration cache only, no hook-config.json.
+        let cl = dir.join(".crosslink");
+        std::fs::create_dir_all(cl.join(".cache")).unwrap();
+        std::fs::write(cl.join("issues.db"), b"sqlite").unwrap();
+    }
+
+    #[test]
+    fn binds_initialized_dir_directly() {
+        let root = tempfile::tempdir().unwrap();
+        mk_initialized(root.path());
+        let found = find_crosslink_dir_from(root.path()).unwrap();
+        assert_eq!(found, root.path().join(".crosslink"));
+    }
+
+    #[test]
+    fn skips_stray_in_subdir_and_binds_root() {
+        // The GH#625 scenario: cwd drifted to web/, which holds a stray.
+        let root = tempfile::tempdir().unwrap();
+        mk_initialized(root.path());
+        let web = root.path().join("web");
+        std::fs::create_dir_all(&web).unwrap();
+        mk_stray(&web);
+
+        let found = find_crosslink_dir_from(&web).unwrap();
+        assert_eq!(
+            found,
+            root.path().join(".crosslink"),
+            "must bind the initialized root, not the stray"
+        );
+    }
+
+    #[test]
+    fn stray_only_errors_naming_the_stray() {
+        let root = tempfile::tempdir().unwrap();
+        let web = root.path().join("web");
+        std::fs::create_dir_all(&web).unwrap();
+        mk_stray(&web);
+
+        let err = find_crosslink_dir_from(&web).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("stray") && msg.contains("GH#625"),
+            "error must explain the stray, got: {msg}"
+        );
+        assert!(
+            msg.contains(&web.join(".crosslink").display().to_string()),
+            "error must name the stray path, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn nested_initialized_dir_still_wins_over_parent() {
+        // An intentionally initialized nested project (has hook-config.json)
+        // must keep binding locally -- the marker, not depth, decides.
+        let root = tempfile::tempdir().unwrap();
+        mk_initialized(root.path());
+        let sub = root.path().join("subproject");
+        std::fs::create_dir_all(&sub).unwrap();
+        mk_initialized(&sub);
+
+        let found = find_crosslink_dir_from(&sub).unwrap();
+        assert_eq!(found, sub.join(".crosslink"));
     }
 }


### PR DESCRIPTION
## Summary

Fixes both stages of #625's two-stage failure:

**Stage 1 — the seeder** (`post-edit-check.py`): the lint-debounce marker was placed under `project_root/.crosslink/.cache`, where `project_root` is the nearest *package* root walking up from the **edited file** (`web/` with its `package.json` in a monorepo). `os.makedirs` then created the stray `web/.crosslink/` out of thin air. The marker now lives in the initialized crosslink dir (found via the shared GH#625-safe discovery); with no initialized dir, debounce is skipped rather than creating one. The hook structurally cannot create a `.crosslink` directory anymore.

**Stage 2 — the binders**: every discovery walk — the Rust `find_crosslink_dir` plus five hook-side copies (`crosslink_config.py`'s shared fn used by post-edit/prompt-guard/work-check, `pre-web-check.py`, `heartbeat.py`, `session-start.py`) — bound to the **first** `.crosslink` found walking up from cwd with no authenticity check, so once a stray existed the CLI hydrated a full duplicate `issues.db` into it.

All discovery now requires the `hook-config.json` marker: `crosslink init` always writes it, agent worktrees carry it, and #625's stray evidence shows it is exactly what strays lack. The CLI skips strays with a WARN naming them and suggesting deletion; hooks skip silently (they must stay quiet); the stray-only case is an actionable error naming the path. Intentionally initialized nested projects keep winning over parents — the marker, not depth, decides.

## Testing

- `find_crosslink_dir` refactored to a pure `find_crosslink_dir_from(start)`; four new tests including the exact reported repro shape (stray in `web/`, initialized root above → binds root) and the nested-initialized-project edge.
- 1767 lib + 2780 bin + 194 CLI integration green; fmt and both clippy gates clean.
- The editing repo's live hooks were synced and ran throughout the change — every Edit in this PR went through the fixed post-edit hook.

Fixes #625

Generated with [Claude Code](https://claude.com/claude-code)