### PR TITLE
fix(kickoff): reconcile pipeline run records; launch writes real identity (GH#614)

### DIFF
--- a/crosslink/src/commands/kickoff/cleanup.rs
+++ b/crosslink/src/commands/kickoff/cleanup.rs
@@ -237,7 +237,27 @@ pub fn cleanup(
             }
         }
 
-        // 3. Remove the git worktree
+        // 3. Reconcile the matching pipeline run row before the worktree
+        //    disappears (GH#614): once removed, lazy display reconcile can only
+        //    ever see it as "aborted". Capture the truth now from the agent's
+        //    terminal status — DONE → completed, failed → failed, anything else
+        //    (stale/timed-out/stopped) → aborted.
+        if !agent.worktree.is_empty() {
+            if let Some(root) = crosslink_dir.parent() {
+                let pipeline_status = match agent.status.as_str() {
+                    "done" => "completed",
+                    "failed" => "failed",
+                    _ => "aborted",
+                };
+                let _ = super::pipeline::reconcile_completion_by_worktree(
+                    root,
+                    &agent.worktree,
+                    pipeline_status,
+                );
+            }
+        }
+
+        // 4. Remove the git worktree
         if !agent.worktree.is_empty() && std::path::Path::new(&agent.worktree).exists() {
             match Command::new("git")
                 .args(["worktree", "remove", "--force", &agent.worktree])

--- a/crosslink/src/commands/kickoff/mod.rs
+++ b/crosslink/src/commands/kickoff/mod.rs
@@ -92,11 +92,9 @@ pub fn dispatch(
                 skip_permissions,
                 permission_mode: permission_mode.as_deref(),
             };
-            // Update pipeline state if launching from a design doc
-            if let Some(ref doc_path) = doc {
-                // pipeline state update is best-effort — don't fail the launch
-                let _ = pipeline::mark_running(doc_path, "pending", "pending", issue);
-            }
+            // The pipeline "running" row is now written from inside `run()`
+            // once the real worktree + agent identity exist (GH#614) — no more
+            // "pending" placeholder rows appended at dispatch time.
             run(crosslink_dir, db, writer, &opts)?;
             Ok(())
         }
@@ -280,9 +278,7 @@ fn dispatch_launch(
             skip_permissions,
             permission_mode,
         };
-        if let Some(ref doc_path) = doc {
-            let _ = pipeline::mark_running(doc_path, "pending", "pending", issue);
-        }
+        // mark_running is now invoked from inside run() with the real identity.
         run(crosslink_dir, db, writer, &opts)?;
         return Ok(());
     }
@@ -392,8 +388,20 @@ fn pipeline_status_overview(crosslink_dir: &Path, json: bool) -> Result<()> {
         .parent()
         .ok_or_else(|| anyhow::anyhow!("Cannot determine repo root"))?;
 
-    let states = pipeline::scan_pipeline_states(root);
+    let mut states = pipeline::scan_pipeline_states(root);
     let agents = monitor::discover_agents(crosslink_dir).unwrap_or_default();
+
+    // Reconcile stale "running" rows against the real world before display so
+    // the RUN column never reports a launch that finished or vanished (GH#614).
+    // An agent counts as live only while it still has a session/container.
+    let live_ids: Vec<String> = agents
+        .iter()
+        .filter(|a| a.session.is_some() || a.docker.is_some())
+        .map(|a| a.id.clone())
+        .collect();
+    for (doc_path, state) in &mut states {
+        pipeline::reconcile_runs_for_display(doc_path, state, &live_ids);
+    }
 
     if states.is_empty() {
         println!("No pipeline state files found in .design/");

--- a/crosslink/src/commands/kickoff/monitor.rs
+++ b/crosslink/src/commands/kickoff/monitor.rs
@@ -71,6 +71,25 @@ pub fn status(crosslink_dir: &Path, agent: &str) -> Result<()> {
         agent_status = "timed-out".to_string();
     }
 
+    // Positive-completion hook (GH#614): when this status read positively sees a
+    // terminal sentinel, reconcile the matching pipeline run row now rather than
+    // waiting for the next display pass. Keyed on the worktree path.
+    let normalized = normalize_status(&agent_status);
+    let pipeline_status = if normalized == "done" {
+        Some("completed")
+    } else if normalized == "failed" {
+        Some("failed")
+    } else {
+        None
+    };
+    if let Some(ps) = pipeline_status {
+        let _ = super::pipeline::reconcile_completion_by_worktree(
+            root,
+            &worktree_dir.to_string_lossy(),
+            ps,
+        );
+    }
+
     println!("Agent:     {agent}");
     println!("Worktree:  {}", worktree_dir.display());
     println!("Status:    {agent_status}");

--- a/crosslink/src/commands/kickoff/pipeline.rs
+++ b/crosslink/src/commands/kickoff/pipeline.rs
@@ -187,6 +187,15 @@ pub fn mark_planned(
 }
 
 /// Update pipeline state to "running" stage with a new run record.
+///
+/// Called from the launch flow only after the worktree and agent identity
+/// exist (see [`crate::commands::kickoff::run`]). The row therefore carries the
+/// real `agent_id` and `worktree` path from creation — there are no more
+/// `"pending"` literals in new rows, which is what GH#614 was about. The launch
+/// is past its point of no return when this runs (the worktree is on disk and
+/// the agent is initialized), so a row written here cannot be stranded as a
+/// permanently-pending ghost: if the agent never starts, reconciliation will
+/// later see the worktree gone (after cleanup) or the sentinel and resolve it.
 pub fn mark_running(
     doc_path: &Path,
     agent_id: &str,
@@ -206,6 +215,274 @@ pub fn mark_running(
 
     write_pipeline_state(doc_path, &state)?;
     Ok(state)
+}
+
+/// Outcome of probing a single run row's worktree during reconciliation.
+///
+/// The reconcile core is generic over how the probe is obtained so it can be
+/// unit-tested without touching the filesystem (see the test module). The
+/// production probe is [`probe_run_worktree`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RunProbe {
+    /// Worktree exists and the `.kickoff-status` sentinel says the agent finished.
+    SentinelDone,
+    /// Worktree exists and the sentinel says the agent failed (`FAILED` / `CI_FAILED` / error).
+    SentinelFailed,
+    /// Worktree exists, no terminal sentinel, and a live agent is still working it.
+    LiveRunning,
+    /// Worktree is gone (or unresolvable, e.g. a legacy `"pending"` path) and no
+    /// live agent matches — the row is stale and should be marked aborted.
+    Gone,
+    /// Worktree exists but is in an indeterminate non-terminal state (e.g. status
+    /// is RUNNING/LAUNCHING and no live-agent signal is available). Leave untouched.
+    Indeterminate,
+}
+
+/// Probe a single run row against the real filesystem and a set of live agent ids.
+///
+/// `sentinel_mtime` is returned alongside the verdict so the caller can stamp
+/// `completed_at` from the sentinel's modification time when available.
+pub fn probe_run_worktree(
+    run: &RunRecord,
+    live_agent_ids: &[String],
+) -> (RunProbe, Option<String>) {
+    let is_live = live_agent_ids.iter().any(|id| id == &run.agent_id) && run.agent_id != "pending";
+
+    // A "pending" worktree literal (legacy rows) or an empty path can never be
+    // resolved on disk — treat as gone unless a live agent vouches for it.
+    if run.worktree.is_empty() || run.worktree == "pending" {
+        return if is_live {
+            (RunProbe::LiveRunning, None)
+        } else {
+            (RunProbe::Gone, None)
+        };
+    }
+
+    let wt = Path::new(&run.worktree);
+    if !wt.exists() {
+        return if is_live {
+            (RunProbe::LiveRunning, None)
+        } else {
+            (RunProbe::Gone, None)
+        };
+    }
+
+    let status_file = wt.join(".kickoff-status");
+    let sentinel_mtime = std::fs::metadata(&status_file)
+        .and_then(|m| m.modified())
+        .ok()
+        .map(|t| chrono::DateTime::<chrono::Utc>::from(t).to_rfc3339());
+
+    if let Ok(raw) = std::fs::read_to_string(&status_file) {
+        let lower = raw.to_lowercase();
+        if lower.contains("done") {
+            return (RunProbe::SentinelDone, sentinel_mtime);
+        }
+        if lower.contains("fail") || lower.contains("error") {
+            return (RunProbe::SentinelFailed, sentinel_mtime);
+        }
+    }
+
+    // Worktree present, no terminal sentinel. Trust the live-agent signal.
+    if is_live {
+        (RunProbe::LiveRunning, None)
+    } else {
+        (RunProbe::Indeterminate, None)
+    }
+}
+
+/// Reconcile the `runs` array against the world, mutating stale rows in place.
+///
+/// For every row whose `status == "running"`, the `probe` closure reports the
+/// real-world verdict (see [`RunProbe`]):
+/// - `SentinelDone` → `status = "completed"`, `completed_at` from the sentinel
+///   mtime (or now if unreadable);
+/// - `SentinelFailed` → `status = "failed"`, `completed_at` likewise;
+/// - `Gone` → `status = "aborted"`, `completed_at = now` (legacy `"pending"`
+///   `agent_id` is left as-is — we never invent an identity, but the status no
+///   longer lies);
+/// - `LiveRunning` / `Indeterminate` → left untouched.
+///
+/// All rows are reconciled, not just the last. When the change leaves no row
+/// actually running, [`stage`] is transitioned off `"running"` to a sensible
+/// terminal/prior stage (see [`stage_after_runs_settle`]).
+///
+/// Returns `true` if anything changed (so callers persist only when needed).
+/// `now` is injected for deterministic testing.
+pub fn reconcile_runs<F>(state: &mut PipelineState, now: &str, mut probe: F) -> bool
+where
+    F: FnMut(&RunRecord) -> (RunProbe, Option<String>),
+{
+    let mut changed = false;
+    for run in &mut state.runs {
+        if run.status != "running" {
+            continue;
+        }
+        let (verdict, sentinel_mtime) = probe(run);
+        match verdict {
+            RunProbe::SentinelDone => {
+                run.status = "completed".to_string();
+                run.completed_at = Some(sentinel_mtime.unwrap_or_else(|| now.to_string()));
+                changed = true;
+            }
+            RunProbe::SentinelFailed => {
+                run.status = "failed".to_string();
+                run.completed_at = Some(sentinel_mtime.unwrap_or_else(|| now.to_string()));
+                changed = true;
+            }
+            RunProbe::Gone => {
+                run.status = "aborted".to_string();
+                run.completed_at = Some(now.to_string());
+                changed = true;
+            }
+            RunProbe::LiveRunning | RunProbe::Indeterminate => {}
+        }
+    }
+
+    if changed && state.stage == "running" {
+        let any_running = state.runs.iter().any(|r| r.status == "running");
+        if !any_running {
+            state.stage = stage_after_runs_settle(state);
+        }
+    }
+
+    changed
+}
+
+/// Decide the stage to land on once no run row is `"running"` any more.
+///
+/// Mirrors the module's existing stage vocabulary (`designed` → `planned` →
+/// `running` → `complete`):
+/// - if the most recent run completed (or no run failed/aborted), the work
+///   reached a terminal success → `"complete"`;
+/// - otherwise the launch did not land (last row aborted/failed): fall back to
+///   `"planned"` when a plan record exists, else `"designed"` so the pipeline UI
+///   invites the operator to re-plan / re-run rather than claiming completion.
+fn stage_after_runs_settle(state: &PipelineState) -> String {
+    match state.runs.last().map(|r| r.status.as_str()) {
+        Some("completed") => "complete".to_string(),
+        _ if state.plans.iter().any(|p| p.status == "done") => "planned".to_string(),
+        _ if !state.plans.is_empty() => "planned".to_string(),
+        _ => "designed".to_string(),
+    }
+}
+
+/// Reconcile a pipeline state's runs for a display read, using the real
+/// filesystem and the supplied set of live agent ids, then persist if changed.
+///
+/// This is the seam invoked by the display read paths (`kickoff status`
+/// overview and the wizard's doc-entry build): plain non-kickoff reads stay
+/// cheap because they never call this, while the kickoff surfaces that already
+/// pay for worktree/sentinel I/O reconcile their stale rows at view time.
+pub fn reconcile_runs_for_display(
+    doc_path: &Path,
+    state: &mut PipelineState,
+    live_agent_ids: &[String],
+) -> bool {
+    let now = chrono::Utc::now().to_rfc3339();
+    let changed = reconcile_runs(state, &now, |run| probe_run_worktree(run, live_agent_ids));
+    if changed {
+        // Best-effort persist: a failed write must not break the display path.
+        let _ = write_pipeline_state(doc_path, state);
+    }
+    changed
+}
+
+/// Mark the run row matching `worktree` (or, for legacy rows lacking a real
+/// worktree, the row closest in `started_at` to `started_near`) as terminally
+/// finished with the given `status` and a `completed_at` of now.
+///
+/// This is the positive-completion hook: callers that have just observed a
+/// worktree finish (sentinel DONE/FAILED at status time, or a worktree being
+/// pruned by cleanup) reconcile the matching row at the moment of truth rather
+/// than waiting for the next lazy display reconcile. Returns `true` if a row
+/// was updated and the state persisted.
+pub fn mark_run_finished(
+    doc_path: &Path,
+    state: &mut PipelineState,
+    worktree: &str,
+    started_near: Option<&str>,
+    status: &str,
+) -> bool {
+    let now = chrono::Utc::now().to_rfc3339();
+    let idx = match_run_index(state, worktree, started_near);
+    let Some(idx) = idx else {
+        return false;
+    };
+    let run = &mut state.runs[idx];
+    if run.status != "running" {
+        return false;
+    }
+    run.status = status.to_string();
+    run.completed_at = Some(now);
+
+    if state.stage == "running" && !state.runs.iter().any(|r| r.status == "running") {
+        state.stage = stage_after_runs_settle(state);
+    }
+
+    let _ = write_pipeline_state(doc_path, state);
+    true
+}
+
+/// Find the index of the run row to reconcile for a completion event.
+///
+/// Prefers an exact worktree-path match; for legacy rows whose `worktree` is
+/// `"pending"` (so no path match is possible), falls back to the still-running
+/// row whose `started_at` is closest to `started_near` when provided.
+fn match_run_index(
+    state: &PipelineState,
+    worktree: &str,
+    started_near: Option<&str>,
+) -> Option<usize> {
+    if !worktree.is_empty() && worktree != "pending" {
+        if let Some(i) = state
+            .runs
+            .iter()
+            .position(|r| r.status == "running" && r.worktree == worktree)
+        {
+            return Some(i);
+        }
+    }
+
+    let near = started_near.and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())?;
+    state
+        .runs
+        .iter()
+        .enumerate()
+        .filter(|(_, r)| r.status == "running")
+        .filter_map(|(i, r)| {
+            let started = chrono::DateTime::parse_from_rfc3339(&r.started_at).ok()?;
+            let delta = (started - near).num_seconds().abs();
+            Some((i, delta))
+        })
+        .min_by_key(|(_, delta)| *delta)
+        .map(|(i, _)| i)
+}
+
+/// Positive-completion hook: a kickoff completion was just observed for a
+/// worktree (a terminal `.kickoff-status` sentinel seen by `kickoff status`, or
+/// a finished worktree being pruned by `kickoff cleanup`). Scan every pipeline
+/// state under `.design/`, find the one whose runs include this worktree, and
+/// mark that row finished with `status` at the moment of truth.
+///
+/// Returns `true` if a matching row was found and persisted. Best-effort and
+/// cheap when there are no design docs (the common non-kickoff case never
+/// reaches here because callers only invoke it after a sentinel/cleanup event).
+pub fn reconcile_completion_by_worktree(repo_root: &Path, worktree: &str, status: &str) -> bool {
+    if worktree.is_empty() {
+        return false;
+    }
+    for (doc_path, mut state) in scan_pipeline_states(repo_root) {
+        if state
+            .runs
+            .iter()
+            .any(|r| r.status == "running" && r.worktree == worktree)
+            && mark_run_finished(&doc_path, &mut state, worktree, None, status)
+        {
+            return true;
+        }
+    }
+    false
 }
 
 /// Get a human-readable stage display string with optional staleness indicator.

--- a/crosslink/src/commands/kickoff/run.rs
+++ b/crosslink/src/commands/kickoff/run.rs
@@ -167,6 +167,23 @@ pub fn run(
     // 8. Initialize crosslink + agent in worktree (only for real launches)
     let agent_id = init_worktree_agent(&worktree_dir, crosslink_dir, &compact_name)?;
 
+    // 8b. Record the pipeline run row now that the worktree and agent identity
+    //     both exist — this is past the launch's point of no return, so the row
+    //     carries the real agent_id and worktree path instead of the legacy
+    //     "pending" placeholders (GH#614). Best-effort: a pipeline-state write
+    //     failure must not abort an otherwise-successful launch.
+    if let Some(doc_path_str) = opts.doc_path {
+        let doc_path = Path::new(doc_path_str);
+        if let Err(e) = super::pipeline::mark_running(
+            doc_path,
+            &agent_id,
+            &worktree_dir.to_string_lossy(),
+            Some(issue_id),
+        ) {
+            tracing::warn!("could not record pipeline run row for {doc_path_str}: {e}");
+        }
+    }
+
     // preflight is guaranteed Some after the dry-run early return above
     let preflight = preflight.context("preflight check was skipped unexpectedly")?;
 

--- a/crosslink/src/commands/kickoff/tests.rs
+++ b/crosslink/src/commands/kickoff/tests.rs
@@ -2603,3 +2603,380 @@ fn test_build_watchdog_script_contains_key_elements() {
     assert!(script.contains("-gt 300")); // staleness threshold
     assert!(script.contains("-ge 3")); // max nudges
 }
+
+// ---------------------------------------------------------------------------
+// GH#614: pipeline `runs` reconciliation
+// ---------------------------------------------------------------------------
+
+use super::pipeline::{self, PipelineState, RunProbe, RunRecord};
+
+/// Build a minimal `PipelineState` carrying the supplied run rows.
+fn pipeline_with_runs(stage: &str, runs: Vec<RunRecord>) -> PipelineState {
+    PipelineState {
+        schema_version: 1,
+        design_doc: ".design/foo.md".to_string(),
+        doc_hash: "sha256:deadbeef".to_string(),
+        stage: stage.to_string(),
+        plans: Vec::new(),
+        runs,
+    }
+}
+
+fn running_row(agent_id: &str, worktree: &str, started_at: &str) -> RunRecord {
+    RunRecord {
+        agent_id: agent_id.to_string(),
+        worktree: worktree.to_string(),
+        issue_id: Some(1),
+        started_at: started_at.to_string(),
+        completed_at: None,
+        status: "running".to_string(),
+    }
+}
+
+#[test]
+fn test_mark_running_writes_real_identity_no_pending() {
+    // The launch path's unit-testable portion: mark_running given a real
+    // agent_id and worktree records exactly those, never "pending".
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(tmp.path().join(".design")).unwrap();
+    let doc = tmp.path().join(".design/foo.md");
+    std::fs::write(&doc, "# Foo\n").unwrap();
+
+    let wt = tmp.path().join(".worktrees/repo--abcd--foo");
+    let state =
+        pipeline::mark_running(&doc, "repo--abcd--foo", &wt.to_string_lossy(), Some(7)).unwrap();
+
+    let row = state.runs.last().unwrap();
+    assert_eq!(row.agent_id, "repo--abcd--foo");
+    assert_ne!(row.agent_id, "pending");
+    assert_eq!(row.worktree, wt.to_string_lossy());
+    assert_ne!(row.worktree, "pending");
+    assert_eq!(row.status, "running");
+    assert_eq!(row.issue_id, Some(7));
+    assert_eq!(state.stage, "running");
+}
+
+#[test]
+fn test_reconcile_done_sentinel_marks_completed_with_timestamp() {
+    let mut state = pipeline_with_runs(
+        "running",
+        vec![running_row("a1", "/wt/a1", "2026-05-12T20:22:43+00:00")],
+    );
+    let changed = pipeline::reconcile_runs(&mut state, "2026-06-12T00:00:00+00:00", |_r| {
+        (
+            RunProbe::SentinelDone,
+            Some("2026-05-13T10:00:00+00:00".to_string()),
+        )
+    });
+    assert!(changed);
+    let row = &state.runs[0];
+    assert_eq!(row.status, "completed");
+    assert_eq!(
+        row.completed_at.as_deref(),
+        Some("2026-05-13T10:00:00+00:00")
+    );
+    // No row still running, no plan → stage collapses to "complete".
+    assert_eq!(state.stage, "complete");
+}
+
+#[test]
+fn test_reconcile_failed_sentinel_marks_failed() {
+    let mut state = pipeline_with_runs(
+        "running",
+        vec![running_row("a1", "/wt/a1", "2026-05-12T20:22:43+00:00")],
+    );
+    let changed = pipeline::reconcile_runs(&mut state, "2026-06-12T00:00:00+00:00", |_r| {
+        (RunProbe::SentinelFailed, None)
+    });
+    assert!(changed);
+    assert_eq!(state.runs[0].status, "failed");
+    // Fallback to injected `now` when sentinel mtime is unreadable.
+    assert_eq!(
+        state.runs[0].completed_at.as_deref(),
+        Some("2026-06-12T00:00:00+00:00")
+    );
+}
+
+#[test]
+fn test_reconcile_missing_worktree_marks_aborted() {
+    let mut state = pipeline_with_runs(
+        "running",
+        vec![running_row("a1", "/wt/gone", "2026-05-12T20:22:43+00:00")],
+    );
+    let changed = pipeline::reconcile_runs(&mut state, "2026-06-12T00:00:00+00:00", |_r| {
+        (RunProbe::Gone, None)
+    });
+    assert!(changed);
+    assert_eq!(state.runs[0].status, "aborted");
+    assert_eq!(
+        state.runs[0].completed_at.as_deref(),
+        Some("2026-06-12T00:00:00+00:00")
+    );
+    // No plan, last row aborted → stage falls back to "designed".
+    assert_eq!(state.stage, "designed");
+}
+
+#[test]
+fn test_reconcile_live_agent_row_untouched() {
+    let mut state = pipeline_with_runs(
+        "running",
+        vec![running_row("a1", "/wt/a1", "2026-05-12T20:22:43+00:00")],
+    );
+    let changed = pipeline::reconcile_runs(&mut state, "2026-06-12T00:00:00+00:00", |_r| {
+        (RunProbe::LiveRunning, None)
+    });
+    assert!(!changed);
+    assert_eq!(state.runs[0].status, "running");
+    assert!(state.runs[0].completed_at.is_none());
+    assert_eq!(state.stage, "running");
+}
+
+#[test]
+fn test_reconcile_all_rows_not_just_last() {
+    let mut state = pipeline_with_runs(
+        "running",
+        vec![
+            running_row("a1", "/wt/a1", "2026-05-12T20:22:43+00:00"),
+            running_row("a2", "/wt/a2", "2026-05-13T20:22:43+00:00"),
+            running_row("a3", "/wt/a3", "2026-05-14T20:22:43+00:00"),
+        ],
+    );
+    // Mark every row gone.
+    let changed = pipeline::reconcile_runs(&mut state, "2026-06-12T00:00:00+00:00", |_r| {
+        (RunProbe::Gone, None)
+    });
+    assert!(changed);
+    assert!(state.runs.iter().all(|r| r.status == "aborted"));
+}
+
+#[test]
+fn test_probe_pending_worktree_is_gone_when_no_live_agent() {
+    // Legacy "pending"/"pending" rows resolve to Gone.
+    let row = running_row("pending", "pending", "2026-05-12T20:22:43+00:00");
+    let (verdict, _mtime) = pipeline::probe_run_worktree(&row, &[]);
+    assert_eq!(verdict, RunProbe::Gone);
+}
+
+#[test]
+fn test_probe_done_sentinel_on_disk() {
+    let tmp = tempfile::tempdir().unwrap();
+    let wt = tmp.path().join("wt-done");
+    std::fs::create_dir_all(&wt).unwrap();
+    std::fs::write(wt.join(".kickoff-status"), "DONE\n").unwrap();
+    let row = running_row("a1", &wt.to_string_lossy(), "2026-05-12T20:22:43+00:00");
+    let (verdict, mtime) = pipeline::probe_run_worktree(&row, &[]);
+    assert_eq!(verdict, RunProbe::SentinelDone);
+    assert!(mtime.is_some());
+}
+
+#[test]
+fn test_probe_failed_sentinel_on_disk() {
+    let tmp = tempfile::tempdir().unwrap();
+    let wt = tmp.path().join("wt-fail");
+    std::fs::create_dir_all(&wt).unwrap();
+    std::fs::write(wt.join(".kickoff-status"), "CI_FAILED\n").unwrap();
+    let row = running_row("a1", &wt.to_string_lossy(), "2026-05-12T20:22:43+00:00");
+    let (verdict, _mtime) = pipeline::probe_run_worktree(&row, &[]);
+    assert_eq!(verdict, RunProbe::SentinelFailed);
+}
+
+#[test]
+fn test_probe_live_worktree_running_status() {
+    let tmp = tempfile::tempdir().unwrap();
+    let wt = tmp.path().join("wt-run");
+    std::fs::create_dir_all(&wt).unwrap();
+    std::fs::write(wt.join(".kickoff-status"), "RUNNING\n").unwrap();
+    let row = running_row("a1", &wt.to_string_lossy(), "2026-05-12T20:22:43+00:00");
+    // Live agent vouches for it.
+    let (verdict, _) = pipeline::probe_run_worktree(&row, &["a1".to_string()]);
+    assert_eq!(verdict, RunProbe::LiveRunning);
+    // No live agent and non-terminal sentinel → indeterminate (left untouched).
+    let (verdict, _) = pipeline::probe_run_worktree(&row, &[]);
+    assert_eq!(verdict, RunProbe::Indeterminate);
+}
+
+/// The exact rot shape from GH#614 — a `runs` array of pending/pending/running
+/// rows pasted verbatim from the issue evidence.
+const GH614_LEGACY_PIPELINE_JSON: &str = r#"{
+  "schema_version": 1,
+  "design_doc": ".design/forecast-decode.md",
+  "doc_hash": "sha256:abc",
+  "stage": "running",
+  "plans": [],
+  "runs": [
+    {
+      "agent_id": "pending",
+      "worktree": "pending",
+      "issue_id": 1,
+      "started_at": "2026-05-12T20:22:43.929777+00:00",
+      "status": "running"
+    },
+    {
+      "agent_id": "pending",
+      "worktree": "pending",
+      "issue_id": 1,
+      "started_at": "2026-05-14T09:10:00.000000+00:00",
+      "status": "running"
+    }
+  ]
+}"#;
+
+#[test]
+fn test_legacy_pending_file_reconciles_to_aborted_and_persists() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(tmp.path().join(".design")).unwrap();
+    let doc = tmp.path().join(".design/forecast-decode.md");
+    std::fs::write(&doc, "# Forecast decode\n").unwrap();
+    let pipeline_file = tmp.path().join(".design/forecast-decode.pipeline.json");
+    std::fs::write(&pipeline_file, GH614_LEGACY_PIPELINE_JSON).unwrap();
+
+    // Old file parses despite its shape (serde defaults tolerate it).
+    let mut state = pipeline::read_pipeline_state(&doc).expect("legacy file must parse");
+    assert_eq!(state.runs.len(), 2);
+    assert!(state.runs.iter().all(|r| r.status == "running"));
+
+    // No live agents → both pending rows are stale → aborted, and persisted.
+    let changed = pipeline::reconcile_runs_for_display(&doc, &mut state, &[]);
+    assert!(changed);
+    assert!(state.runs.iter().all(|r| r.status == "aborted"));
+    assert!(state.runs.iter().all(|r| r.completed_at.is_some()));
+    // "pending" agent_id is left as-is (we never invent identities).
+    assert!(state.runs.iter().all(|r| r.agent_id == "pending"));
+    // Stage no longer claims "running".
+    assert_ne!(state.stage, "running");
+
+    // runs.last()-based display no longer reports running.
+    let display = pipeline::stage_display(&state, &doc);
+    assert!(!display.contains("running"));
+
+    // Persisted to disk: a fresh read sees the reconciled state.
+    let reread = pipeline::read_pipeline_state(&doc).unwrap();
+    assert!(reread.runs.iter().all(|r| r.status == "aborted"));
+}
+
+#[test]
+fn test_reconcile_is_idempotent() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(tmp.path().join(".design")).unwrap();
+    let doc = tmp.path().join(".design/forecast-decode.md");
+    std::fs::write(&doc, "# Forecast decode\n").unwrap();
+    let pipeline_file = tmp.path().join(".design/forecast-decode.pipeline.json");
+    std::fs::write(&pipeline_file, GH614_LEGACY_PIPELINE_JSON).unwrap();
+
+    let mut state = pipeline::read_pipeline_state(&doc).unwrap();
+    assert!(pipeline::reconcile_runs_for_display(&doc, &mut state, &[]));
+
+    // Second pass changes nothing and does not rewrite the file.
+    let before = std::fs::read_to_string(&pipeline_file).unwrap();
+    let changed_again = pipeline::reconcile_runs_for_display(&doc, &mut state, &[]);
+    assert!(!changed_again);
+    let after = std::fs::read_to_string(&pipeline_file).unwrap();
+    assert_eq!(before, after);
+}
+
+#[test]
+fn test_stage_transition_aborted_with_plan_falls_back_to_planned() {
+    let mut state = pipeline_with_runs(
+        "running",
+        vec![running_row("a1", "/wt/gone", "2026-05-12T20:22:43+00:00")],
+    );
+    state.plans.push(super::pipeline::PlanRecord {
+        agent_id: "p1".to_string(),
+        worktree: "/wt/p1".to_string(),
+        started_at: "2026-05-10T00:00:00+00:00".to_string(),
+        completed_at: Some("2026-05-10T01:00:00+00:00".to_string()),
+        status: "done".to_string(),
+        blocking_gaps: 0,
+        advisory_gaps: 0,
+        plan_file: Some(".design/foo.plan.json".to_string()),
+    });
+    let changed = pipeline::reconcile_runs(&mut state, "2026-06-12T00:00:00+00:00", |_r| {
+        (RunProbe::Gone, None)
+    });
+    assert!(changed);
+    assert_eq!(state.runs[0].status, "aborted");
+    // A plan exists → fall back to "planned" rather than "designed".
+    assert_eq!(state.stage, "planned");
+}
+
+#[test]
+fn test_mark_run_finished_matches_by_worktree() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(tmp.path().join(".design")).unwrap();
+    let doc = tmp.path().join(".design/foo.md");
+    std::fs::write(&doc, "# Foo\n").unwrap();
+    let pipeline_file = tmp.path().join(".design/foo.pipeline.json");
+
+    let mut state = pipeline_with_runs(
+        "running",
+        vec![
+            running_row("a1", "/wt/a1", "2026-05-12T20:22:43+00:00"),
+            running_row("a2", "/wt/a2", "2026-05-13T20:22:43+00:00"),
+        ],
+    );
+    std::fs::write(
+        &pipeline_file,
+        serde_json::to_string_pretty(&state).unwrap(),
+    )
+    .unwrap();
+
+    let updated = pipeline::mark_run_finished(&doc, &mut state, "/wt/a2", None, "completed");
+    assert!(updated);
+    assert_eq!(state.runs[0].status, "running"); // a1 untouched
+    assert_eq!(state.runs[1].status, "completed");
+    assert!(state.runs[1].completed_at.is_some());
+    // Still a running row → stage stays "running".
+    assert_eq!(state.stage, "running");
+}
+
+#[test]
+fn test_mark_run_finished_legacy_fallback_by_started_at() {
+    let doc = Path::new("/nonexistent/.design/foo.md");
+    let mut state = pipeline_with_runs(
+        "running",
+        vec![
+            running_row("pending", "pending", "2026-05-12T20:22:43+00:00"),
+            running_row("pending", "pending", "2026-05-14T09:10:00+00:00"),
+        ],
+    );
+    // worktree "pending" can't path-match; fall back to started_at proximity.
+    let updated = pipeline::mark_run_finished(
+        doc,
+        &mut state,
+        "pending",
+        Some("2026-05-14T09:11:00+00:00"),
+        "completed",
+    );
+    assert!(updated);
+    assert_eq!(state.runs[0].status, "running");
+    assert_eq!(state.runs[1].status, "completed");
+}
+
+#[test]
+fn test_reconcile_completion_by_worktree_scans_design_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(tmp.path().join(".design")).unwrap();
+    let doc = tmp.path().join(".design/foo.md");
+    std::fs::write(&doc, "# Foo\n").unwrap();
+    let wt = tmp.path().join(".worktrees/repo--abcd--foo");
+    let state = pipeline_with_runs(
+        "running",
+        vec![running_row(
+            "repo--abcd--foo",
+            &wt.to_string_lossy(),
+            "2026-05-12T20:22:43+00:00",
+        )],
+    );
+    std::fs::write(
+        tmp.path().join(".design/foo.pipeline.json"),
+        serde_json::to_string_pretty(&state).unwrap(),
+    )
+    .unwrap();
+
+    let hit =
+        pipeline::reconcile_completion_by_worktree(tmp.path(), &wt.to_string_lossy(), "completed");
+    assert!(hit);
+    let reread = pipeline::read_pipeline_state(&doc).unwrap();
+    assert_eq!(reread.runs[0].status, "completed");
+    assert_eq!(reread.stage, "complete");
+}

--- a/crosslink/src/commands/kickoff/wizard.rs
+++ b/crosslink/src/commands/kickoff/wizard.rs
@@ -1129,8 +1129,17 @@ pub fn launch_wizard(crosslink_dir: &Path) -> Result<Option<WizardChoices>> {
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
-fn build_design_doc_entries(repo_root: &Path, _crosslink_dir: &Path) -> Vec<DesignDocEntry> {
+fn build_design_doc_entries(repo_root: &Path, crosslink_dir: &Path) -> Vec<DesignDocEntry> {
     let docs = pipeline::scan_design_docs(repo_root);
+
+    // Live agent ids (session/container still up) so reconcile leaves genuinely
+    // active runs untouched while collapsing stale "running" rows (GH#614).
+    let live_ids: Vec<String> = super::monitor::discover_agents(crosslink_dir)
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|a| a.session.is_some() || a.docker.is_some())
+        .map(|a| a.id)
+        .collect();
 
     docs.into_iter()
         .map(|path| {
@@ -1140,7 +1149,10 @@ fn build_design_doc_entries(repo_root: &Path, _crosslink_dir: &Path) -> Vec<Desi
                 .unwrap_or("unknown")
                 .to_string();
 
-            let pipeline = pipeline::read_pipeline_state(&path);
+            let pipeline = pipeline::read_pipeline_state(&path).map(|mut state| {
+                pipeline::reconcile_runs_for_display(&path, &mut state, &live_ids);
+                state
+            });
 
             let stage_display = pipeline.as_ref().map_or_else(
                 || "\u{2014}".to_string(),


### PR DESCRIPTION
## Summary

Fixes #614: the `runs` array in `.design/<slug>.pipeline.json` grew monotonically — every launch appended `{agent_id: "pending", worktree: "pending", status: "running"}` and nothing ever updated a row (the issue's evidence: 14 stale rows across 9 days). `RunRecord` even had a `completed_at: Option` that nothing filled — reconciliation was designed-for and never built. `runs` **is** load-bearing (three display readers consume `runs.last()`), so the fix is the issue's option 1 (reconcile), not option 2 (drop).

### Root cause of the `pending` literals

Two dispatch-time `mark_running(doc, "pending", "pending", ...)` calls fired **before** the worktree or agent existed. Both removed; `mark_running` now runs immediately after `init_worktree_agent` returns the real `agent_id` — past the launch's point of no return, so a row cannot be stranded pending. Pipeline-write failures warn, never abort a launch.

### Reconciliation, three layers

1. **Pure core** — `reconcile_runs(state, now, probe)` over ALL rows, closure-injected for testing: sentinel `done` → `completed` (timestamp from sentinel mtime), failure forms → `failed`, worktree gone with no live agent → `aborted` (legacy `"pending"` identity left honest — never invented), live agent → untouched, present-but-unverifiable → untouched (`Indeterminate`).
2. **Display seams** that already pay worktree I/O (`kickoff status` overview, wizard design-doc entries) reconcile-and-persist on load; hot non-kickoff paths never pay the probes.
3. **Moment-of-truth hooks**: `monitor::status` on a terminal sentinel and `cleanup` before pruning each worktree mark the matching row (worktree-path match; `started_at`-proximity fallback for legacy rows).

**Stage honesty**: when a change leaves no row running, `stage` transitions (`completed` → `complete`; else `planned` when a plan exists, else `designed`) instead of displaying a running stage with no runner.

**Legacy rot self-heals**: the issue's evidence JSON is a verbatim test fixture — old files load unchanged (serde defaults), reconcile to `aborted`, persist, and displays stop reporting `running`. Reconcile is idempotent.

### The side question

`pipeline.json` stays **tracked** by design: plans/gaps are shared state ready for `kickoff --doc`. The rot was the bug, not the tracking — with rows reconciled at completion, the committed history now records what actually happened to each launch.

## Testing

+16 tests: launch identity, full probe matrix, all-rows coverage, verbatim legacy fixture, idempotency, stage transitions, both completion-hook matchers. 1767 lib + 2811 bin + 194 CLI integration green; fmt and both CI-exact clippy gates clean.

Fixes #614

Generated with [Claude Code](https://claude.com/claude-code)