### PR TITLE
fix(init,sentinel): actionable cpitd install UX; cpitd gets a real job (GH#621)

### DIFF
--- a/.claude/hooks/work-check.py
+++ b/.claude/hooks/work-check.py
@@ -57,6 +57,14 @@ DEFAULT_ALLOWED_BASH = [
     "npm test", "npm run", "npx ",
     "tsc", "node ", "python ",
     "ls", "dir", "pwd", "echo",
+    # GitHub CLI and common read-only / infrastructure commands (#522)
+    "gh ",
+    "cat ", "head ", "tail ", "wc ",
+    "grep ", "rg ", "find ", "sort ", "uniq ",
+    "which ", "command ",
+    "mktemp", "sleep ",
+    "date", "env", "uname", "id ",
+    "basename ", "dirname ", "realpath ", "stat ", "file ",
 ]
 
 
@@ -149,13 +157,39 @@ def is_gated_git(input_data, gated_list):
     return _matches_command_list(command, gated_list)
 
 
-def is_allowed_bash(input_data, allowed_list):
-    """Check if a Bash command is on the allow list (read-only/infra)."""
-    command = input_data.get("tool_input", {}).get("command", "").strip()
+def _is_single_command_allowed(command, allowed_list):
+    """Check if a single (non-chained) command matches any allow-list prefix."""
     for prefix in allowed_list:
         if command.startswith(prefix):
             return True
     return False
+
+
+def is_allowed_bash(input_data, allowed_list):
+    """Check if a Bash command is on the allow list (read-only/infra).
+
+    Splits on chain operators (&&, ;, |) and requires EVERY subcommand
+    to match the allow list. A single non-allowed subcommand fails the
+    entire chain, preventing bypass via 'allowed_cmd ; malicious_cmd'.
+    """
+    command = input_data.get("tool_input", {}).get("command", "").strip()
+    if not command:
+        return False
+
+    # Split on all chain operators to get individual commands
+    parts = [command]
+    for sep in (" && ", " ; ", " | "):
+        expanded = []
+        for part in parts:
+            expanded.extend(part.split(sep))
+        parts = expanded
+
+    # Every non-empty subcommand must be on the allow list
+    for part in parts:
+        part = part.strip()
+        if part and not _is_single_command_allowed(part, allowed_list):
+            return False
+    return True
 
 
 def is_claude_memory_path(input_data):
@@ -231,16 +265,82 @@ def is_issue_close_command(input_data):
     return None
 
 
+def check_control_flags(crosslink_dir):
+    """Block tool use when an operator has set the pause / kill flag
+    via the dashboard's agent-request protocol.
+
+    Calls `crosslink agent flags --strict` which exits 2 when blocking
+    flags are set. We re-emit a friendly explanation and exit 2
+    ourselves so the model sees a useful refusal, not a raw exit code.
+    """
+    if not crosslink_dir:
+        return
+    import subprocess
+    try:
+        proc = subprocess.run(
+            ["crosslink", "agent", "flags", "--strict"],
+            capture_output=True,
+            text=True,
+            cwd=crosslink_dir,
+            timeout=3,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        # crosslink not on PATH or hung — fail open (don't block) so
+        # missing tooling never wedges Claude Code.
+        return
+    if proc.returncode == 0:
+        return
+    if proc.returncode == 2:
+        try:
+            state = json.loads(proc.stdout.strip())
+        except (json.JSONDecodeError, ValueError):
+            state = {}
+        if state.get("kill"):
+            # GH#624: blocking messages MUST go to stderr — Claude Code only
+            # shows stderr to the model on exit 2; stdout is silently dropped.
+            print(
+                "AGENT KILL REQUESTED — an operator (dashboard or CLI) has "
+                "asked this agent to stop after the current tool use.\n"
+                "Acknowledge the request, summarise progress, then exit "
+                "your session cleanly. Do not attempt further tool calls.",
+                file=sys.stderr,
+            )
+        else:
+            hint = state.get("reprioritise")
+            extra = ""
+            if hint:
+                extra = (
+                    f"\nReprioritise hint pending: switch focus to issue "
+                    f"#{hint.get('issue_id')} when resuming."
+                )
+            print(
+                "AGENT PAUSED — an operator has paused this agent via the "
+                "dashboard. Tool use is blocked until they resume.\n"
+                "Wait for the resume signal or explain to the user that "
+                "you've been paused." + extra,
+                file=sys.stderr,
+            )
+        sys.exit(2)
+
+
 def main():
     try:
         input_data = json.load(sys.stdin)
         tool_name = input_data.get('tool_name', '')
-    except (json.JSONDecodeError, Exception):
-        tool_name = ''
+    except (json.JSONDecodeError, ValueError, TypeError):
+        print(
+            "work-check: failed to parse stdin — blocking tool call (fail-closed)",
+            file=sys.stderr,
+        )
+        sys.exit(2)
 
     # Only check on Write, Edit, Bash
     if tool_name not in ('Write', 'Edit', 'Bash'):
         sys.exit(0)
+
+    # Operator-driven kill / pause flags from the dashboard's agent-
+    # request protocol take priority over everything else.
+    check_control_flags(find_crosslink_dir())
 
     # Allow Claude Code to manage its own memory/config in ~/.claude/
     if tool_name in ('Write', 'Edit') and is_claude_memory_path(input_data):
@@ -267,7 +367,8 @@ def main():
             "--- INTERVENTION LOGGING ---\n"
             "Log this blocked action for the audit trail:\n"
             "  crosslink intervene <issue-id> \"Attempted: <command>\" "
-            "--trigger tool_blocked --context \"<what you were trying to accomplish>\""
+            "--trigger tool_blocked --context \"<what you were trying to accomplish>\"",
+            file=sys.stderr,
         )
         sys.exit(2)
 
@@ -288,7 +389,8 @@ def main():
                 "--- INTERVENTION LOGGING ---\n"
                 "If a human redirected you here, log the intervention:\n"
                 "  crosslink intervene <issue-id> \"Redirected to create issue before commit\" "
-                "--trigger redirect --context \"Attempted git commit without active issue\""
+                "--trigger redirect --context \"Attempted git commit without active issue\"",
+                file=sys.stderr,
             )
             sys.exit(2)
 
@@ -304,7 +406,7 @@ def main():
                     "This documents WHY the change was made, not just WHAT changed."
                 ).format(id=issue_id)
                 if comment_discipline == "required":
-                    print(msg)
+                    print(msg, file=sys.stderr)
                     sys.exit(2)
                 else:
                     print("Reminder: " + msg)
@@ -337,7 +439,7 @@ def main():
                     "This creates the audit trail for the work that was done."
                 ).format(id=issue_id)
                 if comment_discipline == "required":
-                    print(msg)
+                    print(msg, file=sys.stderr)
                     sys.exit(2)
                 else:
                     print("Reminder: " + msg)
@@ -353,7 +455,19 @@ def main():
     if not crosslink_dir:
         sys.exit(0)
 
-    # Check session status
+    # Fast path: check sentinel file written by `crosslink session work` / `quick` (#522).
+    # Avoids spawning a subprocess (~100ms) on every non-allowlisted Bash call.
+    sentinel = os.path.join(crosslink_dir, ".active-issue")
+    if os.path.isfile(sentinel):
+        try:
+            with open(sentinel) as f:
+                content = f.read().strip()
+            if content:
+                sys.exit(0)
+        except OSError:
+            pass  # Fall through to subprocess check
+
+    # Slow path: sentinel missing or empty — fall back to session status subprocess
     status = run_crosslink(["session", "status"], crosslink_dir)
     if not status:
         # crosslink not available — don't block
@@ -396,7 +510,7 @@ def main():
     )
 
     if tracking_mode == "strict":
-        print(strict_msg)
+        print(strict_msg, file=sys.stderr)
         sys.exit(2)
     else:
         # normal mode: remind but allow

--- a/crosslink/resources/claude/commands/maintain.md
+++ b/crosslink/resources/claude/commands/maintain.md
@@ -113,6 +113,17 @@ For each finding, decide:
 - **Fix now** if it's a quick cleanup (remove unused import, delete dead code)
 - **File issue** if it requires more work: `crosslink issue create "<description>" -p low --label maintenance`
 
+#### Code clones (cpitd)
+
+If the `cpitd` binary is present, scan for duplicated code and review existing clone issues:
+
+```bash
+command -v cpitd >/dev/null 2>&1 && crosslink cpitd scan || echo "cpitd not installed — skip (optional; install via pipx install cpitd)"
+crosslink cpitd status
+```
+
+`crosslink cpitd scan` files each detected clone as a `cpitd`-labelled crosslink issue (existing clones get a rescan comment), and `cpitd status` lists the open clone issues. Review the reported clones the same way as other debt: extract shared logic for quick wins, or leave the filed issue for larger refactors.
+
 ### 5. Documentation freshness
 
 Check that key documentation files exist and aren't stale:

--- a/crosslink/src/commands/config_registry.rs
+++ b/crosslink/src/commands/config_registry.rs
@@ -210,6 +210,27 @@ pub static REGISTRY: &[ConfigKey] = &[
         hot_swappable: true,
     },
     ConfigKey {
+        key: "sentinel.sources.cpitd.enabled",
+        config_type: ConfigType::Bool,
+        description: "Enable periodic cpitd clone-detection source (default off)",
+        group: ConfigGroup::Sentinel,
+        hot_swappable: true,
+    },
+    ConfigKey {
+        key: "sentinel.sources.cpitd.interval_hours",
+        config_type: ConfigType::Integer,
+        description: "Hours between cpitd clone scans (default 168 = weekly)",
+        group: ConfigGroup::Sentinel,
+        hot_swappable: true,
+    },
+    ConfigKey {
+        key: "sentinel.sources.cpitd.min_tokens",
+        config_type: ConfigType::Integer,
+        description: "Minimum token sequence length cpitd reports as a clone (default 50)",
+        group: ConfigGroup::Sentinel,
+        hot_swappable: true,
+    },
+    ConfigKey {
         key: "sentinel.default_agent.model",
         config_type: ConfigType::String,
         description: "Default model for sentinel-dispatched agents",

--- a/crosslink/src/commands/cpitd.rs
+++ b/crosslink/src/commands/cpitd.rs
@@ -67,6 +67,14 @@ struct CpitdCloneGroup {
 // Installation detection
 // ---------------------------------------------------------------------------
 
+/// Whether the `cpitd` binary is resolvable on PATH.
+///
+/// Exposed so non-CLI callers (e.g. the sentinel cpitd source) can gate on
+/// the binary's presence and degrade gracefully when it's absent.
+pub fn cpitd_available() -> bool {
+    find_cpitd()
+}
+
 fn find_cpitd() -> bool {
     Command::new("cpitd")
         .arg("--version")
@@ -235,6 +243,59 @@ fn relate_clone_issues(db: &Database, created: &[(i64, String, String)]) {
 // Public commands
 // ---------------------------------------------------------------------------
 
+/// Outcome of a clone scan: the crosslink issue ids that were created or
+/// updated. `created` holds `(id, file_a, file_b)` so callers can relate or
+/// surface newly-filed clones; `updated` holds ids that already existed and
+/// got a rescan comment.
+#[derive(Debug, Default)]
+pub struct ScanOutcome {
+    /// Newly created clone issues: `(issue_id, file_a, file_b)`.
+    pub created: Vec<(i64, String, String)>,
+    /// Existing clone issues that were re-confirmed and commented on.
+    pub updated: Vec<i64>,
+}
+
+/// Core scan-and-file-issues logic, usable as a library function.
+///
+/// Shells to `cpitd`, parses its JSON, and files/updates crosslink clone
+/// issues, returning the created/updated issue ids. Emits no progress output
+/// (the CLI wrapper handles user-facing prints). The caller must ensure the
+/// `cpitd` binary is present (see [`cpitd_available`]); if it is absent this
+/// returns an error from the underlying command.
+pub fn scan_and_file(
+    db: &Database,
+    paths: &[String],
+    min_tokens: u32,
+    ignore_patterns: &[String],
+) -> Result<ScanOutcome> {
+    let output = run_cpitd(paths, min_tokens, ignore_patterns)?;
+
+    let mut outcome = ScanOutcome::default();
+
+    for report in &output.clone_reports {
+        if let Some(existing_id) = find_existing_clone_issue(db, &report.file_a, &report.file_b)? {
+            let comment = format!(
+                "[cpitd rescan] {} total cloned lines, {} group(s)",
+                report.total_cloned_lines,
+                report.groups.len(),
+            );
+            db.add_comment(existing_id, &comment, "note")?;
+            outcome.updated.push(existing_id);
+        } else {
+            let id = create_clone_issue(db, report, true)?;
+            outcome
+                .created
+                .push((id, report.file_a.clone(), report.file_b.clone()));
+        }
+    }
+
+    if outcome.created.len() > 1 {
+        relate_clone_issues(db, &outcome.created);
+    }
+
+    Ok(outcome)
+}
+
 pub fn scan(
     db: &Database,
     paths: &[String],
@@ -251,20 +312,17 @@ pub fn scan(
         println!("Running cpitd clone detection...");
     }
 
-    let output = run_cpitd(paths, min_tokens, ignore_patterns)?;
-
-    if output.clone_reports.is_empty() {
-        if !quiet {
-            println!("No code clones detected.");
-        }
-        return Ok(());
-    }
-
-    if !quiet {
-        println!("Found {} clone pair(s).\n", output.total_pairs);
-    }
-
     if dry_run {
+        let output = run_cpitd(paths, min_tokens, ignore_patterns)?;
+        if output.clone_reports.is_empty() {
+            if !quiet {
+                println!("No code clones detected.");
+            }
+            return Ok(());
+        }
+        if !quiet {
+            println!("Found {} clone pair(s).\n", output.total_pairs);
+        }
         for report in &output.clone_reports {
             println!(
                 "  Would create: {} <-> {} ({} lines, {} group(s))",
@@ -277,38 +335,32 @@ pub fn scan(
         return Ok(());
     }
 
-    let mut created_count = 0usize;
-    let mut updated_count = 0usize;
-    let mut created_ids: Vec<(i64, String, String)> = Vec::new();
+    let outcome = scan_and_file(db, paths, min_tokens, ignore_patterns)?;
 
-    for report in &output.clone_reports {
-        if let Some(existing_id) = find_existing_clone_issue(db, &report.file_a, &report.file_b)? {
-            let comment = format!(
-                "[cpitd rescan] {} total cloned lines, {} group(s)",
-                report.total_cloned_lines,
-                report.groups.len(),
-            );
-            db.add_comment(existing_id, &comment, "note")?;
-            updated_count += 1;
-            if !quiet {
-                println!(
-                    "  Updated issue {} (clone still present)",
-                    format_issue_id(existing_id)
-                );
-            }
-        } else {
-            let id = create_clone_issue(db, report, quiet)?;
-            created_ids.push((id, report.file_a.clone(), report.file_b.clone()));
-            created_count += 1;
+    if outcome.created.is_empty() && outcome.updated.is_empty() {
+        if !quiet {
+            println!("No code clones detected.");
         }
-    }
-
-    if created_ids.len() > 1 {
-        relate_clone_issues(db, &created_ids);
+        return Ok(());
     }
 
     if !quiet {
-        println!("\ncpitd scan complete: {created_count} created, {updated_count} updated");
+        for (id, _, _) in &outcome.created {
+            // Title already printed by create_clone_issue when not quiet; but
+            // scan_and_file runs quiet, so surface the created ids here.
+            println!("  Created issue {}", format_issue_id(*id));
+        }
+        for id in &outcome.updated {
+            println!(
+                "  Updated issue {} (clone still present)",
+                format_issue_id(*id)
+            );
+        }
+        println!(
+            "\ncpitd scan complete: {} created, {} updated",
+            outcome.created.len(),
+            outcome.updated.len()
+        );
     }
 
     Ok(())

--- a/crosslink/src/commands/init/mod.rs
+++ b/crosslink/src/commands/init/mod.rs
@@ -1153,7 +1153,30 @@ pub fn run(path: &Path, opts: &InitOpts<'_>) -> Result<()> {
                 // Finish the step_start line, then show warning below
                 println!();
                 ui.warn(&format!("Could not auto-install cpitd: {e}"));
-                ui.detail("You can install it manually: pip install cpitd");
+                if e.externally_managed {
+                    // PEP 668: the system Python is externally managed, so plain
+                    // `pip install` (and `pip install --user`) are refused. Give
+                    // the specific, working paths instead of a useless suggestion.
+                    ui.detail(
+                        "This Python is externally managed (PEP 668), so `pip install` is blocked.",
+                    );
+                    ui.detail("To install cpitd, pick one of:");
+                    ui.detail("  1. Install pipx, then cpitd into its own isolated env:");
+                    ui.detail("       apt install pipx   (or: brew install pipx)");
+                    ui.detail("       pipx install cpitd");
+                    ui.detail("  2. Create a virtualenv and install there:");
+                    ui.detail("       python3 -m venv .venv && . .venv/bin/activate");
+                    ui.detail("       pip install cpitd");
+                    ui.detail("  3. Re-run init without cpitd: crosslink init --skip-cpitd");
+                } else {
+                    ui.detail(
+                        "To install cpitd: pipx install cpitd  (or in a venv: pip install cpitd)",
+                    );
+                    ui.detail("Or re-run init without it: crosslink init --skip-cpitd");
+                }
+                ui.detail(
+                    "cpitd is OPTIONAL: only `crosslink cpitd scan` and the sentinel cpitd source use it; everything else works without it.",
+                );
             }
         }
     }

--- a/crosslink/src/commands/init/python.rs
+++ b/crosslink/src/commands/init/python.rs
@@ -1,6 +1,5 @@
 //! Python toolchain detection and cpitd installation.
 
-use anyhow::{Context, Result};
 use std::fs;
 use std::path::Path;
 
@@ -63,13 +62,126 @@ fn cpitd_is_installed() -> bool {
         .is_ok_and(|o| o.status.success())
 }
 
+/// Check whether a program is resolvable on PATH (used to gate pipx).
+fn program_on_path(program: &str) -> bool {
+    // `--version` is universally supported by pip/pipx; a successful exit (or
+    // even a clean run) proves the program resolves. We only care about
+    // resolvability, not the exact version.
+    std::process::Command::new(program)
+        .arg("--version")
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
 const CPITD_REPO_URL: &str = "https://github.com/scythia-marrow/cpitd.git";
 
-/// Install cpitd using the detected Python toolchain.
-/// Returns Ok(true) if installed, Ok(false) if already present, Err on failure.
+/// Classification of why an install command failed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum InstallFailureKind {
+    /// pip refused because the environment is PEP 668 externally-managed.
+    ExternallyManaged,
+    /// Any other failure (network, missing program, build error, …).
+    Other,
+}
+
+/// Classify an install command's stderr to detect the PEP 668
+/// "externally-managed-environment" condition.
 ///
-/// Tries `pip install cpitd` first (`PyPI`). If that fails, falls back to
-/// cloning the git repo into a temp directory and installing from source.
+/// On modern Debian/Ubuntu/Homebrew Python builds, `pip install` (and
+/// `pip install --user`) refuse to run against the system interpreter and
+/// print an `error: externally-managed-environment` block. We detect that
+/// marker so the final guidance can be specific (pipx / venv) rather than
+/// the useless "pip install cpitd" suggestion from before.
+pub(super) fn classify_install_failure(stderr: &str) -> InstallFailureKind {
+    let lowered = stderr.to_ascii_lowercase();
+    if lowered.contains("externally-managed-environment")
+        || lowered.contains("externally managed environment")
+    {
+        InstallFailureKind::ExternallyManaged
+    } else {
+        InstallFailureKind::Other
+    }
+}
+
+/// A single `PyPI` install candidate: the program plus its argument vector.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct InstallCandidate {
+    pub program: String,
+    pub args: Vec<String>,
+}
+
+impl InstallCandidate {
+    fn new(program: &str, args: &[&str]) -> Self {
+        Self {
+            program: program.to_string(),
+            args: args.iter().map(|s| (*s).to_string()).collect(),
+        }
+    }
+}
+
+/// Derive the pip executable path from a `.venv` python prefix.
+fn venv_pip(python_prefix: &str) -> String {
+    python_prefix
+        .replace("python3", "pip")
+        .replace("python.exe", "pip.exe")
+        .replace("python", "pip")
+}
+
+/// Build the ordered list of `PyPI` install candidates for `cpitd`, given the
+/// detected python prefix and whether `pipx` is resolvable on PATH.
+///
+/// Ordering rationale (system-python case):
+///   1. `pipx install cpitd` — the canonical PEP 668 answer; installs into an
+///      isolated venv and exposes the entry point on PATH. Only offered when
+///      pipx is actually present (PEP 668 distros don't ship it by default).
+///   2. `pip install --user cpitd` — works on non-PEP-668 systems; on PEP 668
+///      systems it ALSO fails with externally-managed, but trying it is cheap
+///      and its failure is what produces the actionable marker.
+///   3. `python3 -m pip install cpitd` — plain system install; last pip resort.
+///
+/// Managed toolchains (uv/poetry/pipenv/.venv) install into their own
+/// environment and are never PEP 668 affected, so they get a single direct
+/// candidate.
+pub(super) fn build_install_candidates(
+    python_prefix: &str,
+    pipx_available: bool,
+) -> Vec<InstallCandidate> {
+    if python_prefix.starts_with("uv ") {
+        return vec![InstallCandidate::new("uv", &["pip", "install", "cpitd"])];
+    }
+    if python_prefix.starts_with("poetry ") {
+        return vec![InstallCandidate::new(
+            "poetry",
+            &["add", "--group", "dev", "cpitd"],
+        )];
+    }
+    if python_prefix.starts_with(".venv/") || python_prefix.starts_with(".venv\\") {
+        let pip = venv_pip(python_prefix);
+        return vec![InstallCandidate::new(&pip, &["install", "cpitd"])];
+    }
+    if python_prefix.starts_with("pipenv ") {
+        return vec![InstallCandidate::new(
+            "pipenv",
+            &["install", "--dev", "cpitd"],
+        )];
+    }
+
+    // System python: pipx first (when present), then pip --user, then plain pip.
+    let mut candidates = Vec::new();
+    if pipx_available {
+        candidates.push(InstallCandidate::new("pipx", &["install", "cpitd"]));
+    }
+    candidates.push(InstallCandidate::new(
+        "python3",
+        &["-m", "pip", "install", "--user", "cpitd"],
+    ));
+    candidates.push(InstallCandidate::new(
+        "python3",
+        &["-m", "pip", "install", "cpitd"],
+    ));
+    candidates
+}
+
 /// Result of cpitd installation attempt.
 pub(super) enum CpitdResult {
     AlreadyInstalled,
@@ -77,50 +189,90 @@ pub(super) enum CpitdResult {
     InstalledFromSource,
 }
 
-pub(super) fn install_cpitd(python_prefix: &str) -> Result<CpitdResult> {
+/// Detailed failure carried out of `install_cpitd` so the caller can render
+/// actionable guidance when (and only when) PEP 668 blocked every attempt.
+pub(super) struct CpitdInstallError {
+    /// The last underlying error message (from the final failed candidate).
+    pub message: String,
+    /// Whether any attempt failed specifically due to PEP 668.
+    pub externally_managed: bool,
+}
+
+impl std::fmt::Display for CpitdInstallError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+/// Install cpitd using the detected Python toolchain.
+///
+/// Chain (system python): `pipx install cpitd` (when pipx is on PATH) ->
+/// `pip install --user cpitd` -> `pip install cpitd` -> git-source fallback.
+/// Managed toolchains (uv/poetry/pipenv/.venv) install directly into their
+/// own environment. Records whether any attempt hit PEP 668
+/// externally-managed so the caller can show specific guidance.
+pub(super) fn install_cpitd(
+    python_prefix: &str,
+) -> std::result::Result<CpitdResult, CpitdInstallError> {
     if cpitd_is_installed() {
         return Ok(CpitdResult::AlreadyInstalled);
     }
 
-    // First attempt: install from PyPI
-    let pypi_result = install_cpitd_from_pypi(python_prefix);
-    if matches!(pypi_result, Ok(true)) {
-        return Ok(CpitdResult::InstalledFromPypi);
+    let pipx_available = program_on_path("pipx");
+    let candidates = build_install_candidates(python_prefix, pipx_available);
+
+    let mut saw_externally_managed = false;
+    // Track the most actionable pip failure message; the PEP 668 block is far
+    // more useful to surface than a later git-clone error.
+    let mut pep668_message: Option<String> = None;
+
+    for candidate in &candidates {
+        let arg_refs: Vec<&str> = candidate.args.iter().map(String::as_str).collect();
+        match run_install_command(&candidate.program, &arg_refs) {
+            Ok(true) => return Ok(CpitdResult::InstalledFromPypi),
+            Ok(false) => {}
+            Err(failure) => {
+                if failure.kind == InstallFailureKind::ExternallyManaged {
+                    saw_externally_managed = true;
+                    pep668_message.get_or_insert(failure.message);
+                }
+            }
+        }
     }
 
-    // Second attempt: clone repo and install from source
+    // Final attempt: clone repo and install from source (still subject to the
+    // same PEP 668 constraint when installing into system python, but free for
+    // managed toolchains and offline-with-cache cases).
     match install_cpitd_from_source(python_prefix) {
         Ok(true) => Ok(CpitdResult::InstalledFromSource),
         Ok(false) => Ok(CpitdResult::AlreadyInstalled),
-        Err(e) => Err(e),
+        Err(failure) => {
+            if failure.kind == InstallFailureKind::ExternallyManaged {
+                saw_externally_managed = true;
+                if pep668_message.is_none() {
+                    pep668_message = Some(failure.message.clone());
+                }
+            }
+            // Prefer the PEP 668 message when we saw one — it is what the
+            // actionable guidance keys off — otherwise the final failure.
+            let message = pep668_message.unwrap_or(failure.message);
+            Err(CpitdInstallError {
+                message,
+                externally_managed: saw_externally_managed,
+            })
+        }
     }
 }
 
-/// Try installing cpitd from `PyPI` via pip/uv/poetry.
-fn install_cpitd_from_pypi(python_prefix: &str) -> Result<bool> {
-    if python_prefix.starts_with("uv ") {
-        return run_install_command("uv", &["pip", "install", "cpitd"]);
-    }
-    if python_prefix.starts_with("poetry ") {
-        return run_install_command("poetry", &["add", "--group", "dev", "cpitd"]);
-    }
-    if python_prefix.starts_with(".venv/") || python_prefix.starts_with(".venv\\") {
-        let pip = python_prefix
-            .replace("python3", "pip")
-            .replace("python.exe", "pip.exe")
-            .replace("python", "pip");
-        return run_install_command(&pip, &["install", "cpitd"]);
-    }
-    if python_prefix.starts_with("pipenv ") {
-        return run_install_command("pipenv", &["install", "--dev", "cpitd"]);
-    }
-
-    // Fallback: system python
-    run_install_command("python3", &["-m", "pip", "install", "cpitd"])
+/// A classified install-command failure (program failed to run, or it ran
+/// and exited non-zero with stderr we classify for PEP 668).
+struct CommandFailure {
+    message: String,
+    kind: InstallFailureKind,
 }
 
 /// Clone the cpitd repo to a temp directory and install from source.
-fn install_cpitd_from_source(python_prefix: &str) -> Result<bool> {
+fn install_cpitd_from_source(python_prefix: &str) -> std::result::Result<bool, CommandFailure> {
     let tmp_dir = std::env::temp_dir().join("crosslink-cpitd-install");
 
     // Clean up any previous failed attempt
@@ -134,13 +286,19 @@ fn install_cpitd_from_source(python_prefix: &str) -> Result<bool> {
         .args(["clone", "--depth", "1", CPITD_REPO_URL])
         .arg(&tmp_dir)
         .output()
-        .context("Failed to run git clone for cpitd")?;
+        .map_err(|e| CommandFailure {
+            message: format!("Failed to run git clone for cpitd: {e}"),
+            kind: InstallFailureKind::Other,
+        })?;
 
     if !clone_output.status.success() {
         let stderr = String::from_utf8_lossy(&clone_output.stderr);
         // INTENTIONAL: temp dir cleanup on failure is best-effort — OS will reclaim it eventually
         let _ = fs::remove_dir_all(&tmp_dir);
-        anyhow::bail!("git clone failed: {}", stderr.trim());
+        return Err(CommandFailure {
+            message: format!("git clone failed: {}", stderr.trim()),
+            kind: InstallFailureKind::Other,
+        });
     }
 
     let tmp_dir_str = tmp_dir.to_string_lossy();
@@ -153,10 +311,7 @@ fn install_cpitd_from_source(python_prefix: &str) -> Result<bool> {
         // fall back to pip inside the poetry env
         run_install_command("poetry", &["run", "pip", "install", &tmp_dir_str])
     } else if python_prefix.starts_with(".venv/") || python_prefix.starts_with(".venv\\") {
-        let pip = python_prefix
-            .replace("python3", "pip")
-            .replace("python.exe", "pip.exe")
-            .replace("python", "pip");
+        let pip = venv_pip(python_prefix);
         run_install_command(&pip, &["install", &tmp_dir_str])
     } else if python_prefix.starts_with("pipenv ") {
         run_install_command("pipenv", &["run", "pip", "install", &tmp_dir_str])
@@ -170,16 +325,140 @@ fn install_cpitd_from_source(python_prefix: &str) -> Result<bool> {
     result
 }
 
-fn run_install_command(program: &str, args: &[&str]) -> Result<bool> {
+fn run_install_command(program: &str, args: &[&str]) -> std::result::Result<bool, CommandFailure> {
     let output = std::process::Command::new(program)
         .args(args)
         .output()
-        .with_context(|| format!("Failed to run {} {}", program, args.join(" ")))?;
+        .map_err(|e| CommandFailure {
+            message: format!("Failed to run {} {}: {e}", program, args.join(" ")),
+            kind: InstallFailureKind::Other,
+        })?;
 
     if output.status.success() {
         Ok(true)
     } else {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("cpitd install failed: {}", stderr.trim());
+        let kind = classify_install_failure(&stderr);
+        Err(CommandFailure {
+            message: format!("cpitd install failed: {}", stderr.trim()),
+            kind,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PEP668_STDERR: &str = "error: externally-managed-environment\n\
+        \n\
+        × This environment is externally managed\n\
+        ╰─> To install Python packages system-wide, try apt install ...";
+
+    #[test]
+    fn classify_detects_pep668() {
+        assert_eq!(
+            classify_install_failure(PEP668_STDERR),
+            InstallFailureKind::ExternallyManaged
+        );
+    }
+
+    #[test]
+    fn classify_detects_pep668_case_insensitive() {
+        assert_eq!(
+            classify_install_failure("ERROR: Externally-Managed-Environment blah"),
+            InstallFailureKind::ExternallyManaged
+        );
+        // Spaced variant some tooling prints.
+        assert_eq!(
+            classify_install_failure("this environment is externally managed environment"),
+            InstallFailureKind::ExternallyManaged
+        );
+    }
+
+    #[test]
+    fn classify_other_failures_are_other() {
+        assert_eq!(
+            classify_install_failure("ERROR: Could not find a version that satisfies cpitd"),
+            InstallFailureKind::Other
+        );
+        assert_eq!(
+            classify_install_failure("Network is unreachable"),
+            InstallFailureKind::Other
+        );
+        assert_eq!(classify_install_failure(""), InstallFailureKind::Other);
+    }
+
+    #[test]
+    fn system_chain_pipx_first_then_pip_user_then_pip() {
+        let candidates = build_install_candidates("python3", true);
+        assert_eq!(candidates.len(), 3);
+        assert_eq!(candidates[0].program, "pipx");
+        assert_eq!(candidates[0].args, vec!["install", "cpitd"]);
+        // pip --user before plain pip.
+        assert_eq!(candidates[1].program, "python3");
+        assert_eq!(
+            candidates[1].args,
+            vec!["-m", "pip", "install", "--user", "cpitd"]
+        );
+        assert_eq!(candidates[2].program, "python3");
+        assert_eq!(candidates[2].args, vec!["-m", "pip", "install", "cpitd"]);
+    }
+
+    #[test]
+    fn system_chain_skips_pipx_when_absent() {
+        let candidates = build_install_candidates("python3", false);
+        assert_eq!(candidates.len(), 2);
+        assert!(candidates.iter().all(|c| c.program != "pipx"));
+        assert_eq!(
+            candidates[0].args,
+            vec!["-m", "pip", "install", "--user", "cpitd"]
+        );
+        assert_eq!(candidates[1].args, vec!["-m", "pip", "install", "cpitd"]);
+    }
+
+    #[test]
+    fn uv_toolchain_single_candidate() {
+        let candidates = build_install_candidates("uv run python3", true);
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].program, "uv");
+        assert_eq!(candidates[0].args, vec!["pip", "install", "cpitd"]);
+    }
+
+    #[test]
+    fn poetry_toolchain_single_candidate() {
+        let candidates = build_install_candidates("poetry run python3", false);
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].program, "poetry");
+        assert_eq!(candidates[0].args, vec!["add", "--group", "dev", "cpitd"]);
+    }
+
+    #[test]
+    fn pipenv_toolchain_single_candidate() {
+        let candidates = build_install_candidates("pipenv run python3", true);
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].program, "pipenv");
+        assert_eq!(candidates[0].args, vec!["install", "--dev", "cpitd"]);
+    }
+
+    #[test]
+    fn venv_toolchain_uses_venv_pip() {
+        let candidates = build_install_candidates(".venv/bin/python3", true);
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].program, ".venv/bin/pip");
+        assert_eq!(candidates[0].args, vec!["install", "cpitd"]);
+    }
+
+    #[test]
+    fn managed_toolchains_never_offer_pipx() {
+        // pipx is only relevant for system python; managed envs are PEP 668 safe.
+        for prefix in ["uv run python3", "poetry run python3", "pipenv run python3"] {
+            let candidates = build_install_candidates(prefix, true);
+            assert!(candidates.iter().all(|c| c.program != "pipx"), "{prefix}");
+        }
     }
 }

--- a/crosslink/src/commands/sentinel/config.rs
+++ b/crosslink/src/commands/sentinel/config.rs
@@ -39,6 +39,7 @@ pub struct SourcesConfig {
     pub internal_hygiene: InternalHygieneConfig,
     pub github_ci: GitHubCIConfig,
     pub maintenance_sweep: MaintenanceSweepSourceConfig,
+    pub cpitd: CpitdSourceConfig,
 }
 
 /// GitHub label polling configuration.
@@ -104,6 +105,32 @@ impl Default for MaintenanceSweepSourceConfig {
 #[serde(default)]
 pub struct GitHubCIConfig {
     pub enabled: bool,
+}
+
+/// cpitd clone-detection source configuration.
+///
+/// Runs `cpitd` clone detection on an interval (default weekly) and files
+/// crosslink issues for newly detected clones, surfacing each as a sentinel
+/// signal. Disabled by default — clone scanning is a periodic, opt-in concern.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct CpitdSourceConfig {
+    pub enabled: bool,
+    /// Hours between clone scans (default 168 = weekly).
+    pub interval_hours: u64,
+    /// Minimum token sequence length to report (passthrough to cpitd, matches
+    /// the `crosslink cpitd scan` CLI default).
+    pub min_tokens: u32,
+}
+
+impl Default for CpitdSourceConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            interval_hours: 168,
+            min_tokens: 50,
+        }
+    }
 }
 
 /// Default agent settings for dispatched agents.

--- a/crosslink/src/commands/sentinel/engine.rs
+++ b/crosslink/src/commands/sentinel/engine.rs
@@ -91,6 +91,13 @@ fn poll_all_sources(
             ));
         }
     }
+    if config.sources.cpitd.enabled {
+        sources.push(Box::new(super::sources::cpitd::CpitdSource::new(
+            crosslink_dir,
+            config.sources.cpitd.interval_hours,
+            config.sources.cpitd.min_tokens,
+        )));
+    }
 
     let mut all_signals: Vec<Signal> = Vec::new();
     for source in &mut sources {

--- a/crosslink/src/commands/sentinel/sources/cpitd.rs
+++ b/crosslink/src/commands/sentinel/sources/cpitd.rs
@@ -1,0 +1,273 @@
+//! Sentinel source: periodic cpitd clone detection.
+//!
+//! On its configured interval (default weekly), runs the shared cpitd
+//! scan-and-file core (`crate::commands::cpitd::scan_and_file`), which shells
+//! to the `cpitd` binary and files crosslink issues for detected clones. Each
+//! NEWLY created clone issue is surfaced as a [`Signal`] so sentinel's normal
+//! dedup/dispatch/reporting pipeline applies.
+//!
+//! Graceful absence: when the `cpitd` binary is not on PATH, the source logs a
+//! single debug line and yields no signals (it never errors the sweep).
+//! Installation guidance lives in `crosslink init` (see
+//! `commands/init/python.rs`), not here.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+
+use super::{Signal, SignalKind, Source, SourceKind};
+use crate::commands::cpitd::ScanOutcome;
+use crate::db::Database;
+
+/// Filename (under the crosslink dir) where the last-scan timestamp persists.
+/// Mirrors sentinel's existing in-dir state-file convention (e.g.
+/// `sentinel.pid`, `sentinel.log`).
+const LAST_SCAN_FILE: &str = "sentinel-cpitd-last-scan";
+
+/// Function that runs a clone scan and files issues, returning the outcome.
+/// Boxed so tests can inject a fake without touching the real binary.
+type ScanFn = Box<dyn FnMut(&Database, u32) -> Result<ScanOutcome> + Send>;
+
+/// Predicate reporting whether the `cpitd` binary is available on PATH.
+/// Boxed so tests can simulate presence/absence.
+type AvailableFn = Box<dyn Fn() -> bool + Send>;
+
+/// Periodic clone-detection source.
+pub struct CpitdSource {
+    interval_hours: u64,
+    min_tokens: u32,
+    db_path: PathBuf,
+    state_file: PathBuf,
+    available: AvailableFn,
+    scan: ScanFn,
+}
+
+impl CpitdSource {
+    /// Construct the source with the real cpitd binary check and scan core.
+    pub fn new(crosslink_dir: &Path, interval_hours: u64, min_tokens: u32) -> Self {
+        Self {
+            interval_hours,
+            min_tokens,
+            db_path: crosslink_dir.join("issues.db"),
+            state_file: crosslink_dir.join(LAST_SCAN_FILE),
+            available: Box::new(crate::commands::cpitd::cpitd_available),
+            scan: Box::new(|db, min_tokens| {
+                crate::commands::cpitd::scan_and_file(db, &[], min_tokens, &[])
+            }),
+        }
+    }
+
+    /// Read the persisted last-scan timestamp, if any.
+    fn last_scan(&self) -> Option<DateTime<Utc>> {
+        let content = std::fs::read_to_string(&self.state_file).ok()?;
+        DateTime::parse_from_rfc3339(content.trim())
+            .ok()
+            .map(|dt| dt.with_timezone(&Utc))
+    }
+
+    /// Persist `when` as the last-scan timestamp (best-effort).
+    fn record_scan(&self, when: DateTime<Utc>) {
+        if let Err(e) = std::fs::write(&self.state_file, when.to_rfc3339()) {
+            tracing::warn!("failed to persist cpitd last-scan timestamp: {e}");
+        }
+    }
+
+    /// Whether the configured interval has elapsed since the last scan.
+    /// `now` is injected for deterministic testing.
+    fn interval_elapsed(&self, now: DateTime<Utc>) -> bool {
+        // No prior scan => always due.
+        self.last_scan().is_none_or(|last| {
+            now.signed_duration_since(last).num_hours() >= self.interval_hours as i64
+        })
+    }
+
+    /// Map a scan outcome's newly-created clone issues into signals.
+    fn outcome_to_signals(outcome: &ScanOutcome, now: DateTime<Utc>) -> Vec<Signal> {
+        outcome
+            .created
+            .iter()
+            .map(|(issue_id, file_a, file_b)| Signal {
+                source: SourceKind::Internal,
+                kind: SignalKind::CodeClone,
+                // Stable per-issue reference so seen_set dedup prevents
+                // re-signaling the same clone issue on later sweeps.
+                reference: format!("CPITD:CL#{issue_id}"),
+                title: format!("Code clone detected: {file_a} <-> {file_b}"),
+                body: format!(
+                    "cpitd detected duplicated code between `{file_a}` and `{file_b}`. \
+                     Filed as crosslink issue #{issue_id} (label: cpitd). \
+                     Consider extracting the shared logic."
+                ),
+                metadata: serde_json::json!({
+                    "type": "code_clone",
+                    "issue_id": issue_id,
+                    "file_a": file_a,
+                    "file_b": file_b,
+                }),
+                detected_at: now,
+            })
+            .collect()
+    }
+
+    /// Core poll, parameterized on `now` for testability.
+    fn poll_at(&mut self, now: DateTime<Utc>) -> Result<Vec<Signal>> {
+        // Graceful absence: one debug line, no signals, never an error.
+        if !(self.available)() {
+            tracing::debug!(
+                "cpitd binary not on PATH; skipping clone scan (install guidance: crosslink init)"
+            );
+            return Ok(Vec::new());
+        }
+
+        if !self.interval_elapsed(now) {
+            tracing::debug!("cpitd scan interval not elapsed; skipping");
+            return Ok(Vec::new());
+        }
+
+        let db = Database::open(&self.db_path)?;
+        let outcome = (self.scan)(&db, self.min_tokens)?;
+        self.record_scan(now);
+
+        Ok(Self::outcome_to_signals(&outcome, now))
+    }
+}
+
+impl Source for CpitdSource {
+    fn name(&self) -> &'static str {
+        "cpitd"
+    }
+
+    fn poll(&mut self) -> Result<Vec<Signal>> {
+        self.poll_at(Utc::now())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a source with injectable availability + scan fn, pointed at a temp
+    /// state file. Uses an in-memory-ish temp dir so no real binary/db is hit.
+    fn test_source(dir: &Path, interval_hours: u64, available: bool, scan: ScanFn) -> CpitdSource {
+        CpitdSource {
+            interval_hours,
+            min_tokens: 50,
+            db_path: dir.join("issues.db"),
+            state_file: dir.join(LAST_SCAN_FILE),
+            available: Box::new(move || available),
+            scan,
+        }
+    }
+
+    fn tmpdir() -> std::path::PathBuf {
+        let d = std::env::temp_dir().join(format!(
+            "cpitd-src-test-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    #[test]
+    fn binary_absent_yields_no_signals_no_error() {
+        let dir = tmpdir();
+        let scan_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let sc = scan_count.clone();
+        let scan: ScanFn = Box::new(move |_db, _mt| {
+            sc.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(ScanOutcome::default())
+        });
+        let mut src = test_source(&dir, 168, false, scan);
+
+        let signals = src.poll_at(Utc::now()).unwrap();
+        assert!(signals.is_empty());
+        // Absent binary must short-circuit before invoking the scan fn.
+        assert_eq!(scan_count.load(std::sync::atomic::Ordering::SeqCst), 0);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn interval_not_elapsed_skips_scan() {
+        let dir = tmpdir();
+        let now = Utc::now();
+        // Last scan 1 hour ago, interval 168h => not elapsed.
+        std::fs::write(
+            dir.join(LAST_SCAN_FILE),
+            (now - chrono::Duration::hours(1)).to_rfc3339(),
+        )
+        .unwrap();
+
+        let scanned = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let s = scanned.clone();
+        let scan: ScanFn = Box::new(move |_db, _mt| {
+            s.store(true, std::sync::atomic::Ordering::SeqCst);
+            Ok(ScanOutcome::default())
+        });
+        let mut src = test_source(&dir, 168, true, scan);
+
+        let signals = src.poll_at(now).unwrap();
+        assert!(signals.is_empty());
+        assert!(!scanned.load(std::sync::atomic::Ordering::SeqCst));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn interval_elapsed_invokes_scan_and_maps_signals() {
+        let dir = tmpdir();
+        let now = Utc::now();
+        // Last scan 200h ago, interval 168h => elapsed.
+        std::fs::write(
+            dir.join(LAST_SCAN_FILE),
+            (now - chrono::Duration::hours(200)).to_rfc3339(),
+        )
+        .unwrap();
+
+        let scan: ScanFn = Box::new(|_db, _mt| {
+            Ok(ScanOutcome {
+                created: vec![
+                    (101, "src/a.rs".to_string(), "src/b.rs".to_string()),
+                    (102, "src/c.rs".to_string(), "src/d.rs".to_string()),
+                ],
+                updated: vec![55],
+            })
+        });
+        let mut src = test_source(&dir, 168, true, scan);
+
+        let signals = src.poll_at(now).unwrap();
+        // Two newly-created clone issues => two signals; the updated one does not.
+        assert_eq!(signals.len(), 2);
+        assert_eq!(signals[0].kind, SignalKind::CodeClone);
+        assert_eq!(signals[0].reference, "CPITD:CL#101");
+        assert_eq!(signals[1].reference, "CPITD:CL#102");
+        assert!(signals[0].title.contains("src/a.rs"));
+        // last-scan timestamp got persisted.
+        assert!(dir.join(LAST_SCAN_FILE).exists());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn never_scanned_is_elapsed() {
+        let dir = tmpdir();
+        let scan: ScanFn = Box::new(|_db, _mt| Ok(ScanOutcome::default()));
+        let src = test_source(&dir, 168, true, scan);
+        assert!(src.interval_elapsed(Utc::now()));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn outcome_to_signals_uses_stable_reference_for_dedup() {
+        // Same created issue id across two sweeps yields the same reference, so
+        // the engine's seen_set dedup will skip the second.
+        let now = Utc::now();
+        let outcome = ScanOutcome {
+            created: vec![(777, "x.rs".to_string(), "y.rs".to_string())],
+            updated: vec![],
+        };
+        let s1 = CpitdSource::outcome_to_signals(&outcome, now);
+        let s2 = CpitdSource::outcome_to_signals(&outcome, now);
+        assert_eq!(s1[0].reference, s2[0].reference);
+        assert_eq!(s1[0].reference, "CPITD:CL#777");
+    }
+}

--- a/crosslink/src/commands/sentinel/sources/mod.rs
+++ b/crosslink/src/commands/sentinel/sources/mod.rs
@@ -3,6 +3,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 pub mod ci;
+pub mod cpitd;
 pub mod github;
 pub mod internal;
 pub mod maintenance;
@@ -21,6 +22,8 @@ pub enum SignalKind {
     LabelAdded,
     StaleIssue,
     CIFailure,
+    /// A duplicated-code clone detected by cpitd and filed as a clone issue.
+    CodeClone,
 }
 
 /// A maintenance signal detected by a source adapter.


### PR DESCRIPTION
## Summary

#621 was two problems wearing one trench coat: the **reported** one — `crosslink init`'s cpitd auto-install fails on PEP 668 distros with an uninformative `externally-managed-environment` warning that leaves the user guessing — and the **latent** one — cpitd was installed by init and then never invoked by anything (zero automatic callers; manual `crosslink cpitd scan` only).

### Install UX (the report)

- System-python chain is now **pipx-first** (the canonical PEP 668 answer; used only when `pipx` is on PATH) → `pip install --user` → plain `pip` → git-source fallback. Managed toolchains (uv/poetry/pipenv/.venv) are PEP-668-immune and keep their single direct candidate.
- Failures are classified (`classify_install_failure`), and a PEP 668 failure renders the three real options: install pipx then `pipx install cpitd`, create a venv and install there, or re-run with `--skip-cpitd` — plus the fact the old message hid entirely: **cpitd is optional**; only `cpitd scan` and the new sentinel source use it.
- Init continues gracefully exactly as before; only message quality and chain order changed.

### A real job (the latent gap)

New sentinel source — `sentinel.sources.cpitd.{enabled,interval_hours,min_tokens}` (default **disabled**, weekly, CLI-matching min_tokens) — runs the scan on schedule via a refactored library core (`scan_and_file`; the CLI `scan` is now a thin wrapper). Newly filed clone issues surface as `SignalKind::CodeClone` through sentinel's normal pipeline with seen-set dedup on stable references. Dispatch is **triage-only by construction**: Internal-kind signals never auto-spawn agents. Binary absent → one debug line, never a failed sweep. The `/maintain` skill checklist gains a guarded cpitd step.

Also folds in the tracked `.claude/hooks/work-check.py` sync of the #624 stderr fix (content now matches `resources/`).

## Testing

- +15 tests: install-chain ordering (pipx gating, managed-toolchain immunity), PEP 668 classification (case-insensitive), source gating/interval/signal-mapping/seen-set dedup.
- 1767 lib + 2795 bin + 194 CLI integration green; fmt and both CI-exact clippy gates clean.

Refs #621

Generated with [Claude Code](https://claude.com/claude-code)