### PR TITLE
feat(hook-config): template_required_fields validation on issue create (gh#658)

### DIFF
--- a/crosslink/Cargo.lock
+++ b/crosslink/Cargo.lock
@@ -474,6 +474,7 @@ dependencies = [
  "portable-pty",
  "proptest",
  "ratatui",
+ "regex",
  "reqwest",
  "rusqlite",
  "rust-embed",

--- a/crosslink/Cargo.toml
+++ b/crosslink/Cargo.toml
@@ -34,6 +34,7 @@ clap = { version = "4", features = ["derive", "env"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+regex = "1"
 anyhow = "1"
 uuid = { version = "1", features = ["v4", "serde"] }
 signal-hook = "0.3"

--- a/crosslink/src/commands/config_registry.rs
+++ b/crosslink/src/commands/config_registry.rs
@@ -286,6 +286,13 @@ pub static REGISTRY: &[ConfigKey] = &[
         group: ConfigGroup::Sentinel,
         hot_swappable: true,
     },
+    ConfigKey {
+        key: "template_required_fields",
+        config_type: ConfigType::Map,
+        description: "Per-template required fields in issue descriptions (gh#658)",
+        group: ConfigGroup::Workflow,
+        hot_swappable: false,
+    },
 ];
 
 pub fn find_registry_key(key: &str) -> Option<&'static ConfigKey> {

--- a/crosslink/src/commands/create.rs
+++ b/crosslink/src/commands/create.rs
@@ -1,4 +1,5 @@
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
+use regex::Regex;
 
 use crate::db::Database;
 use crate::lock_check::{release_lock_best_effort, try_claim_lock, ClaimResult};
@@ -74,6 +75,216 @@ pub fn validate_priority(priority: &str) -> bool {
     VALID_PRIORITIES.contains(&priority)
 }
 
+/// A single content-requirement rule for an issue description, parsed from the
+/// `template_required_fields` config map (gh#658).
+///
+/// `pattern` is the sole matcher: the description must match it for the rule to
+/// be satisfied. When the regex defines a capture group, group 1 is treated as
+/// "the field's content"; otherwise the whole match is. `min_chars` is the
+/// minimum number of characters required in that matched content.
+#[derive(Debug)]
+pub struct RequiredFieldRule {
+    /// Human-readable field name, used in error messages.
+    pub field: String,
+    /// Regex the description must match.
+    pub pattern: Regex,
+    /// Minimum number of characters required in the matched field content.
+    pub min_chars: usize,
+}
+
+/// Parse the `template_required_fields` map for `template_name`.
+///
+/// Every regex in the *entire* map is compiled here, not just the requested
+/// template's, so a malformed pattern anywhere fails loudly at config-read time
+/// rather than only when an issue happens to use that template (gh#658 —
+/// "regex should compile-check at config load").
+fn parse_required_fields(
+    config: &serde_json::Value,
+    template_name: &str,
+) -> Result<Vec<RequiredFieldRule>> {
+    let Some(map) = config
+        .get("template_required_fields")
+        .and_then(|v| v.as_object())
+    else {
+        return Ok(Vec::new());
+    };
+
+    let mut requested = Vec::new();
+    for (tmpl, entries) in map {
+        let arr = entries.as_array().ok_or_else(|| {
+            anyhow::anyhow!("template_required_fields.{tmpl} must be an array of rule objects")
+        })?;
+        for (idx, entry) in arr.iter().enumerate() {
+            let rule = parse_one_rule(tmpl, idx, entry)?;
+            if tmpl == template_name {
+                requested.push(rule);
+            }
+        }
+    }
+    Ok(requested)
+}
+
+/// Parse and validate a single rule object, compiling its regex.
+fn parse_one_rule(tmpl: &str, idx: usize, entry: &serde_json::Value) -> Result<RequiredFieldRule> {
+    let obj = entry.as_object().ok_or_else(|| {
+        anyhow::anyhow!("template_required_fields.{tmpl}[{idx}] must be an object")
+    })?;
+
+    let field = obj
+        .get("field")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            anyhow::anyhow!("template_required_fields.{tmpl}[{idx}] is missing string key 'field'")
+        })?
+        .to_string();
+
+    let pattern_str = obj.get("pattern").and_then(|v| v.as_str()).ok_or_else(|| {
+        anyhow::anyhow!(
+            "template_required_fields.{tmpl}[{idx}] ('{field}') is missing string key 'pattern'"
+        )
+    })?;
+    let pattern = Regex::new(pattern_str).with_context(|| {
+        format!("Invalid regex in template_required_fields.{tmpl}[{idx}] ('{field}')")
+    })?;
+
+    let min_chars = match obj.get("min_chars") {
+        None => 0,
+        Some(v) => v.as_u64().ok_or_else(|| {
+            anyhow::anyhow!(
+                "template_required_fields.{tmpl}[{idx}] ('{field}') key 'min_chars' \
+                 must be a non-negative integer"
+            )
+        })? as usize,
+    };
+
+    Ok(RequiredFieldRule {
+        field,
+        pattern,
+        min_chars,
+    })
+}
+
+/// Load the required-field rules for `template_name` from the layered hook config
+/// (team + local override), compiling and validating all patterns (gh#658).
+pub fn load_required_fields(
+    crosslink_dir: &std::path::Path,
+    template_name: &str,
+) -> Result<Vec<RequiredFieldRule>> {
+    let resolved = crate::commands::config::read_config_layered(crosslink_dir)?;
+    parse_required_fields(&resolved.merged, template_name)
+}
+
+/// Validate a description against a template's required-field rules.
+///
+/// Returns the first violation as an error. Callers bypass this entirely when
+/// `--force` is set, when no template is given, or when there is no crosslink
+/// directory to read config from.
+pub fn validate_required_fields(
+    rules: &[RequiredFieldRule],
+    description: Option<&str>,
+) -> Result<()> {
+    let desc = description.unwrap_or("");
+    for rule in rules {
+        let Some(caps) = rule.pattern.captures(desc) else {
+            bail!(
+                "Issue description is missing required field '{}' (must match /{}/). \
+                 Add it with -d, or pass --force to bypass.",
+                rule.field,
+                rule.pattern.as_str()
+            );
+        };
+        // Capture group 1 is "the field's content" when present; otherwise the
+        // whole match. min_chars measures that content (gh#658).
+        let content = caps
+            .get(1)
+            .or_else(|| caps.get(0))
+            .map_or("", |m| m.as_str());
+        let len = content.chars().count();
+        if len < rule.min_chars {
+            bail!(
+                "Required field '{}' is too short: {} characters, needs at least {}. \
+                 Pass --force to bypass.",
+                rule.field,
+                len,
+                rule.min_chars
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Enforce `template_required_fields` for a create/subissue call, unless bypassed.
+fn enforce_required_fields(
+    opts: &CreateOpts<'_>,
+    template: Option<&str>,
+    description: Option<&str>,
+) -> Result<()> {
+    if opts.force {
+        return Ok(());
+    }
+    let (Some(tmpl_name), Some(dir)) = (template, opts.crosslink_dir) else {
+        return Ok(());
+    };
+    let rules = load_required_fields(dir, tmpl_name)?;
+    validate_required_fields(&rules, description)
+}
+
+/// Result of resolving a template against user-supplied fields.
+struct AppliedTemplate {
+    priority: String,
+    description: Option<String>,
+    label: Option<&'static str>,
+}
+
+/// Resolve a template (if any) into the effective priority, description, and
+/// label. Shared by `run` and `run_subissue` so subissues honour `-t` too
+/// (gh#658). With no template, the user's values pass through unchanged.
+fn apply_template(
+    template: Option<&str>,
+    priority: &str,
+    description: Option<&str>,
+) -> Result<AppliedTemplate> {
+    let Some(tmpl_name) = template else {
+        return Ok(AppliedTemplate {
+            priority: priority.to_string(),
+            description: description.map(ToString::to_string),
+            label: None,
+        });
+    };
+
+    let tmpl = get_template(tmpl_name).ok_or_else(|| {
+        anyhow::anyhow!(
+            "Unknown template '{}'. Available: {}",
+            tmpl_name,
+            list_templates().join(", ")
+        )
+    })?;
+
+    // Template priority is the default; user can override with any non-default value.
+    // NOTE: This uses the CLI default ("medium") as a sentinel to detect "user didn't
+    // specify priority". An explicit `--priority medium` is indistinguishable from the
+    // default and will be overridden by the template's priority. To fix this fully,
+    // the CLI would need `Option<String>` for priority (#449).
+    let priority = if priority == "medium" {
+        tmpl.priority
+    } else {
+        priority
+    };
+
+    // Combine template description prefix with user description.
+    let desc = match (tmpl.description_prefix, description) {
+        (Some(prefix), Some(user_desc)) => Some(format!("{prefix}\n\n{user_desc}")),
+        (Some(prefix), None) => Some(prefix.to_string()),
+        (None, user_desc) => user_desc.map(ToString::to_string),
+    };
+
+    Ok(AppliedTemplate {
+        priority: priority.to_string(),
+        description: desc,
+        label: Some(tmpl.label),
+    })
+}
+
 /// Options shared by create and subissue commands.
 /// Auto-claim lock in multi-agent mode and set the session work item.
 /// Returns Ok(()) on success or propagates errors from lock enforcement.
@@ -146,6 +357,8 @@ pub struct CreateOpts<'a> {
     pub crosslink_dir: Option<&'a std::path::Path>,
     /// Skip compaction after creation (batch mode — display ID assigned on next compaction).
     pub defer_id: bool,
+    /// Bypass `template_required_fields` content validation (gh#658).
+    pub force: bool,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -172,42 +385,15 @@ pub fn run(
         }
     }
 
-    // Apply template if specified
-    let (final_priority, final_description, template_label) = if let Some(tmpl_name) = template {
-        let tmpl = get_template(tmpl_name).ok_or_else(|| {
-            anyhow::anyhow!(
-                "Unknown template '{}'. Available: {}",
-                tmpl_name,
-                list_templates().join(", ")
-            )
-        })?;
+    // Apply template if specified, then enforce any required-field content rules
+    // before the issue is created (gh#658).
+    let AppliedTemplate {
+        priority: final_priority,
+        description: final_description,
+        label: template_label,
+    } = apply_template(template, priority, description)?;
 
-        // Template priority is the default; user can override with any non-default value.
-        // NOTE: This uses the CLI default ("medium") as a sentinel to detect "user didn't
-        // specify priority". An explicit `--priority medium` is indistinguishable from the
-        // default and will be overridden by the template's priority. To fix this fully,
-        // the CLI would need `Option<String>` for priority (#449).
-        let priority = if priority == "medium" {
-            tmpl.priority
-        } else {
-            priority
-        };
-
-        // Combine template description prefix with user description
-        let desc = match (tmpl.description_prefix, description) {
-            (Some(prefix), Some(user_desc)) => Some(format!("{prefix}\n\n{user_desc}")),
-            (Some(prefix), None) => Some(prefix.to_string()),
-            (None, user_desc) => user_desc.map(ToString::to_string),
-        };
-
-        (priority.to_string(), desc, Some(tmpl.label))
-    } else {
-        (
-            priority.to_string(),
-            description.map(ToString::to_string),
-            None,
-        )
-    };
+    enforce_required_fields(opts, template, final_description.as_deref())?;
 
     if !validate_priority(&final_priority) {
         bail!(
@@ -290,6 +476,7 @@ pub fn run(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn run_subissue(
     db: &Database,
     writer: Option<&SharedWriter>,
@@ -297,12 +484,23 @@ pub fn run_subissue(
     title: &str,
     description: Option<&str>,
     priority: &str,
+    template: Option<&str>,
     opts: &CreateOpts<'_>,
 ) -> Result<()> {
-    if !validate_priority(priority) {
+    // Apply template (subissues honour -t too — gh#658) then enforce required
+    // fields before the subissue is created.
+    let AppliedTemplate {
+        priority: final_priority,
+        description: final_description,
+        label: template_label,
+    } = apply_template(template, priority, description)?;
+
+    enforce_required_fields(opts, template, final_description.as_deref())?;
+
+    if !validate_priority(&final_priority) {
         bail!(
             "Invalid priority '{}'. Must be one of: {}",
-            priority,
+            final_priority,
             VALID_PRIORITIES.join(", ")
         );
     }
@@ -314,7 +512,18 @@ pub fn run_subissue(
     }
 
     let id = if let Some(w) = writer {
-        let id = w.create_subissue(db, parent_id, title, description, priority)?;
+        let id = w.create_subissue(
+            db,
+            parent_id,
+            title,
+            final_description.as_deref(),
+            &final_priority,
+        )?;
+
+        // Auto-add label from template
+        if let Some(lbl) = template_label {
+            w.add_label(db, id, lbl)?;
+        }
 
         // Add user-specified labels
         for lbl in opts.labels {
@@ -326,7 +535,17 @@ pub fn run_subissue(
         // Wrap create + labels in a transaction so a label failure
         // doesn't leave a subissue without its labels.
         db.transaction(|| {
-            let id = db.create_subissue(parent_id, title, description, priority)?;
+            let id = db.create_subissue(
+                parent_id,
+                title,
+                final_description.as_deref(),
+                &final_priority,
+            )?;
+
+            // Auto-add label from template
+            if let Some(lbl) = template_label {
+                db.add_label(id, lbl)?;
+            }
 
             // Add user-specified labels
             for lbl in opts.labels {
@@ -492,6 +711,7 @@ mod tests {
             quiet: false,
             crosslink_dir: None,
             defer_id: false,
+            force: false,
         };
         run(
             &db,
@@ -519,6 +739,7 @@ mod tests {
             quiet: false,
             crosslink_dir: None,
             defer_id: false,
+            force: false,
         };
         run(
             &db,
@@ -548,6 +769,7 @@ mod tests {
             quiet: false,
             crosslink_dir: None,
             defer_id: false,
+            force: false,
         };
         run(
             &db,
@@ -578,8 +800,19 @@ mod tests {
             quiet: false,
             crosslink_dir: None,
             defer_id: false,
+            force: false,
         };
-        run_subissue(&db, None, parent_id, "Child task", None, "medium", &opts).unwrap();
+        run_subissue(
+            &db,
+            None,
+            parent_id,
+            "Child task",
+            None,
+            "medium",
+            None,
+            &opts,
+        )
+        .unwrap();
         let subs = db.get_subissues(parent_id).unwrap();
         assert_eq!(subs.len(), 1);
         assert_eq!(subs[0].title, "Child task");
@@ -594,6 +827,7 @@ mod tests {
             quiet: false,
             crosslink_dir: None,
             defer_id: false,
+            force: false,
         };
         let result = run(
             &db,
@@ -608,5 +842,336 @@ mod tests {
         );
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Invalid priority"));
+    }
+
+    // ==================== template_required_fields (gh#658) ====================
+
+    fn rule(field: &str, pattern: &str, min_chars: usize) -> RequiredFieldRule {
+        RequiredFieldRule {
+            field: field.to_string(),
+            pattern: Regex::new(pattern).unwrap(),
+            min_chars,
+        }
+    }
+
+    #[test]
+    fn test_validate_required_fields_no_rules_is_ok() {
+        // No rules -> any description (or none) passes.
+        assert!(validate_required_fields(&[], None).is_ok());
+        assert!(validate_required_fields(&[], Some("anything")).is_ok());
+    }
+
+    #[test]
+    fn test_validate_required_fields_missing_field_fails() {
+        let rules = vec![rule("Rationale", r"(?i)\brationale\b", 0)];
+        let err = validate_required_fields(&rules, Some("no keyword here"))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("missing required field 'Rationale'"), "{err}");
+    }
+
+    #[test]
+    fn test_validate_required_fields_min_chars_measures_capture_group() {
+        // Capture group 1 is the measured content, not the whole description.
+        let rules = vec![rule("Rationale", r"(?is)rationale:\s*(.+)", 20)];
+        // Whole description is long, but the captured rationale is short -> fails.
+        let err = validate_required_fields(&rules, Some("Rationale: tiny"))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("too short"), "{err}");
+        // A long enough captured rationale passes.
+        assert!(validate_required_fields(
+            &rules,
+            Some("Rationale: this explanation is comfortably over twenty characters long")
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_validate_required_fields_min_chars_measures_full_match_without_group() {
+        // No capture group -> the whole match is the measured content.
+        let rules = vec![rule("Body", r"(?s).+", 10)];
+        assert!(validate_required_fields(&rules, Some("short")).is_err());
+        assert!(validate_required_fields(&rules, Some("this is long enough")).is_ok());
+    }
+
+    #[test]
+    fn test_parse_required_fields_compiles_and_filters_by_template() {
+        let config = serde_json::json!({
+            "template_required_fields": {
+                "research": [
+                    { "field": "Rationale", "pattern": r"(?i)rationale", "min_chars": 200 }
+                ],
+                "audit": [
+                    { "field": "Scope", "pattern": r"(?i)scope" }
+                ]
+            }
+        });
+        let research = parse_required_fields(&config, "research").unwrap();
+        assert_eq!(research.len(), 1);
+        assert_eq!(research[0].field, "Rationale");
+        assert_eq!(research[0].min_chars, 200);
+        // min_chars defaults to 0 when omitted.
+        let audit = parse_required_fields(&config, "audit").unwrap();
+        assert_eq!(audit[0].min_chars, 0);
+        // Unknown template -> no rules.
+        assert!(parse_required_fields(&config, "feature")
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn test_parse_required_fields_bad_regex_fails_at_load() {
+        // A malformed regex anywhere in the map fails, even when querying a
+        // different template (compile-check at config load).
+        let config = serde_json::json!({
+            "template_required_fields": {
+                "research": [ { "field": "Bad", "pattern": "(unclosed" } ]
+            }
+        });
+        let err = parse_required_fields(&config, "feature")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Invalid regex"), "{err}");
+    }
+
+    #[test]
+    fn test_parse_required_fields_missing_pattern_fails() {
+        let config = serde_json::json!({
+            "template_required_fields": {
+                "research": [ { "field": "Rationale", "min_chars": 50 } ]
+            }
+        });
+        let err = parse_required_fields(&config, "research")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("missing string key 'pattern'"), "{err}");
+    }
+
+    // --- Integration tests driving run()/run_subissue() through real config files ---
+
+    fn write_team_config(dir: &std::path::Path, json: &str) {
+        std::fs::write(dir.join("hook-config.json"), json).unwrap();
+    }
+
+    fn validating_opts(dir: &std::path::Path, force: bool) -> CreateOpts<'_> {
+        CreateOpts {
+            labels: &[],
+            work: false,
+            quiet: true,
+            crosslink_dir: Some(dir),
+            defer_id: false,
+            force,
+        }
+    }
+
+    const RESEARCH_RULE: &str = r#"{
+        "template_required_fields": {
+            "research": [
+                { "field": "Rationale", "pattern": "(?is)rationale:\\s*(.+)", "min_chars": 20 }
+            ]
+        }
+    }"#;
+
+    #[test]
+    fn test_create_research_succeeds_with_required_fields() {
+        let (db, dir) = setup_test_db();
+        write_team_config(dir.path(), RESEARCH_RULE);
+        let opts = validating_opts(dir.path(), false);
+        run(
+            &db,
+            None,
+            "Investigate",
+            Some("Rationale: we need this to understand the failure mode in detail"),
+            "medium",
+            Some("research"),
+            None,
+            None,
+            &opts,
+        )
+        .unwrap();
+        assert_eq!(db.list_issues(Some("all"), None, None).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_create_research_fails_without_description() {
+        let (db, dir) = setup_test_db();
+        write_team_config(dir.path(), RESEARCH_RULE);
+        let opts = validating_opts(dir.path(), false);
+        let err = run(
+            &db,
+            None,
+            "Investigate",
+            None,
+            "medium",
+            Some("research"),
+            None,
+            None,
+            &opts,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("missing required field 'Rationale'"), "{err}");
+        // Nothing was created.
+        assert_eq!(db.list_issues(Some("all"), None, None).unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_create_research_fails_with_short_description() {
+        let (db, dir) = setup_test_db();
+        write_team_config(dir.path(), RESEARCH_RULE);
+        let opts = validating_opts(dir.path(), false);
+        let err = run(
+            &db,
+            None,
+            "Investigate",
+            Some("Rationale: tiny"),
+            "medium",
+            Some("research"),
+            None,
+            None,
+            &opts,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("too short"), "{err}");
+    }
+
+    #[test]
+    fn test_create_research_force_override_succeeds() {
+        let (db, dir) = setup_test_db();
+        write_team_config(dir.path(), RESEARCH_RULE);
+        let opts = validating_opts(dir.path(), true); // --force
+        run(
+            &db,
+            None,
+            "Investigate",
+            Some("Rationale: tiny"),
+            "medium",
+            Some("research"),
+            None,
+            None,
+            &opts,
+        )
+        .unwrap();
+        assert_eq!(db.list_issues(Some("all"), None, None).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_create_research_local_config_override_relaxes_check() {
+        let (db, dir) = setup_test_db();
+        write_team_config(dir.path(), RESEARCH_RULE);
+        // Local override replaces the map entirely, removing the research rule.
+        std::fs::write(
+            dir.path().join("hook-config.local.json"),
+            r#"{ "template_required_fields": {} }"#,
+        )
+        .unwrap();
+        let opts = validating_opts(dir.path(), false);
+        // No description, but the local override relaxed the requirement.
+        run(
+            &db,
+            None,
+            "Investigate",
+            None,
+            "medium",
+            Some("research"),
+            None,
+            None,
+            &opts,
+        )
+        .unwrap();
+        assert_eq!(db.list_issues(Some("all"), None, None).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_create_feature_succeeds_without_required_fields() {
+        let (db, dir) = setup_test_db();
+        write_team_config(dir.path(), RESEARCH_RULE); // only 'research' is constrained
+        let opts = validating_opts(dir.path(), false);
+        run(
+            &db,
+            None,
+            "A feature",
+            None,
+            "medium",
+            Some("feature"),
+            None,
+            None,
+            &opts,
+        )
+        .unwrap();
+        assert_eq!(db.list_issues(Some("all"), None, None).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_subissue_enforces_template_required_fields() {
+        // gh#658: subissues now carry their own -t template (previously an
+        // oversight) and enforce the same content rules.
+        let (db, dir) = setup_test_db();
+        write_team_config(dir.path(), RESEARCH_RULE);
+        let parent_id = db.create_issue("Parent", None, "high").unwrap();
+        let opts = validating_opts(dir.path(), false);
+
+        // Insufficient content -> rejected.
+        let err = run_subissue(
+            &db,
+            None,
+            parent_id,
+            "Child",
+            Some("Rationale: tiny"),
+            "medium",
+            Some("research"),
+            &opts,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("too short"), "{err}");
+        assert!(db.get_subissues(parent_id).unwrap().is_empty());
+
+        // Sufficient content -> created.
+        run_subissue(
+            &db,
+            None,
+            parent_id,
+            "Child",
+            Some("Rationale: a thoroughly detailed explanation of the child task"),
+            "medium",
+            Some("research"),
+            &opts,
+        )
+        .unwrap();
+        assert_eq!(db.get_subissues(parent_id).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_quick_command_enforces_template_required_fields() {
+        // `quick` routes through run() with work=true; validation fires before
+        // the work/lock path, so a missing field is rejected up front.
+        let (db, dir) = setup_test_db();
+        write_team_config(dir.path(), RESEARCH_RULE);
+        let opts = CreateOpts {
+            labels: &[],
+            work: true,
+            quiet: true,
+            crosslink_dir: Some(dir.path()),
+            defer_id: false,
+            force: false,
+        };
+        let err = run(
+            &db,
+            None,
+            "Quick research",
+            None,
+            "medium",
+            Some("research"),
+            None,
+            None,
+            &opts,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("missing required field 'Rationale'"), "{err}");
+        assert_eq!(db.list_issues(Some("all"), None, None).unwrap().len(), 0);
     }
 }

--- a/crosslink/src/main.rs
+++ b/crosslink/src/main.rs
@@ -404,6 +404,9 @@ enum Commands {
         /// Skip compaction after creation (batch mode -- display ID assigned later)
         #[arg(long)]
         defer_id: bool,
+        /// Bypass `template_required_fields` content validation (gh#658)
+        #[arg(long)]
+        force: bool,
         /// Parent issue ID (creates a subissue)
         #[arg(long, value_parser = parse_issue_id_clap)]
         parent: Option<i64>,
@@ -432,6 +435,9 @@ enum Commands {
         /// Add labels to the issue
         #[arg(short, long)]
         label: Vec<String>,
+        /// Bypass `template_required_fields` content validation (gh#658)
+        #[arg(long)]
+        force: bool,
         /// Parent issue ID (creates a subissue)
         #[arg(long, value_parser = parse_issue_id_clap)]
         parent: Option<i64>,
@@ -523,12 +529,18 @@ enum Commands {
         /// Priority (low, medium, high, critical)
         #[arg(short, long, default_value = "medium")]
         priority: String,
+        /// Template (bug, feature, refactor, research)
+        #[arg(short, long)]
+        template: Option<String>,
         /// Add labels to the subissue
         #[arg(short, long)]
         label: Vec<String>,
         /// Set as current session work item
         #[arg(short, long)]
         work: bool,
+        /// Bypass `template_required_fields` content validation (gh#658)
+        #[arg(long)]
+        force: bool,
     },
 
     /// Alias for `timer start`
@@ -582,6 +594,9 @@ enum IssueCommands {
         /// Skip compaction after creation (batch mode -- display ID assigned later)
         #[arg(long)]
         defer_id: bool,
+        /// Bypass `template_required_fields` content validation (gh#658)
+        #[arg(long)]
+        force: bool,
         /// Parent issue ID (creates a subissue)
         #[arg(long, value_parser = parse_issue_id_clap)]
         parent: Option<i64>,
@@ -609,6 +624,9 @@ enum IssueCommands {
         /// Add labels to the issue
         #[arg(short, long)]
         label: Vec<String>,
+        /// Bypass `template_required_fields` content validation (gh#658)
+        #[arg(long)]
+        force: bool,
         /// Parent issue ID (creates a subissue)
         #[arg(long, value_parser = parse_issue_id_clap)]
         parent: Option<i64>,
@@ -2321,6 +2339,7 @@ fn dispatch_issue(action: IssueCommands, quiet: bool, json: bool) -> Result<()> 
             label,
             work,
             defer_id,
+            force,
             parent,
             scheduled,
             due,
@@ -2334,6 +2353,7 @@ fn dispatch_issue(action: IssueCommands, quiet: bool, json: bool) -> Result<()> 
                 quiet,
                 crosslink_dir: Some(&crosslink_dir),
                 defer_id: parent.is_none() && defer_id,
+                force,
             };
             // Subissues don't carry scheduling dates (GH #361 REQ-12); the
             // command handler rejects the combination with a clear error.
@@ -2348,6 +2368,7 @@ fn dispatch_issue(action: IssueCommands, quiet: bool, json: bool) -> Result<()> 
                     &title,
                     description.as_deref(),
                     &priority,
+                    template.as_deref(),
                     &opts,
                 )
             } else {
@@ -2371,6 +2392,7 @@ fn dispatch_issue(action: IssueCommands, quiet: bool, json: bool) -> Result<()> 
             priority,
             template,
             label,
+            force,
             parent,
             scheduled,
             due,
@@ -2384,6 +2406,7 @@ fn dispatch_issue(action: IssueCommands, quiet: bool, json: bool) -> Result<()> 
                 quiet,
                 crosslink_dir: Some(&crosslink_dir),
                 defer_id: false,
+                force,
             };
             if let Some(parent_id) = parent {
                 if scheduled.is_some() || due.is_some() {
@@ -2396,6 +2419,7 @@ fn dispatch_issue(action: IssueCommands, quiet: bool, json: bool) -> Result<()> 
                     &title,
                     description.as_deref(),
                     &priority,
+                    template.as_deref(),
                     &opts,
                 )
             } else {
@@ -2774,6 +2798,7 @@ fn main() -> Result<()> {
             label,
             work,
             defer_id,
+            force,
             parent,
             scheduled,
             due,
@@ -2786,6 +2811,7 @@ fn main() -> Result<()> {
                 label,
                 work,
                 defer_id,
+                force,
                 parent,
                 scheduled,
                 due,
@@ -2800,6 +2826,7 @@ fn main() -> Result<()> {
             priority,
             template,
             label,
+            force,
             parent,
             scheduled,
             due,
@@ -2810,6 +2837,7 @@ fn main() -> Result<()> {
                 priority,
                 template,
                 label,
+                force,
                 parent,
                 scheduled,
                 due,
@@ -2873,6 +2901,7 @@ fn main() -> Result<()> {
                     label,
                     work,
                     defer_id: false,
+                    force: false,
                     parent,
                     scheduled: None,
                     due: None,
@@ -2924,8 +2953,10 @@ fn main() -> Result<()> {
             title,
             description,
             priority,
+            template,
             label,
             work,
+            force,
         } => {
             hint(
                 cli.quiet,
@@ -2936,10 +2967,11 @@ fn main() -> Result<()> {
                     title,
                     description,
                     priority,
-                    template: None,
+                    template,
                     label,
                     work,
                     defer_id: false,
+                    force,
                     parent: Some(parent),
                     scheduled: None,
                     due: None,


### PR DESCRIPTION
Closes #658.

## What

Adds a config-only mechanism for projects to require specific content in an issue's description, scoped by template, enforced at `crosslink issue create` time. Backward compatible — no new hooks or event types, and templates with no entry behave exactly as before.

```json
"template_required_fields": {
  "research": [{ "field": "Rationale", "pattern": "(?is)rationale:\\s*(.+)", "min_chars": 20 }]
}
```

## Changes

- **`config_registry.rs`** — new `template_required_fields` key (Map / Workflow group); shows in `config list`.
- **`create.rs`** — `RequiredFieldRule { field, pattern, min_chars }`, parsing, validation, and a shared `apply_template()` helper now used by both `run()` and `run_subissue()`. Validation runs before creation; bypassed on `--force`, no template, or no crosslink dir.
- **`main.rs`** — `--force` on create/quick/subissue, `-t/--template` on the `subissue` command, dispatch wiring.
- **`Cargo.toml`** — promoted `regex` (already transitively in the lockfile) to a direct dependency.

## Two intentional divergences from the issue's sketch (confirmed with maintainer)

1. **`pattern` (regex) is required and is the sole matcher** — the `desc.contains(&field)` literal check was dropped. `field` is now purely a human-readable label for error messages.
2. **`min_chars` measures the matched field's content** — capture group 1 if the regex defines one, otherwise the whole match. This is what makes a minimum-length rationale enforceable.

Also: subissues previously ignored `-t` entirely (an oversight) — they now carry their own template, apply its prefix/label/priority, and enforce the same rules.

## Acceptance criteria

All 10 criteria met. Verified at the CLI against a scratch workspace (AC#1, 3, 4, 5, 6, 9, 10) and via unit tests (AC#2, 7, 8).

## Tests

15 new tests covering the 8 named acceptance cases plus parse/compile-error units. Full suite: **2836 passed, 0 failed**. clippy clean, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)