### PR TITLE
fix(hooks): blocking messages to stderr -- Claude Code drops stdout on exit 2 (GH#624)

### DIFF
--- a/crosslink/resources/claude/hooks/pre-web-check.py
+++ b/crosslink/resources/claude/hooks/pre-web-check.py
@@ -126,7 +126,12 @@ def main():
         input_data = json.load(sys.stdin)
         tool_name = input_data.get('tool_name', '')
     except (json.JSONDecodeError, ValueError, TypeError):
-        print("pre-web-check: failed to parse stdin — blocking tool call (fail-closed)")
+        # GH#624: blocking messages MUST go to stderr — Claude Code only
+        # shows stderr to the model on exit 2; stdout is silently dropped.
+        print(
+            "pre-web-check: failed to parse stdin — blocking tool call (fail-closed)",
+            file=sys.stderr,
+        )
         sys.exit(2)
 
     # Find crosslink directory and load web rules

--- a/crosslink/resources/claude/hooks/work-check.py
+++ b/crosslink/resources/claude/hooks/work-check.py
@@ -296,11 +296,14 @@ def check_control_flags(crosslink_dir):
         except (json.JSONDecodeError, ValueError):
             state = {}
         if state.get("kill"):
+            # GH#624: blocking messages MUST go to stderr — Claude Code only
+            # shows stderr to the model on exit 2; stdout is silently dropped.
             print(
                 "AGENT KILL REQUESTED — an operator (dashboard or CLI) has "
                 "asked this agent to stop after the current tool use.\n"
                 "Acknowledge the request, summarise progress, then exit "
-                "your session cleanly. Do not attempt further tool calls."
+                "your session cleanly. Do not attempt further tool calls.",
+                file=sys.stderr,
             )
         else:
             hint = state.get("reprioritise")
@@ -314,7 +317,8 @@ def check_control_flags(crosslink_dir):
                 "AGENT PAUSED — an operator has paused this agent via the "
                 "dashboard. Tool use is blocked until they resume.\n"
                 "Wait for the resume signal or explain to the user that "
-                "you've been paused." + extra
+                "you've been paused." + extra,
+                file=sys.stderr,
             )
         sys.exit(2)
 
@@ -324,7 +328,10 @@ def main():
         input_data = json.load(sys.stdin)
         tool_name = input_data.get('tool_name', '')
     except (json.JSONDecodeError, ValueError, TypeError):
-        print("work-check: failed to parse stdin — blocking tool call (fail-closed)")
+        print(
+            "work-check: failed to parse stdin — blocking tool call (fail-closed)",
+            file=sys.stderr,
+        )
         sys.exit(2)
 
     # Only check on Write, Edit, Bash
@@ -360,7 +367,8 @@ def main():
             "--- INTERVENTION LOGGING ---\n"
             "Log this blocked action for the audit trail:\n"
             "  crosslink intervene <issue-id> \"Attempted: <command>\" "
-            "--trigger tool_blocked --context \"<what you were trying to accomplish>\""
+            "--trigger tool_blocked --context \"<what you were trying to accomplish>\"",
+            file=sys.stderr,
         )
         sys.exit(2)
 
@@ -381,7 +389,8 @@ def main():
                 "--- INTERVENTION LOGGING ---\n"
                 "If a human redirected you here, log the intervention:\n"
                 "  crosslink intervene <issue-id> \"Redirected to create issue before commit\" "
-                "--trigger redirect --context \"Attempted git commit without active issue\""
+                "--trigger redirect --context \"Attempted git commit without active issue\"",
+                file=sys.stderr,
             )
             sys.exit(2)
 
@@ -397,7 +406,7 @@ def main():
                     "This documents WHY the change was made, not just WHAT changed."
                 ).format(id=issue_id)
                 if comment_discipline == "required":
-                    print(msg)
+                    print(msg, file=sys.stderr)
                     sys.exit(2)
                 else:
                     print("Reminder: " + msg)
@@ -430,7 +439,7 @@ def main():
                     "This creates the audit trail for the work that was done."
                 ).format(id=issue_id)
                 if comment_discipline == "required":
-                    print(msg)
+                    print(msg, file=sys.stderr)
                     sys.exit(2)
                 else:
                     print("Reminder: " + msg)
@@ -501,7 +510,7 @@ def main():
     )
 
     if tracking_mode == "strict":
-        print(strict_msg)
+        print(strict_msg, file=sys.stderr)
         sys.exit(2)
     else:
         # normal mode: remind but allow


### PR DESCRIPTION
## Summary

Fixes #624: every blocking message in the hook scripts printed to **stdout** before `sys.exit(2)`, but Claude Code's hook contract only shows **stderr** to the model on exit 2 — so every block rendered as `No stderr output`. The agent never saw "create an issue first", the comment-discipline instructions, or the git-push prohibition, and retried blind.

(Live evidence: the session that produced this PR hit the symptom repeatedly while fixing other issues — every hook block all day was an opaque `No stderr output`.)

All eight pre-`exit(2)` prints flipped to `file=sys.stderr`:

- `work-check.py` (7): operator kill/pause, fail-closed stdin parse, permanent git-mutation block, gated `git commit`, required comment discipline on commit and on close, strict-mode no-active-issue block.
- `pre-web-check.py` (1): fail-closed stdin parse.

Non-blocking exit-0 reminder prints stay on stdout untouched — exit-0 stdout has its own contract (JSON control signals).

## Verification

Empirical, both paths: garbage stdin → exit 2, empty stdout, message on stderr; a `git push` payload → exit 2, **zero stdout bytes**, full MANDATORY block text on stderr. `python3 -m py_compile` clean on both files; 194 CLI integration tests green (hook deployment content-agnostic).

Fixes #624

Generated with [Claude Code](https://claude.com/claude-code)