### PR TITLE
fix(ci,init): prerelease-aware container smoke-verify + gitignore runtime state

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -282,7 +282,13 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
           EXPECTED="${{ needs.publish-image.outputs.version }}"
-          ACTUAL=$(echo "${{ steps.version.outputs.out }}" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+          # Extract the version field and strip git build metadata (+<sha>[-dirty]).
+          # Keep any semver prerelease suffix (e.g. -beta.1) — the old
+          # `grep -oE '[0-9]+\.[0-9]+\.[0-9]+'` matched only the X.Y.Z core and
+          # dropped `-beta.1`, failing every prerelease tag (the first one was
+          # v0.9.0-beta.1). Cargo.toml's version carries the prerelease but not
+          # the +build metadata, so EXPECTED has no `+` to strip.
+          ACTUAL=$(echo "${{ steps.version.outputs.out }}" | awk '{print $2}' | sed 's/+.*//')
           if [ "$EXPECTED" != "$ACTUAL" ]; then
             echo "::error::Tag version ($EXPECTED) does not match binary version ($ACTUAL)"
             exit 1

--- a/crosslink/src/commands/init/merge.rs
+++ b/crosslink/src/commands/init/merge.rs
@@ -20,6 +20,11 @@ const GITIGNORE_MANAGED_SECTION: &str = "\
 .crosslink/daemon.log
 .crosslink/last_test_run
 .crosslink/.active-issue
+.crosslink/.last-hydrated-ref
+.crosslink/.promoted-uuids
+.crosslink/promotion-log.json
+.crosslink/hub-v3-shadow-stats.json
+.crosslink/sentinel.log
 .crosslink/keys/
 .crosslink/.hub-cache/
 .crosslink/.knowledge-cache/

--- a/crosslink/src/commands/init/mod.rs
+++ b/crosslink/src/commands/init/mod.rs
@@ -1022,7 +1022,15 @@ pub fn run(path: &Path, opts: &InitOpts<'_>) -> Result<()> {
              \n\
              # Machine-local overrides\n\
              hook-config.local.json\n\
-             rules.local/\n",
+             rules.local/\n\
+             \n\
+             # Machine-local runtime state (regenerated per machine; never commit)\n\
+             .active-issue\n\
+             .last-hydrated-ref\n\
+             .promoted-uuids\n\
+             promotion-log.json\n\
+             hub-v3-shadow-stats.json\n\
+             sentinel.log\n",
         )
         .context("Failed to write .crosslink/.gitignore")?;
     }
@@ -2256,6 +2264,46 @@ mod tests {
 
         let content = fs::read_to_string(dir.path().join(".crosslink/.gitignore")).unwrap();
         assert!(content.contains("integrations/"));
+    }
+
+    #[test]
+    fn test_crosslink_inner_gitignore_ignores_runtime_state() {
+        // GH#778: runtime state files must be gitignored so `git add -A` can
+        // never commit machine-local churn (it did, into the v0.9.0-beta.1
+        // release merge, before this fix).
+        let dir = test_dir();
+        run(dir.path(), &test_opts(false)).unwrap();
+
+        let inner = fs::read_to_string(dir.path().join(".crosslink/.gitignore")).unwrap();
+        for entry in [
+            ".active-issue",
+            ".last-hydrated-ref",
+            ".promoted-uuids",
+            "promotion-log.json",
+            "hub-v3-shadow-stats.json",
+            "sentinel.log",
+        ] {
+            assert!(
+                inner.contains(entry),
+                "inner .crosslink/.gitignore missing runtime entry: {entry}"
+            );
+        }
+
+        // The root managed section must ignore them too (the deeper cause:
+        // the root .gitignore is what `git add -A` consults from repo root).
+        let root = fs::read_to_string(dir.path().join(".gitignore")).unwrap();
+        for entry in [
+            ".crosslink/.last-hydrated-ref",
+            ".crosslink/.promoted-uuids",
+            ".crosslink/promotion-log.json",
+            ".crosslink/hub-v3-shadow-stats.json",
+            ".crosslink/sentinel.log",
+        ] {
+            assert!(
+                root.contains(entry),
+                "root .gitignore managed section missing runtime entry: {entry}"
+            );
+        }
     }
 
     // --- Tier 1/2 smoke tests (GH issue #242) ---


### PR DESCRIPTION
Post-release CI/hygiene cleanup surfaced by the v0.9.0-beta.1 cut. Two independent fixes; both previously prepared but never landed (the original branch was never PR'd — a different smoke-verify fix, #728/#579, merged instead).

## #779 — container smoke-verify drops semver prerelease

`container-image.yml` extracted the binary version with `grep -oE '[0-9]+\.[0-9]+\.[0-9]+'`, matching only the `X.Y.Z` core and discarding `-beta.1`. Against the `v0.9.0-beta.1` tag it compared `EXPECTED=0.9.0-beta.1` to `ACTUAL=0.9.0` and failed. The image itself **published fine** — only the post-publish verify false-failed. Now extracts the version field and strips git `+build` metadata while preserving the prerelease: `awk '{print $2}' | sed 's/+.*//'` (validated against `0.9.0-beta.1+sha-dirty`, `0.9.0-beta.1`, `1.2.3+abc`, `0.9.0`). Doesn't retroactively fix the tag's run (workflows execute the tagged commit's copy) — protects every future prerelease.

## #778 — gitignore machine-local runtime state

The init-deployed gitignores ignored `agent.json`/`.hub-cache/`/`keys/` but not the runtime files written in normal operation, so a `git add -A` commits them as churn (it did, into the release merge — crates.io unaffected, `include` is a whitelist). Both deployed templates now ignore `.active-issue`, `.last-hydrated-ref`, `.promoted-uuids`, `promotion-log.json`, `hub-v3-shadow-stats.json`, `sentinel.log`:
- inner `.crosslink/.gitignore` (`init/mod.rs`)
- root managed section (`merge.rs`), which only had `.active-issue` and is what `git add -A` consults from repo root — the deeper cause.

A test asserts both surfaces ignore every runtime entry.

## Testing
13 gitignore/init tests pass (incl. the new one); `cargo fmt --all -- --check` and `cargo clippy --all-targets -- -D warnings` clean; `container-image.yml` YAML-valid.

Closes #778, closes #779

Generated with [Claude Code](https://claude.com/claude-code)